### PR TITLE
Allow inspector windows to stay open when closing main debug UI

### DIFF
--- a/src/windows/debug-window.ts
+++ b/src/windows/debug-window.ts
@@ -37,6 +37,7 @@ export class DebugWindow extends BaseWindow {
     if (this.screenInspectorWindow.isOpen()) {
       this.screenInspectorWindow.render();
     }
+
     if (this.matchInspectorWindow.isOpen()) {
       this.matchInspectorWindow.render();
     }

--- a/src/windows/debug-window.ts
+++ b/src/windows/debug-window.ts
@@ -23,7 +23,13 @@ export class DebugWindow extends BaseWindow {
 
   protected override renderContent(): void {
     this.renderMenu();
+  }
 
+  public override render(): void {
+    super.render();
+
+    // Always render child windows so they remain visible even when
+    // the debug menu window itself is closed.
     this.eventInspectorWindow.render();
     this.screenInspectorWindow.render();
     this.matchInspectorWindow.render();

--- a/src/windows/debug-window.ts
+++ b/src/windows/debug-window.ts
@@ -29,11 +29,21 @@ export class DebugWindow extends BaseWindow {
     super.render();
 
     // Always render child windows so they remain visible even when
-    // the debug menu window itself is closed.
-    this.eventInspectorWindow.render();
-    this.screenInspectorWindow.render();
-    this.matchInspectorWindow.render();
-    this.peerInspectorWindow.render();
+    // the debug menu window itself is closed
+    if (this.eventInspectorWindow.isOpen()) {
+      this.eventInspectorWindow.render();
+    }
+
+    if (this.screenInspectorWindow.isOpen()) {
+      this.screenInspectorWindow.render();
+    }
+    if (this.matchInspectorWindow.isOpen()) {
+      this.matchInspectorWindow.render();
+    }
+
+    if (this.peerInspectorWindow.isOpen()) {
+      this.peerInspectorWindow.render();
+    }
   }
 
   private renderMenu(): void {


### PR DESCRIPTION
## Summary
- keep child debug windows open even if the Debug menu is hidden

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68603bc931fc83278cbe16dc7131ba84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that all inspector windows remain visible independently of the debug menu window’s visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->