### PR TITLE
Refactor screens with factories and controllers

### DIFF
--- a/src/screens/loading/loading-controller.ts
+++ b/src/screens/loading/loading-controller.ts
@@ -1,0 +1,17 @@
+import type { GameState } from "../../models/game-state.js";
+import { EventConsumerService } from "../../services/gameplay/event-consumer-service.js";
+import { WorldScreen } from "../world/world-screen.js";
+import { container } from "../../services/di-container.js";
+
+export class LoadingController {
+  constructor(private readonly gameState: GameState) {}
+
+  public createWorldScreen(): WorldScreen {
+    const worldScreen = new WorldScreen(
+      this.gameState,
+      container.get(EventConsumerService)
+    );
+    worldScreen.load();
+    return worldScreen;
+  }
+}

--- a/src/screens/loading/loading-object-factory.ts
+++ b/src/screens/loading/loading-object-factory.ts
@@ -1,0 +1,18 @@
+import { LoadingBackgroundObject } from "../../objects/backgrounds/loading-background-object.js";
+import { ProgressBarObject } from "../../objects/common/progress-bar-object.js";
+
+export interface LoadingObjects {
+  background: LoadingBackgroundObject;
+  progressBar: ProgressBarObject;
+}
+
+export class LoadingObjectFactory {
+  constructor(private readonly canvas: HTMLCanvasElement) {}
+
+  public createObjects(): LoadingObjects {
+    const background = new LoadingBackgroundObject(this.canvas);
+    const progressBar = new ProgressBarObject(this.canvas);
+    progressBar.setText("Loading world screen....");
+    return { background, progressBar };
+  }
+}

--- a/src/screens/main-screen/login-controller.ts
+++ b/src/screens/main-screen/login-controller.ts
@@ -1,0 +1,25 @@
+import { APIService } from "../../services/network/api-service.js";
+import { CryptoService } from "../../services/security/crypto-service.js";
+import { WebSocketService } from "../../services/network/websocket-service.js";
+
+export class LoginController {
+  constructor(
+    private readonly apiService: APIService,
+    private readonly cryptoService: CryptoService,
+    private readonly webSocketService: WebSocketService
+  ) {}
+
+  public checkForUpdates(): Promise<boolean> {
+    return this.apiService.checkForUpdates();
+  }
+
+  public async downloadConfiguration(): Promise<any> {
+    const response = await this.apiService.getConfiguration();
+    const decrypted = await this.cryptoService.decryptResponse(response);
+    return JSON.parse(decrypted);
+  }
+
+  public connectToServer(): void {
+    this.webSocketService.connectToServer();
+  }
+}

--- a/src/screens/main-screen/login-object-factory.ts
+++ b/src/screens/main-screen/login-object-factory.ts
@@ -1,0 +1,17 @@
+import { MessageObject } from "../../objects/common/message-object.js";
+import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
+
+export interface LoginObjects {
+  message: MessageObject;
+  closeableMessage: CloseableMessageObject;
+}
+
+export class LoginObjectFactory {
+  constructor(private readonly canvas: HTMLCanvasElement) {}
+
+  public createObjects(): LoginObjects {
+    const message = new MessageObject(this.canvas);
+    const closeableMessage = new CloseableMessageObject(this.canvas);
+    return { message, closeableMessage };
+  }
+}

--- a/src/screens/main-screen/scoreboard-controller.ts
+++ b/src/screens/main-screen/scoreboard-controller.ts
@@ -1,0 +1,10 @@
+import type { RankingResponse } from "../../interfaces/responses/ranking-response.js";
+import { APIService } from "../../services/network/api-service.js";
+
+export class ScoreboardController {
+  constructor(private readonly apiService: APIService) {}
+
+  public async fetchRanking(): Promise<RankingResponse[]> {
+    return this.apiService.getRanking();
+  }
+}

--- a/src/screens/main-screen/scoreboard-object-factory.ts
+++ b/src/screens/main-screen/scoreboard-object-factory.ts
@@ -1,0 +1,33 @@
+import { TitleObject } from "../../objects/common/title-object.js";
+import { ButtonObject } from "../../objects/common/button-object.js";
+import { RankingTableObject } from "../../objects/ranking-table-object.js";
+import { CloseableMessageObject } from "../../objects/common/closeable-message-object.js";
+
+export interface ScoreboardObjects {
+  title: TitleObject;
+  button: ButtonObject;
+  rankingTable: RankingTableObject;
+  closeableMessage: CloseableMessageObject;
+}
+
+export class ScoreboardObjectFactory {
+  constructor(private readonly canvas: HTMLCanvasElement) {}
+
+  public createObjects(): ScoreboardObjects {
+    const titleObject = new TitleObject();
+    titleObject.setText("SCOREBOARD");
+
+    const buttonObject = new ButtonObject(this.canvas, "Back");
+    buttonObject.setPosition(this.canvas.width / 2, this.canvas.height - 60 - 20);
+
+    const rankingTableObject = new RankingTableObject();
+    const closeableMessageObject = new CloseableMessageObject(this.canvas);
+
+    return {
+      title: titleObject,
+      button: buttonObject,
+      rankingTable: rankingTableObject,
+      closeableMessage: closeableMessageObject,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- introduce object factories and controllers for login, loading and scoreboard screens
- use new factories and controllers inside screen implementations
- adjust imports for type-only usage

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68681e427ee8832783b844b627d22f9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced controllers for loading, login, and scoreboard screens to manage network and UI logic.
  * Added object factories for loading, login, and scoreboard screens to streamline UI component creation.

* **Refactor**
  * Centralized network and cryptographic operations in controllers, removing direct service handling from screens.
  * Consolidated multiple UI objects into single containers managed by factories for each screen.
  * Simplified screen classes by delegating UI and data management to controllers and factories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->