### PR TITLE
Fix TS errors in interfaces

### DIFF
--- a/src/interfaces/services/gameplay/object-orchestrator-service-interface.ts
+++ b/src/interfaces/services/gameplay/object-orchestrator-service-interface.ts
@@ -1,4 +1,4 @@
-import type { MultiplayerScreen } from "../../../screens/multiplayer-screen.js";
+import type { MultiplayerScreen } from "../../screens/multiplayer-screen.js";
 import type { WebRTCPeer } from "../../webrtc-peer.js";
 import type { BinaryReader } from "../../../utils/binary-reader-utils.js";
 

--- a/src/interfaces/services/network/webrtc-dispatcher-service-interface.ts
+++ b/src/interfaces/services/network/webrtc-dispatcher-service-interface.ts
@@ -1,7 +1,6 @@
 import type { WebRTCPeer } from "../../webrtc-peer.js";
 import type { WebRTCType } from "../../../enums/webrtc-type.js";
 import type { BinaryReader } from "../../../utils/binary-reader-utils.js";
-import type { PeerCommandHandlerFunction } from "../../../types/peer-command-handler-function-type.js";
 
 export interface IWebRTCDispatcherService {
   registerCommandHandlers(instance: any): void;

--- a/src/interfaces/services/ui/screen-transition-service-interface.ts
+++ b/src/interfaces/services/ui/screen-transition-service-interface.ts
@@ -1,9 +1,9 @@
-import type { GameFrame } from "../../../models/game-frame.js";
+import type { ScreenManager } from "../../screens/screen-manager.js";
 import type { GameScreen } from "../../screens/game-screen.js";
 
 export interface IScreenTransitionService {
   update(deltaTimeStamp: DOMHighResTimeStamp): void;
   isTransitionActive(): boolean;
-  fadeOutAndIn(frame: GameFrame, nextScreen: GameScreen, outSeconds: number, inSeconds: number): void;
-  crossfade(frame: GameFrame, nextScreen: GameScreen, seconds: number): void;
+  fadeOutAndIn(screenManager: ScreenManager, nextScreen: GameScreen, outSeconds: number, inSeconds: number): void;
+  crossfade(screenManager: ScreenManager, nextScreen: GameScreen, seconds: number): void;
 }

--- a/src/services/gameplay/event-consumer-service.ts
+++ b/src/services/gameplay/event-consumer-service.ts
@@ -1,5 +1,5 @@
 import { EventType } from "../../enums/event-type.js";
-import { EventQueueService } from "./event-queue-service.js";
+import type { IEventQueueService } from "../../interfaces/services/gameplay/event-queue-service-interface.js";
 import type { EventSubscription } from "../../types/event-subscription.js";
 import { LocalEvent } from "../../models/local-event.js";
 import { RemoteEvent } from "../../models/remote-event.js";
@@ -9,8 +9,8 @@ import { injectable } from "@needle-di/core";
 
 @injectable()
 export class EventConsumerService {
-  private localQueue: EventQueueService<LocalEvent>;
-  private remoteQueue: EventQueueService<RemoteEvent>;
+  private localQueue: IEventQueueService<LocalEvent>;
+  private remoteQueue: IEventQueueService<RemoteEvent>;
 
   private localSubscriptions: EventSubscription[] = [];
   private remoteSubscriptions: EventSubscription[] = [];


### PR DESCRIPTION
## Summary
- fix import path for `MultiplayerScreen` reference
- remove unused `PeerCommandHandlerFunction` import
- align `IScreenTransitionService` with `ScreenTransitionService`
- use `IEventQueueService` type in `EventConsumerService`

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@mori2003/jsimgui', '@needle-di/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868373528588327821fa7b2469bf7cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated method signatures in screen transition services to use a different manager type for smoother transitions.
  * Improved internal type usage for event handling and service interfaces to enhance maintainability.
* **Chores**
  * Cleaned up and optimized import statements across multiple service interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->