### PR TITLE
Refactor error handling in login screen

### DIFF
--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -156,11 +156,9 @@ export class LoginScreen extends BaseGameScreen {
 
     this.credentialService
       .createCredential(username, username)
-      .catch((error) => {
-        console.error(error);
-        alert(error.message);
-        this.registerButtonElement?.removeAttribute("disabled");
-      });
+      .catch((error) =>
+        this.handleCredentialError(error, this.registerButtonElement!)
+      );
   }
 
   private async handleSignInClick(): Promise<void> {
@@ -170,11 +168,24 @@ export class LoginScreen extends BaseGameScreen {
 
     this.signInButtonElement?.setAttribute("disabled", "true");
 
-    this.credentialService.getCredential().catch((error) => {
-      console.error(error);
+    this.credentialService
+      .getCredential()
+      .catch((error) =>
+        this.handleCredentialError(error, this.signInButtonElement!)
+      );
+  }
+
+  private handleCredentialError(
+    error: Error,
+    buttonElement: HTMLElement
+  ): void {
+    console.error(error);
+
+    if (error.name !== "NotAllowedError") {
       alert(error.message);
-      this.signInButtonElement?.removeAttribute("disabled");
-    });
+    }
+
+    buttonElement?.removeAttribute("disabled");
   }
 
   private downloadConfiguration(): void {

--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -161,7 +161,7 @@ export class LoginScreen extends BaseGameScreen {
       );
   }
 
-  private async handleSignInClick(): Promise<void> {
+  private handleSignInClick(): void {
     if (this.signInButtonElement?.hasAttribute("disabled")) {
       return;
     }

--- a/src/services/credential-service.ts
+++ b/src/services/credential-service.ts
@@ -115,10 +115,6 @@ export class CredentialService {
       publicKey,
     });
 
-    if (credential === null) {
-      throw new Error("User canceled credential creation");
-    }
-
     const verifyRegistrationRequest: VerifyRegistrationRequest = {
       transactionId,
       registrationResponse: WebAuthnUtils.serializeCredential(


### PR DESCRIPTION
Moved repeated error handling logic into a new `handleCredentialError` method in `login-screen.ts` to improve code reuse and readability. Removed unnecessary null check in `credential-service.ts` for credential creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved error handling on the login screen for credential-related actions, consolidating logic and reducing unnecessary alerts for certain error types.

- **Bug Fixes**
  - Addressed an issue where alerts were shown for user-cancelled credential operations, resulting in a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->