### PR TITLE
Break circular dependencies between communication services

### DIFF
--- a/src/interfaces/services/webrtc-service-interface.ts
+++ b/src/interfaces/services/webrtc-service-interface.ts
@@ -1,0 +1,11 @@
+export interface IWebRTCService {
+  registerCommandHandlers(instance: any): void;
+  dispatchCommand(
+    commandId: number,
+    peer: import("../webrtc-peer.js").WebRTCPeer,
+    binaryReader: import("../../utils/binary-reader-utils.js").BinaryReader
+  ): void;
+  sendIceCandidate(token: string, iceCandidate: RTCIceCandidateInit): void;
+  removePeer(token: string): void;
+  getPeers(): import("../webrtc-peer.js").WebRTCPeer[];
+}

--- a/src/services/event-processor-service.ts
+++ b/src/services/event-processor-service.ts
@@ -7,8 +7,7 @@ import { EventQueueService } from "./event-queue-service.js";
 import { BinaryWriter } from "../utils/binary-writer-utils.js";
 import type { BinaryReader } from "../utils/binary-reader-utils.js";
 import { PeerCommandHandler } from "../decorators/peer-command-handler-decorator.js";
-import { WebRTCService } from "./webrtc-service.js";
-import { ServiceLocator } from "./service-locator.js";
+import type { IWebRTCService } from "../interfaces/services/webrtc-service-interface.js";
 
 export type EventSubscription = {
   eventType: EventType;
@@ -18,15 +17,15 @@ export type EventSubscription = {
 export class EventProcessorService {
   private localQueue: EventQueueService<LocalEvent>;
   private remoteQueue: EventQueueService<RemoteEvent>;
-  private webrtcService: WebRTCService | null = null;
+  private webrtcService: IWebRTCService | null = null;
 
   constructor() {
     this.localQueue = new EventQueueService<LocalEvent>();
     this.remoteQueue = new EventQueueService<RemoteEvent>();
   }
 
-  public initialize(): void {
-    this.webrtcService = ServiceLocator.get(WebRTCService);
+  public initialize(webrtcService: IWebRTCService): void {
+    this.webrtcService = webrtcService;
     this.webrtcService.registerCommandHandlers(this);
     console.log("Event processor service initialized");
   }
@@ -71,7 +70,7 @@ export class EventProcessorService {
       });
   }
 
-  private getWebRTCService(): WebRTCService {
+  private getWebRTCService(): IWebRTCService {
     if (this.webrtcService === null) {
       throw new Error("WebRTCService is not initialized");
     }

--- a/src/services/service-manager.ts
+++ b/src/services/service-manager.ts
@@ -63,8 +63,9 @@ export class ServiceManager {
   }
 
   private static initializeServices() {
+    const webrtcService = ServiceLocator.get(WebRTCService);
     ServiceLocator.get(ObjectOrchestratorService).initialize();
-    ServiceLocator.get(EventProcessorService).initialize();
-    ServiceLocator.get(WebRTCService).initialize();
+    ServiceLocator.get(EventProcessorService).initialize(webrtcService);
+    webrtcService.initialize();
   }
 }

--- a/src/services/webrtc-peer-service.ts
+++ b/src/services/webrtc-peer-service.ts
@@ -1,7 +1,7 @@
 import { GamePlayer } from "../models/game-player.js";
 import { MatchmakingService } from "./matchmaking-service.js";
 import { WebRTCType } from "../enums/webrtc-type.js";
-import { WebRTCService } from "./webrtc-service.js";
+import type { IWebRTCService } from "../interfaces/services/webrtc-service-interface.js";
 import type { WebRTCPeer } from "../interfaces/webrtc-peer.js";
 import { BinaryReader } from "../utils/binary-reader-utils.js";
 import { BinaryWriter } from "../utils/binary-writer-utils.js";
@@ -14,7 +14,7 @@ export class WebRTCPeerService implements WebRTCPeer {
   private SEQUENCE_FUTURE_WINDOW = 32;
 
   private matchmakingService: MatchmakingService;
-  private webrtcService: WebRTCService;
+  private webrtcDelegate: IWebRTCService;
   private peerConnection: RTCPeerConnection;
   private iceCandidatesQueue: RTCIceCandidateInit[] = [];
   private dataChannels: Record<string, RTCDataChannel> = {};
@@ -42,10 +42,11 @@ export class WebRTCPeerService implements WebRTCPeer {
 
   constructor(
     private gameState = ServiceLocator.get(GameState),
-    private token: string
+    private token: string,
+    webrtcDelegate: IWebRTCService
   ) {
     this.matchmakingService = ServiceLocator.get(MatchmakingService);
-    this.webrtcService = ServiceLocator.get(WebRTCService);
+    this.webrtcDelegate = webrtcDelegate;
 
     this.host = gameState.getMatch()?.isHost() ?? false;
 
@@ -143,7 +144,7 @@ export class WebRTCPeerService implements WebRTCPeer {
 
     this.iceCandidatesQueue.forEach((candidate) => {
       this.processIceCandidate(candidate, true);
-      this.webrtcService.sendIceCandidate(this.token, candidate);
+      this.webrtcDelegate.sendIceCandidate(this.token, candidate);
     });
 
     this.iceCandidatesQueue = [];
@@ -264,7 +265,7 @@ export class WebRTCPeerService implements WebRTCPeer {
 
   private handleDisconnection(): void {
     console.info("Peer connection closed");
-    this.webrtcService.removePeer(this.token);
+    this.webrtcDelegate.removePeer(this.token);
 
     // If the peer was connected, notify the matchmaking service
     if (this.connected) {
@@ -351,7 +352,7 @@ export class WebRTCPeerService implements WebRTCPeer {
       console.info("Queued ICE candidate", iceCandidate);
     }
 
-    this.webrtcService.sendIceCandidate(this.token, iceCandidate);
+    this.webrtcDelegate.sendIceCandidate(this.token, iceCandidate);
   }
 
   private async processIceCandidate(
@@ -518,7 +519,7 @@ export class WebRTCPeerService implements WebRTCPeer {
     }
 
     try {
-      this.webrtcService.dispatchCommand(commandId, this, binaryReader);
+      this.webrtcDelegate.dispatchCommand(commandId, this, binaryReader);
     } catch (error) {
       console.error(
         `Error executing command handler for ID ${commandId} from peer ${this.getName()}:`,

--- a/src/services/webrtc-service.ts
+++ b/src/services/webrtc-service.ts
@@ -12,8 +12,9 @@ import { ServerCommandHandler } from "../decorators/server-command-handler.js";
 import { WebSocketService } from "./websocket-service.js";
 import { ServiceLocator } from "./service-locator.js";
 import { GameState } from "../models/game-state.js";
+import type { IWebRTCService } from "../interfaces/services/webrtc-service-interface.js";
 
-export class WebRTCService {
+export class WebRTCService implements IWebRTCService {
   private peers: Map<string, WebRTCPeer> = new Map();
 
   // Network stats
@@ -215,7 +216,7 @@ export class WebRTCService {
   }
 
   private addPeer(token: string): WebRTCPeer {
-    const peer = new WebRTCPeerService(this.gameState, token);
+    const peer = new WebRTCPeerService(this.gameState, token, this);
     this.peers.set(token, peer);
 
     console.log("Added WebRTC peer, updated peers count", this.peers.size);


### PR DESCRIPTION
## Summary
- introduce `IWebRTCService` interface with filename suffix `-interface`
- update event processor and peer classes to use `IWebRTCService`
- inject `WebRTCService` instance via the interface to break cycles

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@mori2003/jsimgui')*

------
https://chatgpt.com/codex/tasks/task_e_6861280872908327b7a7d2c7b722b4fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal services to use a WebRTC service interface for improved modularity.
  * Changed how dependencies are injected and referenced within related services.
  * Adjusted method signatures to accept interface-based arguments instead of concrete implementations.

No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->