### PR TITLE
Add Vite configuration file

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "/hood-ball/",
+});


### PR DESCRIPTION
Introduced a new Vite configuration file with a base path set to '/hood-ball/'. This is likely to configure the base URL for the application.