### PR TITLE
Add tsconfig aliases for services

### DIFF
--- a/src/debug/debug-object.ts
+++ b/src/debug/debug-object.ts
@@ -1,4 +1,4 @@
-import { TimerService } from "../services/gameplay/timer-service.js";
+import { TimerService } from "@gameplay/timer-service.js";
 import { BaseAnimatedGameObject } from "../objects/base/base-animated-object.js";
 
 export class DebugObject extends BaseAnimatedGameObject {

--- a/src/debug/windows/event-inspector-window.ts
+++ b/src/debug/windows/event-inspector-window.ts
@@ -4,8 +4,8 @@ import type { GameEvent } from "../../interfaces/events/game-event.js";
 import { LocalEvent } from "../../models/local-event.js";
 import { RemoteEvent } from "../../models/remote-event.js";
 import { BaseWindow } from "./base-window.js";
-import { EventProcessorService } from "../../services/gameplay/event-processor-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { EventProcessorService } from "@gameplay/event-processor-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class EventInspectorWindow extends BaseWindow {
   private selectedEvent: GameEvent | null = null;

--- a/src/debug/windows/peer-inspector-window.ts
+++ b/src/debug/windows/peer-inspector-window.ts
@@ -1,7 +1,7 @@
 import { ImGui, ImVec2 } from "@mori2003/jsimgui";
 import { BaseWindow } from "./base-window.js";
-import { WebRTCService } from "../../services/network/webrtc-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { WebRTCService } from "@network/webrtc-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class PeerInspectorWindow extends BaseWindow {
   private static readonly COLOR_CONNECTED_STATE = 0xff00ff00;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import "./main.css";
-import { GameLoopService } from "./services/gameplay/game-loop-service.js";
+import { GameLoopService } from "@gameplay/game-loop-service.js";
 
 const canvas = document.querySelector("#game") as HTMLCanvasElement;
 

--- a/src/objects/alert-object.ts
+++ b/src/objects/alert-object.ts
@@ -2,7 +2,7 @@ import {
   BLUE_TEAM_COLOR,
   RED_TEAM_COLOR,
 } from "../constants/colors-constants.js";
-import { TimerService } from "../services/gameplay/timer-service.js";
+import { TimerService } from "@gameplay/timer-service.js";
 import { BaseAnimatedGameObject } from "./base/base-animated-object.js";
 import type { MultiplayerGameObject } from "../interfaces/objects/multiplayer-game-object.js";
 

--- a/src/objects/base/base-animated-object.ts
+++ b/src/objects/base/base-animated-object.ts
@@ -1,5 +1,5 @@
 import { AnimationType } from "../../enums/animation-type.js";
-import { ObjectAnimationService } from "../../services/gameplay/object-animation-service.js";
+import { ObjectAnimationService } from "@gameplay/object-animation-service.js";
 import { BaseMoveableGameObject } from "./base-moveable-game-object.js";
 
 export class BaseAnimatedGameObject extends BaseMoveableGameObject {

--- a/src/objects/common/toast-object.ts
+++ b/src/objects/common/toast-object.ts
@@ -1,4 +1,4 @@
-import { TimerService } from "../../services/gameplay/timer-service.js";
+import { TimerService } from "@gameplay/timer-service.js";
 import { BaseAnimatedGameObject } from "../base/base-animated-object.js";
 
 export class ToastObject extends BaseAnimatedGameObject {

--- a/src/screens/base/base-game-screen.ts
+++ b/src/screens/base/base-game-screen.ts
@@ -4,11 +4,11 @@ import { BaseTappableGameObject } from "../../objects/base/base-tappable-game-ob
 import type { GameObject } from "../../interfaces/objects/game-object.js";
 import type { GameScreen } from "../../interfaces/screens/game-screen.js";
 import type { ScreenManager } from "../../interfaces/screens/screen-manager.js";
-import { ScreenManagerService } from "../../services/screen-manager-service.js";
-import { EventConsumerService } from "../../services/gameplay/event-consumer-service.js";
+import { ScreenManagerService } from "@services/screen-manager-service.js";
+import { EventConsumerService } from "@gameplay/event-consumer-service.js";
 import { EventType } from "../../enums/event-type.js";
 import type { GameState } from "../../models/game-state.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class BaseGameScreen implements GameScreen {
   protected eventConsumerService: EventConsumerService;

--- a/src/screens/loading/loading-screen.ts
+++ b/src/screens/loading/loading-screen.ts
@@ -1,8 +1,8 @@
 import type { GameState } from "../../models/game-state.js";
 import { LoadingBackgroundObject } from "../../objects/backgrounds/loading-background-object.js";
 import { ProgressBarObject } from "../../objects/common/progress-bar-object.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { ScreenTransitionService } from "@services/screen-transition-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { WorldScreen } from "../world/world-screen.js";
 

--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -1,14 +1,14 @@
 import { MessageObject } from "../../objects/common/message-object.js";
-import { CryptoService } from "../../services/crypto-service.js";
-import { WebSocketService } from "../../services/network/websocket-service.js";
-import { APIService } from "../../services/network/api-service.js";
+import { CryptoService } from "@services/crypto-service.js";
+import { WebSocketService } from "@network/websocket-service.js";
+import { APIService } from "@network/api-service.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { MainMenuScreen } from "./main-menu-screen.js";
 import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
 import { GameState } from "../../models/game-state.js";
 import { EventType } from "../../enums/event-type.js";
-import { CredentialService } from "../../services/credential-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { CredentialService } from "@services/credential-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class LoginScreen extends BaseGameScreen {
   private apiService: APIService;

--- a/src/screens/main-screen/main-menu-screen.ts
+++ b/src/screens/main-screen/main-menu-screen.ts
@@ -2,7 +2,7 @@ import { CloseableMessageObject } from "../../objects/common/closeable-message-o
 import { MenuOptionObject } from "../../objects/common/menu-option-object.js";
 import { TitleObject } from "../../objects/common/title-object.js";
 import { ServerMessageWindowObject } from "../../objects/server-message-window-object.js";
-import { APIService } from "../../services/network/api-service.js";
+import { APIService } from "@network/api-service.js";
 import type { MessagesResponse } from "../../interfaces/responses/messages-response.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 import { LoadingScreen } from "../loading/loading-screen.js";
@@ -10,7 +10,7 @@ import { ScoreboardScreen } from "./scoreboard-screen.js";
 import { SettingsScreen } from "./settings-screen.js";
 import { EventType } from "../../enums/event-type.js";
 import type { GameState } from "../../models/game-state.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class MainMenuScreen extends BaseGameScreen {
   private MENU_OPTIONS_TEXT: string[] = ["Join game", "Scoreboard", "Settings"];

--- a/src/screens/main-screen/main-screen.ts
+++ b/src/screens/main-screen/main-screen.ts
@@ -1,5 +1,5 @@
 import { BaseGameScreen } from "../base/base-game-screen.js";
-import { ScreenManagerService } from "../../services/screen-manager-service.js";
+import { ScreenManagerService } from "@services/screen-manager-service.js";
 import { MainBackgroundObject } from "../../objects/backgrounds/main-background-object.js";
 import type { GameScreen } from "../../interfaces/screens/game-screen.js";
 import type { GameState } from "../../models/game-state.js";

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -5,8 +5,8 @@ import { BaseGameScreen } from "../base/base-game-screen.js";
 import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
 import { RankingTableObject } from "../../objects/ranking-table-object.js";
 import type { GameState } from "../../models/game-state.js";
-import { APIService } from "../../services/network/api-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { APIService } from "@network/api-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
 
 export class ScoreboardScreen extends BaseGameScreen {
   private titleObject: TitleObject | null = null;

--- a/src/screens/main-screen/settings-screen.ts
+++ b/src/screens/main-screen/settings-screen.ts
@@ -3,7 +3,7 @@ import { ButtonObject } from "../../objects/common/button-object.js";
 import { TitleObject } from "../../objects/common/title-object.js";
 import { SettingObject } from "../../objects/setting-object.js";
 import { DebugService } from "../../debug/debug-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
+import { ServiceLocator } from "@services/service-locator.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
 
 export class SettingsScreen extends BaseGameScreen {

--- a/src/screens/world/world-screen.ts
+++ b/src/screens/world/world-screen.ts
@@ -20,14 +20,14 @@ import type { PlayerDisconnectedPayload } from "../../interfaces/events/player-d
 import { BinaryWriter } from "../../utils/binary-writer-utils.js";
 import { BinaryReader } from "../../utils/binary-reader-utils.js";
 import type { IMatchmakingProvider } from "../../interfaces/services/matchmaking-provider.js";
-import { MatchmakingService } from "../../services/gameplay/matchmaking-service.js";
-import { MatchmakingControllerService } from "../../services/gameplay/matchmaking-controller-service.js";
-import { ScoreManagerService } from "../../services/gameplay/score-manager-service.js";
-import { ServiceLocator } from "../../services/service-locator.js";
-import { EventProcessorService } from "../../services/gameplay/event-processor-service.js";
-import { ObjectOrchestratorService } from "../../services/gameplay/object-orchestrator-service.js";
-import { ScreenTransitionService } from "../../services/screen-transition-service.js";
-import { TimerManagerService } from "../../services/gameplay/timer-manager-service.js";
+import { MatchmakingService } from "@gameplay/matchmaking-service.js";
+import { MatchmakingControllerService } from "@gameplay/matchmaking-controller-service.js";
+import { ScoreManagerService } from "@gameplay/score-manager-service.js";
+import { ServiceLocator } from "@services/service-locator.js";
+import { EventProcessorService } from "@gameplay/event-processor-service.js";
+import { ObjectOrchestratorService } from "@gameplay/object-orchestrator-service.js";
+import { ScreenTransitionService } from "@services/screen-transition-service.js";
+import { TimerManagerService } from "@gameplay/timer-manager-service.js";
 import { MainScreen } from "../main-screen/main-screen.js";
 import { MainMenuScreen } from "../main-screen/main-menu-screen.js";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,12 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@gameplay/*": ["src/services/gameplay/*"],
+      "@network/*": ["src/services/network/*"],
+      "@services/*": ["src/services/*"]
+    },
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- add `@services` path alias to tsconfig
- reference services with alias imports

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867e572209c832790fd5cdc83176b70