### PR TITLE
Update event logging for clarity

### DIFF
--- a/src/services/event-processor-service.ts
+++ b/src/services/event-processor-service.ts
@@ -86,7 +86,7 @@ export class EventProcessorService {
       context,
       24,
       context.canvas.height - 24,
-      `Event: ${eventName}`,
+      `Last Event: ${eventName}`,
       false,
       true
     );


### PR DESCRIPTION
Change the event logging message from 'Event' to 'Last Event' to improve clarity.