### PR TITLE
Refactor dependencies for clean layering

### DIFF
--- a/src/interfaces/objects/animatable-object.ts
+++ b/src/interfaces/objects/animatable-object.ts
@@ -1,0 +1,7 @@
+export interface AnimatableObject {
+  setOpacity(opacity: number): void;
+  setX(x: number): void;
+  setY(y: number): void;
+  setAngle(angle: number): void;
+  setScale(scale: number): void;
+}

--- a/src/interfaces/screens/game-screen.ts
+++ b/src/interfaces/screens/game-screen.ts
@@ -17,7 +17,7 @@ export interface GameScreen {
   getObjectLayer(object: GameObject): LayerType;
   addObjectToSceneLayer(object: GameObject): void;
 
-  update(deltaTimeStamp: number): void;
+  update(deltaTimeStamp: DOMHighResTimeStamp): void;
   render(context: CanvasRenderingContext2D): void;
 
   getOpacity(): number;

--- a/src/interfaces/screens/game-screen.ts
+++ b/src/interfaces/screens/game-screen.ts
@@ -1,6 +1,6 @@
 import { LayerType } from "../../enums/layer-type.js";
 import type { GameObject } from "../objects/game-object.js";
-import { ScreenManagerService } from "../../services/screen-manager-service.js";
+import type { ScreenManager } from "./screen-manager.js";
 
 export interface GameScreen {
   isActive(): boolean;
@@ -8,8 +8,8 @@ export interface GameScreen {
   getUIObjects(): GameObject[];
   getSceneObjects(): GameObject[];
 
-  getScreenManagerService(): ScreenManagerService | null;
-  setScreenManagerService(screenManagerService: ScreenManagerService): void;
+  getScreenManagerService(): ScreenManager | null;
+  setScreenManagerService(screenManagerService: ScreenManager): void;
 
   load(): void;
   hasLoaded(): boolean;

--- a/src/interfaces/screens/screen-manager.ts
+++ b/src/interfaces/screens/screen-manager.ts
@@ -3,6 +3,10 @@ import type { GameScreen } from "./game-screen.js";
 export interface ScreenManager {
   getCurrentScreen(): GameScreen | null;
   getNextScreen(): GameScreen | null;
+  getPreviousScreen(): GameScreen | null;
   setCurrentScreen(screen: GameScreen): void;
   setNextScreen(screen: GameScreen | null): void;
+  setInitialScreen(screen: GameScreen): void;
+  update(deltaTimeStamp: DOMHighResTimeStamp): void;
+  render(context: CanvasRenderingContext2D): void;
 }

--- a/src/interfaces/screens/screen-manager.ts
+++ b/src/interfaces/screens/screen-manager.ts
@@ -1,12 +1,11 @@
 import type { GameScreen } from "./game-screen.js";
 
 export interface ScreenManager {
+  getPreviousScreen(): GameScreen | null;
   getCurrentScreen(): GameScreen | null;
   getNextScreen(): GameScreen | null;
-  getPreviousScreen(): GameScreen | null;
   setCurrentScreen(screen: GameScreen): void;
   setNextScreen(screen: GameScreen | null): void;
-  setInitialScreen(screen: GameScreen): void;
   update(deltaTimeStamp: DOMHighResTimeStamp): void;
   render(context: CanvasRenderingContext2D): void;
 }

--- a/src/interfaces/services/peer-connection-listener.ts
+++ b/src/interfaces/services/peer-connection-listener.ts
@@ -1,0 +1,4 @@
+export interface PeerConnectionListener {
+  onPeerConnected(peer: import('../webrtc-peer.js').WebRTCPeer): void;
+  onPeerDisconnected(peer: import('../webrtc-peer.js').WebRTCPeer): void;
+}

--- a/src/interfaces/services/peer-connection-listener.ts
+++ b/src/interfaces/services/peer-connection-listener.ts
@@ -1,4 +1,6 @@
+import type { WebRTCPeer } from "../webrtc-peer";
+
 export interface PeerConnectionListener {
-  onPeerConnected(peer: import('../webrtc-peer.js').WebRTCPeer): void;
-  onPeerDisconnected(peer: import('../webrtc-peer.js').WebRTCPeer): void;
+  onPeerConnected(peer: WebRTCPeer): void;
+  onPeerDisconnected(peer: WebRTCPeer): void;
 }

--- a/src/models/game-frame.ts
+++ b/src/models/game-frame.ts
@@ -1,9 +1,8 @@
 import { NotificationObject } from "../objects/common/notification-object.js";
 import type { GameScreen } from "../interfaces/screens/game-screen.js";
-import type { ScreenManager } from "../interfaces/screens/screen-manager.js";
 import { DebugObject } from "../objects/common/debug-object.js";
 
-export class GameFrame implements ScreenManager {
+export class GameFrame {
   private currentScreen: GameScreen | null = null;
   private nextScreen: GameScreen | null = null;
   private notificationObject: NotificationObject | null = null;
@@ -23,14 +22,6 @@ export class GameFrame implements ScreenManager {
 
   public setNextScreen(screen: GameScreen | null): void {
     this.nextScreen = screen;
-  }
-
-  public setInitialScreen(screen: GameScreen): void {
-    this.currentScreen = screen;
-  }
-
-  public getPreviousScreen(): GameScreen | null {
-    return null;
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {

--- a/src/models/game-frame.ts
+++ b/src/models/game-frame.ts
@@ -25,6 +25,24 @@ export class GameFrame implements ScreenManager {
     this.nextScreen = screen;
   }
 
+  public setInitialScreen(screen: GameScreen): void {
+    this.currentScreen = screen;
+  }
+
+  public getPreviousScreen(): GameScreen | null {
+    return null;
+  }
+
+  public update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    this.currentScreen?.update(deltaTimeStamp);
+    this.nextScreen?.update(deltaTimeStamp);
+  }
+
+  public render(context: CanvasRenderingContext2D): void {
+    this.currentScreen?.render(context);
+    this.nextScreen?.render(context);
+  }
+
   public getNotificationObject(): NotificationObject | null {
     return this.notificationObject;
   }

--- a/src/objects/base/base-dynamic-colliding-game-object.ts
+++ b/src/objects/base/base-dynamic-colliding-game-object.ts
@@ -15,6 +15,10 @@ export class BaseDynamicCollidingGameObject extends BaseStaticCollidingGameObjec
   protected vy: number = 0;
   protected mass: number = 0;
 
+  public override isDynamic(): boolean {
+    return true;
+  }
+
   constructor() {
     super();
   }

--- a/src/objects/base/base-static-colliding-game-object.ts
+++ b/src/objects/base/base-static-colliding-game-object.ts
@@ -1,6 +1,5 @@
 import { HitboxObject } from "../common/hitbox-object.js";
 import { BaseAnimatedGameObject } from "./base-animated-object.js";
-import { BaseDynamicCollidingGameObject } from "./base-dynamic-colliding-game-object.js";
 
 type CollidingGameObjectConstructor = new (
   ...args: never[]
@@ -13,6 +12,10 @@ export class BaseStaticCollidingGameObject extends BaseAnimatedGameObject {
   private collidingObjects: BaseStaticCollidingGameObject[] = [];
   private avoidingCollision = false;
   private excludedCollisionClasses: CollidingGameObjectConstructor[] = [];
+
+  public isDynamic(): boolean {
+    return false;
+  }
 
   public override load(): void {
     this.hitboxObjects.forEach((object) =>
@@ -41,7 +44,7 @@ export class BaseStaticCollidingGameObject extends BaseAnimatedGameObject {
         this.isCollisionClassIncluded(
           object.constructor as CollidingGameObjectConstructor
         ) &&
-        !(object instanceof BaseDynamicCollidingGameObject) &&
+        !object.isDynamic() &&
         object.hasRigidBody()
     );
   }

--- a/src/screens/base/base-game-screen.ts
+++ b/src/screens/base/base-game-screen.ts
@@ -3,6 +3,7 @@ import { LayerType } from "../../enums/layer-type.js";
 import { BaseTappableGameObject } from "../../objects/base/base-tappable-game-object.js";
 import type { GameObject } from "../../interfaces/objects/game-object.js";
 import type { GameScreen } from "../../interfaces/screens/game-screen.js";
+import type { ScreenManager } from "../../interfaces/screens/screen-manager.js";
 import { ScreenManagerService } from "../../services/screen-manager-service.js";
 import { EventConsumerService } from "../../services/event-consumer-service.js";
 import { EventType } from "../../enums/event-type.js";
@@ -34,7 +35,7 @@ export class BaseGameScreen implements GameScreen {
     return this.opacity > 0;
   }
 
-  public getScreenManagerService(): ScreenManagerService | null {
+  public getScreenManagerService(): ScreenManager | null {
     return this.screenManagerService;
   }
 

--- a/src/screens/main-screen.ts
+++ b/src/screens/main-screen.ts
@@ -12,7 +12,7 @@ export class MainScreen extends BaseGameScreen {
     this.screenManagerService = new ScreenManagerService();
   }
 
-  public setScreen(screen: GameScreen): void {
+  public activateScreen(screen: GameScreen): void {
     this.screen = screen;
     this.screen?.setOpacity(1);
     this.screenManagerService?.setInitialScreen(screen);

--- a/src/screens/main-screen.ts
+++ b/src/screens/main-screen.ts
@@ -13,9 +13,9 @@ export class MainScreen extends BaseGameScreen {
   }
 
   public setScreen(screen: GameScreen): void {
-    console.log("MainScreen: Setting new screen", screen.constructor.name);
     this.screen = screen;
-    this.updateScreen(screen);
+    this.screen?.setOpacity(1);
+    this.screenManagerService?.setInitialScreen(screen);
   }
 
   public override load(): void {
@@ -45,12 +45,6 @@ export class MainScreen extends BaseGameScreen {
     super.render(context);
 
     this.screenManagerService?.render(context);
-  }
-
-  private updateScreen(screen: GameScreen): void {
-    // Set the screen to be fully visible
-    this.screen?.setOpacity(1);
-    this.screenManagerService?.setInitialScreen(screen);
   }
 
   private createMainBackgroundObject() {

--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -9,18 +9,15 @@ import { GameState } from "../../models/game-state.js";
 import { EventType } from "../../enums/event-type.js";
 import { CredentialService } from "../../services/credential-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class LoginScreen extends BaseGameScreen {
   private apiService: APIService;
   private cryptoService: CryptoService;
   private webSocketService: WebSocketService;
   private credentialService: CredentialService;
-  private screenTransitionService: ScreenTransitionService;
 
   private messageObject: MessageObject | null = null;
   private errorCloseableMessageObject: CloseableMessageObject | null = null;
-
   private dialogElement: HTMLDialogElement | null = null;
   private displayNameInputElement: HTMLInputElement | null = null;
   private registerButtonElement: HTMLElement | null = null;
@@ -32,7 +29,6 @@ export class LoginScreen extends BaseGameScreen {
     this.cryptoService = ServiceLocator.get(CryptoService);
     this.webSocketService = ServiceLocator.get(WebSocketService);
     this.credentialService = ServiceLocator.get(CredentialService);
-    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
     this.dialogElement = document.querySelector("dialog");
     this.displayNameInputElement = document.querySelector(
       "#display-name-input"
@@ -230,6 +226,8 @@ export class LoginScreen extends BaseGameScreen {
     const mainMenuScreen = new MainMenuScreen(this.gameState, true);
     mainMenuScreen.load();
 
-    this.screenTransitionService.crossfade(mainMenuScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(mainMenuScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -9,12 +9,14 @@ import { GameState } from "../../models/game-state.js";
 import { EventType } from "../../enums/event-type.js";
 import { CredentialService } from "../../services/credential-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
+import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class LoginScreen extends BaseGameScreen {
   private apiService: APIService;
   private cryptoService: CryptoService;
   private webSocketService: WebSocketService;
   private credentialService: CredentialService;
+  private screenTransitionService: ScreenTransitionService;
 
   private messageObject: MessageObject | null = null;
   private errorCloseableMessageObject: CloseableMessageObject | null = null;
@@ -30,6 +32,7 @@ export class LoginScreen extends BaseGameScreen {
     this.cryptoService = ServiceLocator.get(CryptoService);
     this.webSocketService = ServiceLocator.get(WebSocketService);
     this.credentialService = ServiceLocator.get(CredentialService);
+    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
     this.dialogElement = document.querySelector("dialog");
     this.displayNameInputElement = document.querySelector(
       "#display-name-input"
@@ -227,8 +230,6 @@ export class LoginScreen extends BaseGameScreen {
     const mainMenuScreen = new MainMenuScreen(this.gameState, true);
     mainMenuScreen.load();
 
-    this.screenManagerService
-      ?.getTransitionService()
-      .crossfade(mainMenuScreen, 0.2);
+    this.screenTransitionService.crossfade(mainMenuScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -203,9 +203,7 @@ export class MainMenuScreen extends BaseGameScreen {
     const scoreboardScreen = new ScoreboardScreen(this.gameState);
     scoreboardScreen.load();
 
-    this.screenManagerService
-      ?.getTransitionService()
-      .crossfade(scoreboardScreen, 0.2);
+    this.screenTransitionService.crossfade(scoreboardScreen, 0.2);
   }
 
   private transitionToSettingsScreen(): void {
@@ -214,9 +212,7 @@ export class MainMenuScreen extends BaseGameScreen {
     const settingsScreen = new SettingsScreen(this.gameState);
     settingsScreen.load();
 
-    this.screenManagerService
-      ?.getTransitionService()
-      .crossfade(settingsScreen, 0.2);
+    this.screenTransitionService.crossfade(settingsScreen, 0.2);
   }
 
   private enableMenuButtons(): void {

--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -4,7 +4,6 @@ import { TitleObject } from "../../objects/common/title-object.js";
 import { ServerMessageWindowObject } from "../../objects/server-message-window-object.js";
 import { APIService } from "../../services/api-service.js";
 import type { MessagesResponse } from "../../interfaces/responses/messages-response.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { LoadingScreen } from "../loading-screen.js";
 import { ScoreboardScreen } from "./scoreboard-screen.js";
@@ -17,7 +16,6 @@ export class MainMenuScreen extends BaseGameScreen {
   private MENU_OPTIONS_TEXT: string[] = ["Join game", "Scoreboard", "Settings"];
 
   private apiService: APIService;
-  private screenTransitionService: ScreenTransitionService;
 
   private messagesResponse: MessagesResponse[] | null = null;
 
@@ -28,7 +26,6 @@ export class MainMenuScreen extends BaseGameScreen {
     super(gameState);
     this.showNews = showNews;
     this.apiService = ServiceLocator.get(APIService);
-    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
     this.subscribeToEvents();
   }
 
@@ -194,7 +191,9 @@ export class MainMenuScreen extends BaseGameScreen {
     const loadingScreen = new LoadingScreen(this.gameState);
     loadingScreen.load();
 
-    this.screenTransitionService.crossfade(loadingScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(loadingScreen, 0.2);
   }
 
   private transitionToScoreboardScreen(): void {
@@ -203,7 +202,9 @@ export class MainMenuScreen extends BaseGameScreen {
     const scoreboardScreen = new ScoreboardScreen(this.gameState);
     scoreboardScreen.load();
 
-    this.screenTransitionService.crossfade(scoreboardScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(scoreboardScreen, 0.2);
   }
 
   private transitionToSettingsScreen(): void {
@@ -212,7 +213,9 @@ export class MainMenuScreen extends BaseGameScreen {
     const settingsScreen = new SettingsScreen(this.gameState);
     settingsScreen.load();
 
-    this.screenTransitionService.crossfade(settingsScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(settingsScreen, 0.2);
   }
 
   private enableMenuButtons(): void {

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -7,7 +7,6 @@ import { RankingTableObject } from "../../objects/ranking-table-object.js";
 import type { GameState } from "../../models/game-state.js";
 import { APIService } from "../../services/api-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
@@ -16,12 +15,10 @@ export class ScoreboardScreen extends BaseGameScreen {
   private closeableMessageObject: CloseableMessageObject | null = null;
 
   private apiService: APIService;
-  private screenTransitionService: ScreenTransitionService;
 
   constructor(gameState: GameState) {
     super(gameState);
     this.apiService = ServiceLocator.get(APIService);
-    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
   }
 
   public override load(): void {
@@ -103,6 +100,8 @@ export class ScoreboardScreen extends BaseGameScreen {
 
     console.log("Returning to", previousScreen.constructor.name);
 
-    this.screenTransitionService.crossfade(previousScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(previousScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -7,6 +7,7 @@ import { RankingTableObject } from "../../objects/ranking-table-object.js";
 import type { GameState } from "../../models/game-state.js";
 import { APIService } from "../../services/api-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
+import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
@@ -15,10 +16,12 @@ export class ScoreboardScreen extends BaseGameScreen {
   private closeableMessageObject: CloseableMessageObject | null = null;
 
   private apiService: APIService;
+  private screenTransitionService: ScreenTransitionService;
 
   constructor(gameState: GameState) {
     super(gameState);
     this.apiService = ServiceLocator.get(APIService);
+    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
   }
 
   public override load(): void {
@@ -100,8 +103,6 @@ export class ScoreboardScreen extends BaseGameScreen {
 
     console.log("Returning to", previousScreen.constructor.name);
 
-    this.screenManagerService
-      ?.getTransitionService()
-      .crossfade(previousScreen, 0.2);
+    this.screenTransitionService.crossfade(previousScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/settings-screen.ts
+++ b/src/screens/main-screen/settings-screen.ts
@@ -5,13 +5,16 @@ import { SettingObject } from "../../objects/setting-object.js";
 import { DebugService } from "../../services/debug-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
+import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class SettingsScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
   private buttonObject: ButtonObject | null = null;
+  private screenTransitionService: ScreenTransitionService;
 
   constructor(gameState: GameState) {
     super(gameState);
+    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
   }
 
   public override load(): void {
@@ -81,9 +84,7 @@ export class SettingsScreen extends BaseGameScreen {
 
     console.log("Returning to", previousScreen.constructor.name);
 
-    this.screenManagerService
-      ?.getTransitionService()
-      .crossfade(previousScreen, 0.2);
+    this.screenTransitionService.crossfade(previousScreen, 0.2);
   }
 
   private handleSettingObjectPress(settingObject: SettingObject): void {

--- a/src/screens/main-screen/settings-screen.ts
+++ b/src/screens/main-screen/settings-screen.ts
@@ -5,16 +5,13 @@ import { SettingObject } from "../../objects/setting-object.js";
 import { DebugService } from "../../services/debug-service.js";
 import { ServiceLocator } from "../../services/service-locator.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
 
 export class SettingsScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;
   private buttonObject: ButtonObject | null = null;
-  private screenTransitionService: ScreenTransitionService;
 
   constructor(gameState: GameState) {
     super(gameState);
-    this.screenTransitionService = ServiceLocator.get(ScreenTransitionService);
   }
 
   public override load(): void {
@@ -84,7 +81,9 @@ export class SettingsScreen extends BaseGameScreen {
 
     console.log("Returning to", previousScreen.constructor.name);
 
-    this.screenTransitionService.crossfade(previousScreen, 0.2);
+    this.screenManagerService
+      ?.getTransitionService()
+      .crossfade(previousScreen, 0.2);
   }
 
   private handleSettingObjectPress(settingObject: SettingObject): void {

--- a/src/screens/utils/screen-utils.ts
+++ b/src/screens/utils/screen-utils.ts
@@ -1,6 +1,6 @@
-import { GameFrame } from "../models/game-frame.js";
-import { BaseMultiplayerScreen } from "../screens/base/base-multiplayer-screen.js";
-import type { MultiplayerScreen } from "../interfaces/screens/multiplayer-screen.js";
+import { GameFrame } from "../../models/game-frame.js";
+import { BaseMultiplayerScreen } from "../base/base-multiplayer-screen.js";
+import type { MultiplayerScreen } from "../../interfaces/screens/multiplayer-screen.js";
 
 export class ScreenUtils {
   public static getScreenById(

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -627,7 +627,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
     const mainScreen = new MainScreen(this.gameState);
     const mainMenuScreen = new MainMenuScreen(this.gameState, false);
 
-    mainScreen.setScreen(mainMenuScreen);
+    mainScreen.activateScreen(mainMenuScreen);
     mainScreen.load();
 
     this.screenTransitionService.fadeOutAndIn(mainScreen, 1, 1);

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -16,8 +16,6 @@ import { GamePlayer } from "../models/game-player.js";
 import { EventType } from "../enums/event-type.js";
 import { RemoteEvent } from "../models/remote-event.js";
 import { ScreenType } from "../enums/screen-type.js";
-import { MainScreen } from "./main-screen.js";
-import { MainMenuScreen } from "./main-screen/main-menu-screen.js";
 import { MatchStateType } from "../enums/match-state-type.js";
 import type { PlayerConnectedPayload } from "../interfaces/events/player-connected-payload.js";
 import type { PlayerDisconnectedPayload } from "../interfaces/events/player-disconnected-payload.js";
@@ -102,7 +100,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
     );
 
     this.gameState.setMatch(null);
-    this.returnToMainMenuScreen();
+    void this.returnToMainMenuScreen();
   }
 
   private handleMatchState(): void {
@@ -617,10 +615,13 @@ export class WorldScreen extends BaseCollidingGameScreen {
     console.log("Game over end");
 
     this.matchmakingService.handleGameOver();
-    this.returnToMainMenuScreen();
+    void this.returnToMainMenuScreen();
   }
 
-  private returnToMainMenuScreen(): void {
+  private async returnToMainMenuScreen(): Promise<void> {
+    const { MainScreen } = await import("./main-screen.js");
+    const { MainMenuScreen } = await import("./main-screen/main-menu-screen.js");
+
     const mainScreen = new MainScreen(this.gameState);
     const mainMenuScreen = new MainMenuScreen(this.gameState, false);
 

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -620,7 +620,9 @@ export class WorldScreen extends BaseCollidingGameScreen {
 
   private async returnToMainMenuScreen(): Promise<void> {
     const { MainScreen } = await import("./main-screen.js");
-    const { MainMenuScreen } = await import("./main-screen/main-menu-screen.js");
+    const { MainMenuScreen } = await import(
+      "./main-screen/main-menu-screen.js"
+    );
 
     const mainScreen = new MainScreen(this.gameState);
     const mainMenuScreen = new MainMenuScreen(this.gameState, false);

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -165,7 +165,7 @@ export class GameLoopService {
     const mainScreen = new MainScreen(this.gameState);
     const mainMenuScreen = new MainMenuScreen(this.gameState, false);
 
-    mainScreen.setScreen(mainMenuScreen);
+    mainScreen.activateScreen(mainMenuScreen);
     mainScreen.load();
 
     this.screenTransitionService.fadeOutAndIn(mainScreen, 1, 1);
@@ -190,7 +190,7 @@ export class GameLoopService {
     const mainScreen = new MainScreen(this.gameState);
     const loginScreen = new LoginScreen(this.gameState);
 
-    mainScreen.setScreen(loginScreen);
+    mainScreen.activateScreen(loginScreen);
     mainScreen.load();
 
     this.screenTransitionService.crossfade(mainScreen, 1);

--- a/src/services/matchmaking-service.ts
+++ b/src/services/matchmaking-service.ts
@@ -26,13 +26,14 @@ import { ServerCommandHandler } from "../decorators/server-command-handler.js";
 import { ServiceLocator } from "./service-locator.js";
 import { WebSocketService } from "./websocket-service.js";
 import { WebRTCService } from "./webrtc-service.js";
+import type { PeerConnectionListener } from "../interfaces/services/peer-connection-listener.js";
 import { EventProcessorService } from "./event-processor-service.js";
 import { APIService } from "./api-service.js";
 import { TimerManagerService } from "./timer-manager-service.js";
 import { IntervalManagerService } from "./interval-manager-service.js";
 import { GAME_VERSION } from "../constants/game-constants.js";
 
-export class MatchmakingService {
+export class MatchmakingService implements PeerConnectionListener {
   private findMatchesTimerService: TimerService | null = null;
   private pingCheckInterval: IntervalService | null = null;
 

--- a/src/services/object-animator-service.ts
+++ b/src/services/object-animator-service.ts
@@ -1,8 +1,8 @@
 import { AnimationType } from "../enums/animation-type.js";
-import { BaseAnimatedGameObject } from "../objects/base/base-animated-object.js";
+import type { AnimatableObject } from "../interfaces/objects/animatable-object.js";
 
 export class ObjectAnimationService {
-  private readonly object: BaseAnimatedGameObject;
+  private readonly object: AnimatableObject;
 
   private completed: boolean = false;
 
@@ -15,7 +15,7 @@ export class ObjectAnimationService {
   private animationType: AnimationType;
 
   constructor(
-    object: BaseAnimatedGameObject,
+    object: AnimatableObject,
     animationType: AnimationType,
     startValue: number,
     endValue: number,

--- a/src/services/object-orchestrator-service.ts
+++ b/src/services/object-orchestrator-service.ts
@@ -5,7 +5,7 @@ import type { WebRTCPeer } from "../interfaces/webrtc-peer.js";
 import { ObjectUtils } from "../utils/object-utils.js";
 import type { MultiplayerScreen } from "../interfaces/screens/multiplayer-screen.js";
 import { ObjectStateType } from "../enums/object-state-type.js";
-import { ScreenUtils } from "../utils/screen-utils.js";
+import { ScreenUtils } from "../screens/utils/screen-utils.js";
 import { WebRTCType } from "../enums/webrtc-type.js";
 import { BinaryReader } from "../utils/binary-reader-utils.js";
 import { BinaryWriter } from "../utils/binary-writer-utils.js";

--- a/src/services/service-manager.ts
+++ b/src/services/service-manager.ts
@@ -64,8 +64,9 @@ export class ServiceManager {
 
   private static initializeServices() {
     const webrtcService = ServiceLocator.get(WebRTCService);
+    const matchmakingService = ServiceLocator.get(MatchmakingService);
     ServiceLocator.get(ObjectOrchestratorService).initialize();
     ServiceLocator.get(EventProcessorService).initialize(webrtcService);
-    webrtcService.initialize();
+    webrtcService.initialize(matchmakingService);
   }
 }


### PR DESCRIPTION
## Summary
- enforce low-level interfaces to avoid higher-level imports
- move screen utilities into the screens layer
- break circular dependency in collision objects
- introduce connection listener to decouple WebRTC services
- provide dynamic imports for returning to main menu

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*
- `npx --yes madge --circular --extensions ts ./src | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6861cb9bf3c48327843da746a09479ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced interfaces for animatable objects and peer connection listeners, enabling more flexible object animation and peer event handling.
  * Added new methods for screen management, including retrieving previous screens, updating, and rendering.
  * Added dynamic/static distinction methods for game objects.

* **Bug Fixes**
  * Improved screen transition logic in the main menu for consistency.
  * Corrected import paths for better module resolution.

* **Refactor**
  * Updated several services and classes to use abstract interfaces instead of concrete implementations for greater flexibility and maintainability.
  * Streamlined screen and peer connection management by generalizing dependencies and method signatures.
  * Replaced direct class instance checks with interface methods for object type distinction.
  * Renamed key screen activation methods for clearer intent and updated asynchronous handling of screen transitions.

* **Style**
  * Removed unnecessary blank lines and debug statements for cleaner code.

* **Chores**
  * Updated import statements and method signatures to align with new interface-based designs.
  * Modified service initialization to pass dependencies explicitly for improved clarity and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->