### PR TITLE
Introduce interface for matchmaking provider

### DIFF
--- a/src/interfaces/services/matchmaking-provider.ts
+++ b/src/interfaces/services/matchmaking-provider.ts
@@ -1,0 +1,5 @@
+export interface IMatchmakingProvider {
+  findOrAdvertiseMatch(): Promise<void>;
+  handleGameOver(): Promise<void>;
+  savePlayerScore(): Promise<void>;
+}

--- a/src/models/game-state.ts
+++ b/src/models/game-state.ts
@@ -6,6 +6,7 @@ import { GamePointer } from "./game-pointer.js";
 import { DebugSettings } from "../debug/debug-settings.js";
 import { GameKeyboard } from "./game-keyboard.js";
 import { GameGamepad } from "./game-gamepad.js";
+import { MatchStateType } from "../enums/match-state-type.js";
 
 export class GameState {
   private debugSettings: DebugSettings;
@@ -82,5 +83,22 @@ export class GameState {
     } else {
       console.log("Match set in game state", match);
     }
+  }
+
+  public setMatchState(state: MatchStateType): void {
+    if (this.match === null) {
+      console.warn("Cannot set state, match is null");
+      return;
+    }
+
+    this.match.setState(state);
+  }
+
+  public startMatch(): void {
+    this.setMatchState(MatchStateType.InProgress);
+  }
+
+  public endMatch(): void {
+    this.setMatchState(MatchStateType.GameOver);
   }
 }

--- a/src/services/matchmaking-service.ts
+++ b/src/services/matchmaking-service.ts
@@ -27,8 +27,11 @@ import { APIService } from "./api-service.js";
 import { TimerManagerService } from "./timer-manager-service.js";
 import { IntervalManagerService } from "./interval-manager-service.js";
 import { MatchFinderService } from "./match-finder-service.js";
+import type { IMatchmakingProvider } from "../interfaces/services/matchmaking-provider.js";
 
-export class MatchmakingService implements PeerConnectionListener {
+export class MatchmakingService
+  implements PeerConnectionListener, IMatchmakingProvider
+{
   private findMatchesTimerService: TimerService | null = null;
   private pingCheckInterval: IntervalService | null = null;
 

--- a/src/services/score-manager-service.ts
+++ b/src/services/score-manager-service.ts
@@ -12,7 +12,7 @@ import { ScoreboardObject } from "../objects/scoreboard-object.js";
 import { AlertObject } from "../objects/alert-object.js";
 import { TimerManagerService } from "./timer-manager-service.js";
 import { EventProcessorService } from "./event-processor-service.js";
-import { MatchmakingService } from "./matchmaking-service.js";
+import type { IMatchmakingProvider } from "../interfaces/services/matchmaking-provider.js";
 
 export class ScoreManagerService {
   constructor(
@@ -23,7 +23,7 @@ export class ScoreManagerService {
     private readonly alertObject: AlertObject,
     private readonly timerManagerService: TimerManagerService,
     private readonly eventProcessorService: EventProcessorService,
-    private readonly matchmakingService: MatchmakingService,
+    private readonly matchmakingService: IMatchmakingProvider,
     private readonly goalTimeEndCallback: () => void,
     private readonly gameOverEndCallback: () => void,
   ) {}
@@ -59,7 +59,7 @@ export class ScoreManagerService {
     }
     this.scoreboardObject.stopTimer();
     this.ballObject.handleGoalScored();
-    this.gameState.getMatch()?.setState(MatchStateType.GoalScored);
+    this.gameState.setMatchState(MatchStateType.GoalScored);
     const binaryReader = BinaryReader.fromArrayBuffer(arrayBuffer);
     const playerId = binaryReader.fixedLengthString(32);
     const playerScore = binaryReader.unsignedInt8();
@@ -103,7 +103,7 @@ export class ScoreManagerService {
     }
     this.scoreboardObject.stopTimer();
     this.ballObject.handleGoalScored();
-    this.gameState.getMatch()?.setState(MatchStateType.GoalScored);
+    this.gameState.setMatchState(MatchStateType.GoalScored);
     player.sumScore(1);
     this.sendGoalEvent(player);
     const goalTeam =
@@ -174,7 +174,7 @@ export class ScoreManagerService {
   }
 
   private handleGameOverStart(winner: GamePlayer | null): void {
-    this.gameState.getMatch()?.setState(MatchStateType.GameOver);
+    this.gameState.endMatch();
     const playerName = winner?.getName().toUpperCase() ?? "UNKNOWN";
     const playerTeam = winner === this.gameState.getGamePlayer() ? "blue" : "red";
     this.alertObject.show([playerName, "WINS!"], playerTeam);


### PR DESCRIPTION
## Summary
- add `IMatchmakingProvider` interface
- type `WorldScreen` and `ScoreManagerService` to the new interface
- expose match state helpers via `GameState`
- update code to use `GameState` methods instead of manipulating match directly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866e4971cf88327bd174c81fcb75713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced match lifecycle management with new methods to start, end, and update match states.
* **Refactor**
  * Centralized match state management for improved consistency.
  * Updated services to use a common matchmaking interface, allowing for greater flexibility and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->