### PR TITLE
Refactor matchmaking networking

### DIFF
--- a/src/services/matchmaking-network-service.ts
+++ b/src/services/matchmaking-network-service.ts
@@ -1,0 +1,577 @@
+import { TimerService } from "./timer-service.js";
+import { Match } from "../models/match.js";
+import { GamePlayer } from "../models/game-player.js";
+import { GameState } from "../models/game-state.js";
+import { MATCH_ATTRIBUTES } from "../constants/matchmaking-constants.js";
+import type { WebRTCPeer } from "../interfaces/webrtc-peer.js";
+import { EventType } from "../enums/event-type.js";
+import { LocalEvent } from "../models/local-event.js";
+import type { PlayerConnectedPayload } from "../interfaces/events/player-connected-payload.js";
+import type { PlayerDisconnectedPayload } from "../interfaces/events/player-disconnected-payload.js";
+import { WebRTCType } from "../enums/webrtc-type.js";
+import { IntervalService } from "./interval-service.js";
+import { WebSocketType } from "../enums/websocket-type.js";
+import { BinaryWriter } from "../utils/binary-writer-utils.js";
+import { BinaryReader } from "../utils/binary-reader-utils.js";
+import { PeerCommandHandler } from "../decorators/peer-command-handler-decorator.js";
+import { ServerCommandHandler } from "../decorators/server-command-handler.js";
+import { ServiceLocator } from "./service-locator.js";
+import { WebSocketService } from "./websocket-service.js";
+import { WebRTCService } from "./webrtc-service.js";
+import type { PeerConnectionListener } from "../interfaces/services/peer-connection-listener.js";
+import { EventProcessorService } from "./event-processor-service.js";
+import { TimerManagerService } from "./timer-manager-service.js";
+import { IntervalManagerService } from "./interval-manager-service.js";
+import { MatchFinderService } from "./match-finder-service.js";
+
+export class MatchmakingNetworkService implements PeerConnectionListener {
+  private findMatchesTimerService: TimerService | null = null;
+  private pingCheckInterval: IntervalService | null = null;
+
+  constructor(
+    private readonly gameState: GameState = ServiceLocator.get(GameState),
+    private readonly timerManagerService: TimerManagerService = ServiceLocator.get(TimerManagerService),
+    private readonly intervalManagerService: IntervalManagerService = ServiceLocator.get(IntervalManagerService),
+    private readonly webSocketService: WebSocketService = ServiceLocator.get(WebSocketService),
+    private readonly webrtcService: WebRTCService = ServiceLocator.get(WebRTCService),
+    private readonly eventProcessorService: EventProcessorService = ServiceLocator.get(EventProcessorService),
+    private readonly matchFinderService: MatchFinderService,
+    private readonly pendingIdentities: Map<string, boolean>,
+    private readonly receivedIdentities: Map<string, { playerId: string; playerName: string }>,
+  ) {
+    this.webSocketService.registerCommandHandlers(this);
+    this.webrtcService.registerCommandHandlers(this);
+  }
+
+  public startFindMatchesTimer(resolve: () => void): void {
+    this.findMatchesTimerService = this.timerManagerService.createTimer(10, resolve);
+  }
+
+  public stopFindMatchesTimer(): void {
+    this.findMatchesTimerService?.stop(false);
+  }
+
+  public startPingCheckInterval(): void {
+    this.pingCheckInterval = this.intervalManagerService.createInterval(
+      1,
+      this.sendPingToJoinedPlayers.bind(this),
+    );
+  }
+
+  public removePingCheckInterval(): void {
+    if (this.pingCheckInterval !== null) {
+      this.intervalManagerService.removeInterval(this.pingCheckInterval);
+    }
+  }
+
+  @ServerCommandHandler(WebSocketType.PlayerIdentity)
+  public handlePlayerIdentity(binaryReader: BinaryReader): void {
+    const tokenBytes = binaryReader.bytes(32);
+    const playerId = binaryReader.fixedLengthString(32);
+    const playerName = binaryReader.fixedLengthString(16);
+
+    const token = btoa(String.fromCharCode(...tokenBytes));
+
+    console.log(
+      `Received player identity (token: ${token}, playerId: ${playerId}, playerName: ${playerName})`,
+    );
+
+    this.receivedIdentities.set(token, { playerId, playerName });
+
+    if (this.gameState.getMatch()?.isHost()) {
+      this.handlePlayerIdentityAsHost(token, tokenBytes);
+    } else {
+      this.handlePlayerIdentityAsPlayer(token);
+    }
+  }
+
+  public onPeerConnected(peer: WebRTCPeer): void {
+    if (this.gameState.getMatch()?.isHost()) {
+      return console.log("Peer connected", peer);
+    }
+
+    console.log("Connected to host", peer);
+
+    this.sendJoinRequest(peer);
+  }
+
+  public onPeerDisconnected(peer: WebRTCPeer): void {
+    if (peer.hasJoined() === false) {
+      return console.warn("Ignoring disconnection from non-joined peer", peer);
+    }
+
+    const playerId = peer.getPlayer()?.getId() ?? null;
+
+    if (playerId === null) {
+      return console.warn("Unknown peer disconnected", peer);
+    }
+
+    if (this.gameState.getMatch()?.isHost()) {
+      this.handlePlayerDisconnection(peer);
+    } else {
+      this.handleHostDisconnected(peer);
+    }
+  }
+
+  @PeerCommandHandler(WebRTCType.JoinRequest)
+  public handleJoinRequest(peer: WebRTCPeer): void {
+    const match = this.gameState.getMatch();
+
+    if (match === null) {
+      this.handleGameMatchNull(peer);
+      return;
+    }
+
+    if (match.getAvailableSlots() === 0) {
+      this.handleUnavailableSlots(peer);
+      return;
+    }
+
+    const token = peer.getToken();
+    const identity = this.receivedIdentities.get(token) ?? null;
+
+    if (identity === null) {
+      this.handleUnknownIdentity(peer);
+      return;
+    }
+
+    const { playerId, playerName } = identity;
+    console.log("Received join request from", playerName);
+
+    const gamePlayer = new GamePlayer(playerId, playerName);
+    peer.setPlayer(gamePlayer);
+
+    match.addPlayer(gamePlayer);
+
+    this.receivedIdentities.delete(token);
+
+    this.sendJoinResponse(peer, match);
+  }
+
+  @PeerCommandHandler(WebRTCType.JoinResponse)
+  public handleJoinResponse(
+    peer: WebRTCPeer,
+    binaryReader: BinaryReader,
+  ): void {
+    if (this.gameState.getMatch() !== null) {
+      return this.handleAlreadyJoinedMatch(peer);
+    }
+
+    console.log("Received join response from", peer.getToken());
+
+    const matchState = binaryReader.unsignedInt8();
+    const matchTotalSlots = binaryReader.unsignedInt8();
+
+    const match = new Match(
+      false,
+      matchState,
+      matchTotalSlots,
+      MATCH_ATTRIBUTES,
+    );
+
+    this.gameState.setMatch(match);
+
+    const localGamePlayer = this.gameState.getGamePlayer();
+    match.addPlayer(localGamePlayer);
+  }
+
+  @PeerCommandHandler(WebRTCType.PlayerConnection)
+  public handlePlayerConnection(
+    peer: WebRTCPeer,
+    binaryReader: BinaryReader,
+  ): void {
+    const isConnected = binaryReader.boolean();
+    const isHost = binaryReader.boolean();
+    const playerId = binaryReader.fixedLengthString(32);
+    const playerName = binaryReader.fixedLengthString(16);
+    const playerScore = binaryReader.unsignedInt8();
+
+    if (isConnected === false) {
+      return this.handlePlayerDisconnectedById(playerId);
+    }
+
+    const gamePlayer = new GamePlayer(
+      playerId,
+      playerName,
+      isHost,
+      playerScore,
+    );
+
+    if (isHost) {
+      if (this.isHostIdentityUnverified(peer, gamePlayer)) {
+        peer.disconnect(true);
+        return;
+      }
+
+      peer.setPlayer(gamePlayer);
+      this.receivedIdentities.delete(peer.getToken());
+    }
+
+    this.gameState.getMatch()?.addPlayer(gamePlayer);
+  }
+
+  @PeerCommandHandler(WebRTCType.SnapshotEnd)
+  public handleSnapshotEnd(peer: WebRTCPeer): void {
+    console.log("Received snapshot from", peer.getName());
+
+    this.stopFindMatchesTimer();
+    peer.setJoined(true);
+
+    const player = peer.getPlayer();
+
+    if (player === null) {
+      this.handleRemotePlayerNull(peer);
+      return;
+    }
+
+    const localEvent = new LocalEvent<PlayerConnectedPayload>(
+      EventType.PlayerConnected,
+    );
+
+    localEvent.setData({
+      player,
+      matchmaking: true,
+    });
+
+    this.eventProcessorService.addLocalEvent(localEvent);
+
+    this.sendSnapshotACK(peer);
+  }
+
+  @PeerCommandHandler(WebRTCType.SnapshotACK)
+  public handleSnapshotACK(peer: WebRTCPeer): void {
+    console.log("Received snapshot ACK from", peer.getName());
+
+    peer.setJoined(true);
+
+    const player = peer.getPlayer();
+
+    if (player === null) {
+      this.handleRemotePlayerNull(peer);
+      return;
+    }
+
+    this.webrtcService
+      .getPeers()
+      .filter((matchPeer) => matchPeer !== peer)
+      .forEach((p) => {
+        console.log("Sending player connection to", p.getName());
+        this.sendPlayerConnection(p, player, true, false);
+      });
+
+    const localEvent = new LocalEvent<PlayerConnectedPayload>(
+      EventType.PlayerConnected,
+    );
+
+    localEvent.setData({
+      player,
+      matchmaking: false,
+    });
+
+    this.eventProcessorService.addLocalEvent(localEvent);
+
+    void this.matchFinderService.advertiseMatch();
+  }
+
+  @PeerCommandHandler(WebRTCType.PlayerPing)
+  public handlePlayerPing(peer: WebRTCPeer, binaryReader: BinaryReader): void {
+    if (this.gameState.getGamePlayer().isHost()) {
+      console.warn(
+        `Unexpected player ping information from player ${peer.getName()}`,
+      );
+      return;
+    }
+
+    const playerId = binaryReader.fixedLengthString(32);
+    const playerPingTime = binaryReader.unsignedInt16();
+
+    this.gameState.getMatch()?.getPlayer(playerId)?.setPingTime(playerPingTime);
+  }
+
+  private handlePlayerIdentityAsHost(
+    token: string,
+    tokenBytes: Uint8Array,
+  ): void {
+    console.log("Sending player identity to player", token);
+    const webSocketPayload = BinaryWriter.build()
+      .unsignedInt8(WebSocketType.PlayerIdentity)
+      .bytes(tokenBytes, 32)
+      .toArrayBuffer();
+
+    this.webSocketService.sendMessage(webSocketPayload);
+  }
+
+  private handlePlayerIdentityAsPlayer(token: string): void {
+    console.log("Received player identity for token", token);
+    this.pendingIdentities.set(token, true);
+
+    this.webrtcService.sendOffer(token);
+  }
+
+  private handleAlreadyJoinedMatch(peer: WebRTCPeer): void {
+    console.warn(
+      "Already joined a match, disconnecting peer...",
+      peer.getToken(),
+    );
+
+    peer.disconnect(true);
+  }
+
+  private handlePlayerDisconnection(peer: WebRTCPeer): void {
+    const player = peer.getPlayer();
+
+    if (player === null) {
+      this.handleRemotePlayerNull(peer);
+      return;
+    }
+
+    console.log(`Player ${player.getName()} disconnected`);
+    this.gameState.getMatch()?.removePlayer(player);
+
+    this.webrtcService
+      .getPeers()
+      .filter((matchPeer) => matchPeer !== peer)
+      .forEach((p) => {
+        this.sendPlayerConnection(p, player, false, false);
+      });
+
+    const playerDisconnectedEvent = new LocalEvent<PlayerDisconnectedPayload>(
+      EventType.PlayerDisconnected,
+    );
+
+    playerDisconnectedEvent.setData({ player });
+
+    this.eventProcessorService.addLocalEvent(playerDisconnectedEvent);
+
+    void this.matchFinderService.advertiseMatch();
+  }
+
+  private handlePlayerDisconnectedById(playerId: string) {
+    const match = this.gameState.getMatch();
+
+    if (match === null) {
+      return console.warn("Game match is null");
+    }
+
+    const player = match.getPlayer(playerId);
+
+    if (player === null) {
+      return console.warn("Player not found", playerId);
+    }
+
+    console.log(`Player ${player.getName()} disconnected`);
+    match.removePlayer(player);
+
+    const localEvent = new LocalEvent<PlayerDisconnectedPayload>(
+      EventType.PlayerDisconnected,
+    );
+
+    localEvent.setData({ player });
+
+    this.eventProcessorService.addLocalEvent(localEvent);
+  }
+
+  private handleHostDisconnected(peer: WebRTCPeer): void {
+    console.log(`Host ${peer.getName()} disconnected`);
+
+    this.gameState.setMatch(null);
+
+    const localEvent = new LocalEvent(EventType.HostDisconnected);
+    this.eventProcessorService.addLocalEvent(localEvent);
+  }
+
+  private sendJoinRequest(peer: WebRTCPeer): void {
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.JoinRequest)
+      .toArrayBuffer();
+
+    peer.sendReliableOrderedMessage(payload, true);
+  }
+
+  private handleGameMatchNull(peer: WebRTCPeer): void {
+    console.warn("Game match is null, disconnecting peer...", peer.getToken());
+    peer.disconnect(true);
+  }
+
+  private handleUnavailableSlots(peer: WebRTCPeer): void {
+    console.log(
+      "Received join request but the match is full, disconnecting peer...",
+      peer.getToken(),
+    );
+
+    peer.disconnect(true);
+  }
+
+  private handleUnknownIdentity(peer: WebRTCPeer): void {
+    console.warn(
+      "Received join request but no identity was found, disconnecting peer...",
+      peer.getToken(),
+    );
+
+    peer.disconnect(true);
+  }
+
+  private handleRemotePlayerNull(peer: WebRTCPeer): void {
+    console.warn("Remote player is null for peer", peer.getToken());
+    peer.disconnect(true);
+  }
+
+  private sendJoinResponse(peer: WebRTCPeer, match: Match): void {
+    const state = match.getState();
+    const totalSlots = match.getTotalSlots();
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.JoinResponse)
+      .unsignedInt8(state)
+      .unsignedInt8(totalSlots)
+      .toArrayBuffer();
+
+    console.log("Sending join response to", peer.getName());
+    peer.sendReliableOrderedMessage(payload, true);
+
+    this.sendPlayerList(peer);
+    this.sendSnapshotEnd(peer);
+  }
+
+  private sendPlayerList(peer: WebRTCPeer): void {
+    const match = this.gameState.getMatch();
+
+    if (match === null) {
+      this.handleGameMatchNull(peer);
+      return;
+    }
+
+    console.log("Sending player list to", peer.getName());
+
+    const players = match.getPlayers();
+
+    players
+      .filter((matchPlayer) => matchPlayer !== peer.getPlayer())
+      .forEach((player) => {
+        this.sendPlayerConnection(peer, player, true, true);
+      });
+  }
+
+  private sendPlayerConnection(
+    peer: WebRTCPeer,
+    player: GamePlayer,
+    isConnected: boolean,
+    skipQueue: boolean,
+  ): void {
+    const isHost = player.isHost();
+    const playerId = player.getId();
+    const playerScore = player.getScore();
+    const playerName = player.getName();
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.PlayerConnection)
+      .boolean(isConnected)
+      .boolean(isHost)
+      .fixedLengthString(playerId, 32)
+      .fixedLengthString(playerName, 16)
+      .unsignedInt8(playerScore)
+      .toArrayBuffer();
+
+    peer.sendReliableOrderedMessage(payload, skipQueue);
+  }
+
+  private isHostIdentityUnverified(
+    peer: WebRTCPeer,
+    gamePlayer: GamePlayer,
+  ): boolean {
+    const identity = this.receivedIdentities.get(peer.getToken()) ?? null;
+
+    if (identity === null) {
+      console.warn("Host identity not found for token", peer.getToken());
+      return true;
+    }
+
+    if (identity.playerId !== gamePlayer.getId()) {
+      console.warn(
+        `Host player ID mismatch: expected ${identity.playerId}, got ${gamePlayer.getId()} for ${peer.getName()}`,
+      );
+
+      return true;
+    }
+
+    if (identity.playerName !== gamePlayer.getName()) {
+      console.warn(
+        `Host player name mismatch: expected ${identity.playerName}, got ${gamePlayer.getName()} for ${peer.getName()}`,
+      );
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private sendSnapshotEnd(peer: WebRTCPeer): void {
+    console.log("Sending snapshot end to", peer.getName());
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.SnapshotEnd)
+      .toArrayBuffer();
+
+    peer.sendReliableOrderedMessage(payload, true);
+  }
+
+  private sendSnapshotACK(peer: WebRTCPeer): void {
+    console.log("Sending snapshot ACK to", peer.getName());
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.SnapshotACK)
+      .toArrayBuffer();
+
+    peer.sendReliableOrderedMessage(payload, true);
+  }
+
+  private sendPingToJoinedPlayers(): void {
+    this.sendPingInformationToJoinedPlayers();
+
+    this.webrtcService
+      .getPeers()
+      .filter((peer) => peer.hasJoined())
+      .forEach((p) => {
+        p.sendPingRequest();
+      });
+  }
+
+  private sendPingInformationToJoinedPlayers(): void {
+    const players = this.gameState.getMatch()?.getPlayers() || [];
+
+    this.webrtcService
+      .getPeers()
+      .filter((peer) => peer.hasJoined())
+      .forEach((p) => {
+        if (p.getPlayer() === null) {
+          return console.warn("Peer has no player associated", p);
+        }
+
+        players.forEach((player) => {
+          if (player.isHost()) {
+            return;
+          }
+
+          this.sendPlayerPingToPlayer(player, p);
+        });
+      });
+  }
+
+  private sendPlayerPingToPlayer(player: GamePlayer, peer: WebRTCPeer): void {
+    const playerPing = player.getPingTime();
+
+    if (playerPing === null) {
+      return;
+    }
+
+    const playerId = player.getId();
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebRTCType.PlayerPing)
+      .fixedLengthString(playerId, 32)
+      .unsignedInt16(playerPing)
+      .toArrayBuffer();
+
+    peer.sendUnreliableUnorderedMessage(payload);
+  }
+}

--- a/src/services/service-registry.ts
+++ b/src/services/service-registry.ts
@@ -67,6 +67,6 @@ export class ServiceRegistry {
     const matchmakingService = ServiceLocator.get(MatchmakingService);
     ServiceLocator.get(ObjectOrchestratorService).initialize();
     ServiceLocator.get(EventProcessorService).initialize(webrtcService);
-    webrtcService.initialize(matchmakingService);
+    webrtcService.initialize(matchmakingService.getNetworkService());
   }
 }


### PR DESCRIPTION
## Summary
- create `MatchmakingNetworkService` to handle peer-related commands
- delegate WebRTC setup to the new service
- update service registry to use the network service

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*

------
https://chatgpt.com/codex/tasks/task_e_6866e8063bd48327b4d6b58bf05d118b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated service to manage matchmaking and peer connections for multiplayer games, handling player connections, synchronization, and network events.

* **Refactor**
  * Streamlined matchmaking logic by moving network communication and peer event handling into the new service, simplifying the main matchmaking code.

* **Chores**
  * Updated service initialization to use the new matchmaking network service for WebRTC setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->