### PR TITLE
Fix unused import causing TS6133

### DIFF
--- a/src/screens/main-screen/login-screen.ts
+++ b/src/screens/main-screen/login-screen.ts
@@ -8,7 +8,6 @@ import { CloseableMessageObject } from "../../objects/common/closeable-message-o
 import { GameState } from "../../models/game-state.js";
 import { EventType } from "../../enums/event-type.js";
 import { CredentialService } from "../../services/security/credential-service.js";
-import { EventProcessorService } from "../../services/gameplay/event-processor-service.js";
 import { container } from "../../services/di-container.js";
 import { EventConsumerService } from "../../services/gameplay/event-consumer-service.js";
 


### PR DESCRIPTION
## Summary
- remove unused `EventProcessorService` import from login screen

## Testing
- `npm run build` *(fails: Cannot find module '@needle-di/core' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68681872ccdc8327ae676adc15d1cd04