### PR TITLE
Fix debug menu rendering after disabling debug mode

### DIFF
--- a/src/screens/main-screen/settings-screen.ts
+++ b/src/screens/main-screen/settings-screen.ts
@@ -107,6 +107,8 @@ export class SettingsScreen extends BaseGameScreen {
     this.updateDebugStateForObjects();
 
     if (state === false) {
+      const debugService = ServiceLocator.get(DebugService);
+      debugService.stop();
       return;
     }
 

--- a/src/services/debug-service.ts
+++ b/src/services/debug-service.ts
@@ -32,11 +32,15 @@ export class DebugService {
   }
 
   public render(): void {
-    if (!this.initialized) return;
+    if (!this.initialized || !this.gameState.isDebugging()) return;
 
     ImGuiImplWeb.BeginRenderWebGL();
     this.debugWindow?.render();
     ImGuiImplWeb.EndRenderWebGL();
+  }
+
+  public stop(): void {
+    this.debugWindow?.close();
   }
 
   private getDebugCanvas(): HTMLCanvasElement {


### PR DESCRIPTION
## Summary
- block rendering when debugging is disabled
- close debug window when disabling debug mode via settings

## Testing
- `npm run build` *(fails: cannot find module '@mori2003/jsimgui' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68606e5bbf788327a2b2432f0970782a