### PR TITLE
Centralize screen transitions

### DIFF
--- a/src/screens/loading-screen.ts
+++ b/src/screens/loading-screen.ts
@@ -29,7 +29,12 @@ export class LoadingScreen extends BaseGameScreen {
     this.worldScreen = new WorldScreen(this.gameState);
     this.worldScreen.load();
 
-    this.screenTransitionService.fadeOutAndIn(this.worldScreen, 1, 1);
+    this.screenTransitionService.fadeOutAndIn(
+      this.screenManagerService!,
+      this.worldScreen,
+      1,
+      1
+    );
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {

--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -228,6 +228,6 @@ export class LoginScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(mainMenuScreen, 0.2);
+      .crossfade(this.screenManagerService, mainMenuScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -193,7 +193,7 @@ export class MainMenuScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(loadingScreen, 0.2);
+      .crossfade(this.screenManagerService, loadingScreen, 0.2);
   }
 
   private transitionToScoreboardScreen(): void {
@@ -204,7 +204,7 @@ export class MainMenuScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(scoreboardScreen, 0.2);
+      .crossfade(this.screenManagerService, scoreboardScreen, 0.2);
   }
 
   private transitionToSettingsScreen(): void {
@@ -215,7 +215,7 @@ export class MainMenuScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(settingsScreen, 0.2);
+      .crossfade(this.screenManagerService, settingsScreen, 0.2);
   }
 
   private enableMenuButtons(): void {

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -102,6 +102,6 @@ export class ScoreboardScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(previousScreen, 0.2);
+      .crossfade(this.screenManagerService, previousScreen, 0.2);
   }
 }

--- a/src/screens/main-screen/settings-screen.ts
+++ b/src/screens/main-screen/settings-screen.ts
@@ -83,7 +83,7 @@ export class SettingsScreen extends BaseGameScreen {
 
     this.screenManagerService
       ?.getTransitionService()
-      .crossfade(previousScreen, 0.2);
+      .crossfade(this.screenManagerService, previousScreen, 0.2);
   }
 
   private handleSettingObjectPress(settingObject: SettingObject): void {

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -402,6 +402,11 @@ export class WorldScreen extends BaseCollidingGameScreen {
     mainScreen.activateScreen(mainMenuScreen);
     mainScreen.load();
 
-    this.screenTransitionService.fadeOutAndIn(mainScreen, 1, 1);
+    this.screenTransitionService.fadeOutAndIn(
+      this.gameState.getGameFrame(),
+      mainScreen,
+      1,
+      1
+    );
   }
 }

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -168,7 +168,12 @@ export class GameLoopService {
     mainScreen.activateScreen(mainMenuScreen);
     mainScreen.load();
 
-    this.screenTransitionService.fadeOutAndIn(mainScreen, 1, 1);
+    this.screenTransitionService.fadeOutAndIn(
+      this.gameFrame,
+      mainScreen,
+      1,
+      1
+    );
   }
 
   private loadObjects(): void {
@@ -193,7 +198,7 @@ export class GameLoopService {
     mainScreen.activateScreen(loginScreen);
     mainScreen.load();
 
-    this.screenTransitionService.crossfade(mainScreen, 1);
+    this.screenTransitionService.crossfade(this.gameFrame, mainScreen, 1);
   }
 
   private loop(timeStamp: DOMHighResTimeStamp): void {

--- a/src/services/screen-manager-service.ts
+++ b/src/services/screen-manager-service.ts
@@ -1,6 +1,7 @@
 import type { GameScreen } from "../interfaces/screens/game-screen.js";
 import type { ScreenManager } from "../interfaces/screens/screen-manager.js";
 import { ScreenTransitionService } from "./screen-transition-service.js";
+import { ServiceLocator } from "./service-locator.js";
 
 export class ScreenManagerService implements ScreenManager {
   private stack: GameScreen[] = [];
@@ -10,7 +11,7 @@ export class ScreenManagerService implements ScreenManager {
   private transitionService: ScreenTransitionService;
 
   constructor() {
-    this.transitionService = new ScreenTransitionService(this);
+    this.transitionService = ServiceLocator.get(ScreenTransitionService);
   }
 
   public getTransitionService(): ScreenTransitionService {

--- a/src/services/service-registry.ts
+++ b/src/services/service-registry.ts
@@ -18,7 +18,7 @@ export class ServiceRegistry {
   public static register(canvas: HTMLCanvasElement, debugging: boolean): void {
     const gameState = new GameState(canvas, debugging);
     ServiceRegistry.registerGameStates(gameState);
-    ServiceRegistry.registerCoreServices(gameState);
+    ServiceRegistry.registerCoreServices();
     ServiceRegistry.registerCommunicationServices();
     ServiceRegistry.registerGameplayServices();
     ServiceRegistry.initializeServices();
@@ -28,14 +28,12 @@ export class ServiceRegistry {
     ServiceLocator.register(GameState, gameState);
   }
 
-  private static registerCoreServices(gameState: GameState): void {
-    const gameFrame = gameState.getGameFrame();
-
+  private static registerCoreServices(): void {
     ServiceLocator.register(DebugService, new DebugService());
     ServiceLocator.register(CryptoService, new CryptoService());
     ServiceLocator.register(
       ScreenTransitionService,
-      new ScreenTransitionService(gameFrame)
+      new ScreenTransitionService()
     );
     ServiceLocator.register(TimerManagerService, new TimerManagerService());
     ServiceLocator.register(


### PR DESCRIPTION
## Summary
- use a singleton `ScreenTransitionService`
- switch to passing the screen manager when calling `crossfade` or `fadeOutAndIn`
- update service registry and screen manager service to use the global transition service
- adjust all screens to pass their screen manager when requesting transitions

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*

------
https://chatgpt.com/codex/tasks/task_e_6866ec820f9c8327869af97f48c99ca2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way screen transitions are managed by updating transition methods to explicitly require a screen manager or game frame as a parameter.
  * Enhanced the lifecycle management of screen transitions, ensuring transitions only occur with a valid manager and clearing references after completion.
  * Updated service registration to streamline how core services are initialized.

* **Chores**
  * Adopted a service locator pattern for acquiring transition services, reducing direct dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->