### PR TITLE
Apply object opacity only when appropriate

### DIFF
--- a/src/objects/alert-object.ts
+++ b/src/objects/alert-object.ts
@@ -62,7 +62,7 @@ export class AlertObject
 
   public override render(context: CanvasRenderingContext2D): void {
     context.save();
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
 
     this.setTransformOrigin(context);
     this.setFontStyle(context);

--- a/src/objects/base/base-game-object.ts
+++ b/src/objects/base/base-game-object.ts
@@ -61,6 +61,10 @@ export class BaseGameObject implements GameObject {
     }
   }
 
+  protected resetOpacity(context: CanvasRenderingContext2D): void {
+    this.opacity = context.globalAlpha;
+  }
+
   public setDebugSettings(debugSettings: DebugSettings | null): void {
     this.debugSettings = debugSettings;
   }

--- a/src/objects/base/base-game-object.ts
+++ b/src/objects/base/base-game-object.ts
@@ -62,11 +62,6 @@ export class BaseGameObject implements GameObject {
     }
   }
 
-  protected resetToGlobalOpacity(context: CanvasRenderingContext2D): void {
-    // Reset object opacity to the screen opacity
-    this.opacity = context.globalAlpha;
-  }
-
   public setDebugSettings(debugSettings: DebugSettings | null): void {
     this.debugSettings = debugSettings;
   }

--- a/src/objects/base/base-game-object.ts
+++ b/src/objects/base/base-game-object.ts
@@ -56,12 +56,14 @@ export class BaseGameObject implements GameObject {
   }
 
   protected applyOpacity(context: CanvasRenderingContext2D): void {
+    // Apply desired object opacity only if it's less than the screen opacity
     if (context.globalAlpha > this.opacity) {
       context.globalAlpha = this.opacity;
     }
   }
 
