### PR TITLE
Fix fadeOutAndIn call in loading screen

### DIFF
--- a/src/screens/loading-screen.ts
+++ b/src/screens/loading-screen.ts
@@ -30,7 +30,7 @@ export class LoadingScreen extends BaseGameScreen {
     this.worldScreen.load();
 
     this.screenTransitionService.fadeOutAndIn(
-      this.screenManagerService!,
+      this.gameState.getGameFrame(),
       this.worldScreen,
       1,
       1


### PR DESCRIPTION
## Summary
- update `LoadingScreen` to pass the game frame to `fadeOutAndIn`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866f07233e08327a03337c4240cf250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the transition behavior on the loading screen for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->