### PR TITLE
Fix WebRTC ICE candidate queue processing

### DIFF
--- a/src/models/match.ts
+++ b/src/models/match.ts
@@ -70,7 +70,7 @@ export class Match {
 
     console.log(
       `Removed player ${player.getName()} from match, total players`,
-      this.players
+      this.players.size
     );
   }
 

--- a/src/services/webrtc-peer-service.ts
+++ b/src/services/webrtc-peer-service.ts
@@ -141,15 +141,12 @@ export class WebRTCPeerService implements WebRTCPeer {
       new RTCSessionDescription(answer)
     );
 
-    this.iceCandidatesQueue.forEach((candidate) =>
-      this.processIceCandidate(candidate, true)
-    );
-
-    this.iceCandidatesQueue = [];
-
     this.iceCandidatesQueue.forEach((candidate) => {
+      this.processIceCandidate(candidate, true);
       this.webrtcService.sendIceCandidate(this.token, candidate);
     });
+
+    this.iceCandidatesQueue = [];
   }
 
   public getPingTime(): number | null {


### PR DESCRIPTION
## Summary
- forward queued ICE candidates correctly when establishing a peer connection
- fix player removal log to show current player count

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@mori2003/jsimgui')*

------
https://chatgpt.com/codex/tasks/task_e_685b17d711e48327a0f69c06b466fcc3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved log messages to display the number of players remaining after removal instead of full player details.
  - Streamlined the handling of ICE candidates to process and send them more efficiently during connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->