-  protected resetOpacity(context: CanvasRenderingContext2D): void {
+  protected resetToGlobalOpacity(context: CanvasRenderingContext2D): void {
+    // Reset object opacity to the screen opacity
     this.opacity = context.globalAlpha;
   }
 

--- a/src/objects/base/base-game-object.ts
+++ b/src/objects/base/base-game-object.ts
@@ -55,6 +55,12 @@ export class BaseGameObject implements GameObject {
     this.opacity = opacity;
   }
 
+  protected applyOpacity(context: CanvasRenderingContext2D): void {
+    if (context.globalAlpha > this.opacity) {
+      context.globalAlpha = this.opacity;
+    }
+  }
+
   public setDebugSettings(debugSettings: DebugSettings | null): void {
     this.debugSettings = debugSettings;
   }

--- a/src/objects/common/closeable-message-object.ts
+++ b/src/objects/common/closeable-message-object.ts
@@ -44,10 +44,10 @@ export class CloseableMessageObject extends BaseTappableGameObject {
   }
 
   public render(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
     this.drawRoundedRectangle(context);
     this.drawText(context);
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
 
     super.render(context);
   }

--- a/src/objects/common/closeable-window-object.ts
+++ b/src/objects/common/closeable-window-object.ts
@@ -82,7 +82,7 @@ export class CloseableWindowObject extends BaseTappableGameObject {
     this.backdropObject.render(context);
     this.renderWindow(context);
 
-    this.resetOpacity(context);
+    this.resetToGlobalOpacity(context);
 
     super.render(context);
   }

--- a/src/objects/common/closeable-window-object.ts
+++ b/src/objects/common/closeable-window-object.ts
@@ -82,7 +82,7 @@ export class CloseableWindowObject extends BaseTappableGameObject {
     this.backdropObject.render(context);
     this.renderWindow(context);
 
-    context.globalAlpha = 1; // Reset global alpha
+    this.resetOpacity(context);
 
     super.render(context);
   }

--- a/src/objects/common/closeable-window-object.ts
+++ b/src/objects/common/closeable-window-object.ts
@@ -77,12 +77,14 @@ export class CloseableWindowObject extends BaseTappableGameObject {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+
     this.applyOpacity(context);
 
     this.backdropObject.render(context);
     this.renderWindow(context);
 
-    this.resetToGlobalOpacity(context);
+    context.restore();
 
     super.render(context);
   }

--- a/src/objects/common/closeable-window-object.ts
+++ b/src/objects/common/closeable-window-object.ts
@@ -77,7 +77,7 @@ export class CloseableWindowObject extends BaseTappableGameObject {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
 
     this.backdropObject.render(context);
     this.renderWindow(context);

--- a/src/objects/common/debug-object.ts
+++ b/src/objects/common/debug-object.ts
@@ -43,10 +43,6 @@ export class DebugObject extends BaseAnimatedGameObject {
     context.restore();
   }
 
-  private applyOpacity(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
-  }
-
   private drawText(context: CanvasRenderingContext2D): void {
     context.fillStyle = "#FFFF00";
     context.font = "18px system-ui";

--- a/src/objects/common/message-object.ts
+++ b/src/objects/common/message-object.ts
@@ -35,10 +35,10 @@ export class MessageObject extends BaseAnimatedGameObject {
   }
 
   public render(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
     this.drawRoundedRectangle(context);
     this.drawText(context);
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
   }
 
   private drawRoundedRectangle(context: CanvasRenderingContext2D): void {

--- a/src/objects/common/notification-object.ts
+++ b/src/objects/common/notification-object.ts
@@ -44,7 +44,7 @@ export class NotificationObject extends BaseAnimatedGameObject {
     context.font = "20px system-ui";
     context.fillText(this.text, this.textX, this.y + this.HEIGHT / 2 + 6);
 
-    context.globalAlpha = 1;
+    this.resetOpacity(context);
   }
 
   public show(text: string): void {

--- a/src/objects/common/notification-object.ts
+++ b/src/objects/common/notification-object.ts
@@ -44,7 +44,7 @@ export class NotificationObject extends BaseAnimatedGameObject {
     context.font = "20px system-ui";
     context.fillText(this.text, this.textX, this.y + this.HEIGHT / 2 + 6);
 
-    this.resetOpacity(context);
+    this.resetToGlobalOpacity(context);
   }
 
   public show(text: string): void {

--- a/src/objects/common/notification-object.ts
+++ b/src/objects/common/notification-object.ts
@@ -28,6 +28,8 @@ export class NotificationObject extends BaseAnimatedGameObject {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+
     this.applyOpacity(context);
 
     // Draw red borders
@@ -44,7 +46,7 @@ export class NotificationObject extends BaseAnimatedGameObject {
     context.font = "20px system-ui";
     context.fillText(this.text, this.textX, this.y + this.HEIGHT / 2 + 6);
 
-    this.resetToGlobalOpacity(context);
+    context.restore();
   }
 
   public show(text: string): void {

--- a/src/objects/common/notification-object.ts
+++ b/src/objects/common/notification-object.ts
@@ -28,7 +28,7 @@ export class NotificationObject extends BaseAnimatedGameObject {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
 
     // Draw red borders
     context.fillStyle = "rgba(255, 0, 0, 0.85)";

--- a/src/objects/common/toast-object.ts
+++ b/src/objects/common/toast-object.ts
@@ -95,10 +95,6 @@ export class ToastObject extends BaseAnimatedGameObject {
     this.y = this.topMargin; // Set y position based on topMargin
   }
 
-  private applyOpacity(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
-  }
-
   private applyTransformations(context: CanvasRenderingContext2D): void {
     context.translate(this.x + this.width / 2, this.y + this.height / 2);
     context.rotate((this.angle * Math.PI) / 180);

--- a/src/objects/ranking-table-object.ts
+++ b/src/objects/ranking-table-object.ts
@@ -10,7 +10,7 @@ export class RankingTableObject extends BaseAnimatedGameObject {
 
   public render(context: CanvasRenderingContext2D): void {
     context.save();
-    context.globalAlpha = this.opacity;
+    this.applyOpacity(context);
 
     context.font = "bold 24px system-ui";
     context.textAlign = "left";

--- a/src/screens/base/base-game-screen.ts
+++ b/src/screens/base/base-game-screen.ts
@@ -65,12 +65,6 @@ export class BaseGameScreen implements GameScreen {
 
   public setOpacity(opacity: number): void {
     this.opacity = opacity;
-
-    [...this.sceneObjects, ...this.uiObjects].forEach((object) => {
-      if (object.getOpacity() > opacity) {
-        object.setOpacity(opacity);
-      }
-    });
   }
 
   public getUIObjects(): GameObject[] {


### PR DESCRIPTION
## Summary
- ensure screen opacity takes precedence
- replace hard-coded `globalAlpha` usage with helper

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*
- `npx eslint .` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68606dfe41e48327b4abd69180fa8276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized opacity handling across various on-screen elements, improving consistency in visual effects.
  * Simplified opacity management for screens and objects, reducing direct manipulation of rendering properties.

* **Bug Fixes**
  * Removed redundant or unused opacity methods from certain objects to prevent potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->