### PR TITLE
Fix scoreboard and loading screen DI injection

### DIFF
--- a/src/screens/loading/loading-screen.ts
+++ b/src/screens/loading/loading-screen.ts
@@ -2,7 +2,7 @@ import type { GameState } from "../../models/game-state.js";
 import { LoadingBackgroundObject } from "../../objects/backgrounds/loading-background-object.js";
 import { ProgressBarObject } from "../../objects/common/progress-bar-object.js";
 import { ScreenTransitionService } from "../../services/screen-transition-service.js";
-import { injectable, inject } from "@needle-di/core";
+import { injectable } from "@needle-di/core";
 import { container } from "../../services/di-container.js";
 import { EventConsumerService } from "../../services/gameplay/event-consumer-service.js";
 import { BaseGameScreen } from "../base/base-game-screen.js";
@@ -18,7 +18,9 @@ export class LoadingScreen extends BaseGameScreen {
   constructor(
     gameState: GameState,
     eventConsumerService: EventConsumerService,
-    screenTransitionService = inject(ScreenTransitionService)
+    screenTransitionService: ScreenTransitionService = container.get(
+      ScreenTransitionService
+    )
   ) {
     super(gameState, eventConsumerService);
     this.screenTransitionService = screenTransitionService;

--- a/src/screens/main-screen/scoreboard-screen.ts
+++ b/src/screens/main-screen/scoreboard-screen.ts
@@ -6,7 +6,8 @@ import { CloseableMessageObject } from "../../objects/common/closeable-message-o
 import { RankingTableObject } from "../../objects/ranking-table-object.js";
 import type { GameState } from "../../models/game-state.js";
 import { APIService } from "../../services/network/api-service.js";
-import { injectable, inject } from "@needle-di/core";
+import { injectable } from "@needle-di/core";
+import { container } from "../../services/di-container.js";
 import { EventConsumerService } from "../../services/gameplay/event-consumer-service.js";
 
 @injectable()
@@ -21,7 +22,7 @@ export class ScoreboardScreen extends BaseGameScreen {
   constructor(
     gameState: GameState,
     eventConsumerService: EventConsumerService,
-    apiService = inject(APIService)
+    apiService: APIService = container.get(APIService)
   ) {
     super(gameState, eventConsumerService);
     this.apiService = apiService;


### PR DESCRIPTION
## Summary
- retrieve APIService and ScreenTransitionService using the DI container instead of `inject()`

## Testing
- `npm run build` *(fails: Cannot find module '@mori2003/jsimgui')*

------
https://chatgpt.com/codex/tasks/task_e_6867fcce6d088327bab2123833304b26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how certain services are initialized within screens to improve consistency in dependency handling. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->