### PR TITLE
Add boost mechanic

### DIFF
--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -1,0 +1,38 @@
+import { BaseGameEntity } from "../../core/entities/base-game-entity.js";
+import { LIGHT_GREEN_COLOR } from "../constants/colors-constants.js";
+
+export class BoostMeterEntity extends BaseGameEntity {
+  private readonly WIDTH = 20;
+  private readonly HEIGHT = 100;
+  private boostLevel = 1; // 0..1
+  private x: number;
+  private y: number;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+    this.x = this.canvas.width - this.WIDTH - 20;
+    this.y = this.canvas.height - this.HEIGHT - 20;
+  }
+
+  public setBoostLevel(level: number): void {
+    this.boostLevel = Math.max(0, Math.min(1, level));
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.applyOpacity(context);
+
+    context.strokeStyle = "white";
+    context.strokeRect(this.x, this.y, this.WIDTH, this.HEIGHT);
+
+    context.fillStyle = LIGHT_GREEN_COLOR;
+    const filledHeight = this.HEIGHT * this.boostLevel;
+    context.fillRect(
+      this.x,
+      this.y + this.HEIGHT - filledHeight,
+      this.WIDTH,
+      filledHeight
+    );
+    context.restore();
+  }
+}

--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -1,0 +1,44 @@
+import { BaseStaticCollidingGameEntity } from "../../core/entities/base-static-colliding-game-entity.js";
+import { HitboxEntity } from "../../core/entities/hitbox-entity.js";
+import { LIGHT_GREEN_COLOR } from "../constants/colors-constants.js";
+
+export class BoostPadEntity extends BaseStaticCollidingGameEntity {
+  private readonly SIZE = 40;
+
+  constructor(private startX: number, private startY: number) {
+    super();
+    this.x = this.startX;
+    this.y = this.startY;
+    this.width = this.SIZE;
+    this.height = this.SIZE;
+    this.rigidBody = false;
+  }
+
+  public override load(): void {
+    this.createHitbox();
+    super.load();
+  }
+
+  private createHitbox(): void {
+    const hitbox = new HitboxEntity(
+      this.x - this.width / 2,
+      this.y - this.height / 2,
+      this.width,
+      this.height
+    );
+    this.setHitboxEntities([hitbox]);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    context.fillStyle = LIGHT_GREEN_COLOR;
+    context.fillRect(
+      this.x - this.width / 2,
+      this.y - this.height / 2,
+      this.width,
+      this.height
+    );
+    context.restore();
+    super.render(context);
+  }
+}

--- a/src/game/entities/common/button-entity.ts
+++ b/src/game/entities/common/button-entity.ts
@@ -10,6 +10,22 @@ export class ButtonEntity extends BaseTappableGameEntity {
     this.setSize(canvas);
   }
 
+  public getX(): number {
+    return this.x;
+  }
+
+  public getY(): number {
+    return this.y;
+  }
+
+  public getWidth(): number {
+    return this.width;
+  }
+
+  public getHeight(): number {
+    return this.height;
+  }
+
   public setPosition(x: number, y: number): void {
     this.x = x - this.width / 2;
     this.y = y - this.height / 2;

--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -6,10 +6,14 @@ import { GameKeyboard } from "../../core/models/game-keyboard.js";
 import { EntityUtils } from "../../core/utils/entity-utils.js";
 import { GameGamepad } from "../../core/models/game-gamepad.js";
 import { GamepadButton } from "../../core/enums/gamepad-button.js";
+import { ButtonEntity } from "./common/button-entity.js";
+import { BoostMeterEntity } from "./boost-meter-entity.js";
 
 export class LocalCarEntity extends CarEntity {
   private readonly joystickEntity: JoystickEntity;
   private active = true;
+  private boostButtonEntity: ButtonEntity | null = null;
+  private boostMeterEntity: BoostMeterEntity | null = null;
 
   constructor(
     x: number,
@@ -45,6 +49,22 @@ export class LocalCarEntity extends CarEntity {
     return this.joystickEntity;
   }
 
+  public setBoostButtonEntity(button: ButtonEntity): void {
+    this.boostButtonEntity = button;
+  }
+
+  public setBoostMeterEntity(meter: BoostMeterEntity): void {
+    this.boostMeterEntity = meter;
+  }
+
+  public getBoostButtonEntity(): ButtonEntity | null {
+    return this.boostButtonEntity;
+  }
+
+  public getBoostMeterEntity(): BoostMeterEntity | null {
+    return this.boostMeterEntity;
+  }
+
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
     if (this.active) {
       if (this.gameGamepad.get()) {
@@ -55,6 +75,9 @@ export class LocalCarEntity extends CarEntity {
         this.handleKeyboardControls(deltaTimeStamp);
       }
     }
+
+    this.handleBoostInput();
+    this.boostMeterEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
 
     if (this.canvas) {
       EntityUtils.fixEntityPositionIfOutOfBounds(this, this.canvas);
@@ -179,5 +202,38 @@ export class LocalCarEntity extends CarEntity {
       Math.sign(angleDifference) *
         Math.min(Math.abs(angleDifference), this.HANDLING * deltaTimeStamp)
     );
+  }
+
+  private handleBoostInput(): void {
+    let activating = false;
+
+    const pressedKeys = this.gameKeyboard.getPressedKeys();
+    if (pressedKeys.has("Shift")) {
+      activating = true;
+    }
+
+    if (this.boostButtonEntity) {
+      const x = this.gamePointer.getX();
+      const y = this.gamePointer.getY();
+      if (
+        this.gamePointer.isPressing() &&
+        x >= this.boostButtonEntity.getX() &&
+        x <= this.boostButtonEntity.getX() + this.boostButtonEntity.getWidth() &&
+        y >= this.boostButtonEntity.getY() &&
+        y <= this.boostButtonEntity.getY() + this.boostButtonEntity.getHeight()
+      ) {
+        activating = true;
+      }
+    }
+
+    if (this.gameGamepad.isButtonPressed(GamepadButton.R1)) {
+      activating = true;
+    }
+
+    if (activating) {
+      this.activateBoost();
+    } else {
+      this.deactivateBoost();
+    }
   }
 }

--- a/src/game/scenes/world/world-entity-factory.ts
+++ b/src/game/scenes/world/world-entity-factory.ts
@@ -5,6 +5,9 @@ import { BallEntity } from "../../entities/ball-entity.js";
 import { ScoreboardEntity } from "../../entities/scoreboard-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { ToastEntity } from "../../entities/common/toast-entity.js";
+import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
+import { BoostMeterEntity } from "../../entities/boost-meter-entity.js";
+import { ButtonEntity } from "../../entities/common/button-entity.js";
 import { getConfigurationKey } from "../../utils/configuration-utils.js";
 import { SCOREBOARD_SECONDS_DURATION } from "../../constants/configuration-constants.js";
 import type { GameState } from "../../../core/models/game-state.js";
@@ -71,14 +74,38 @@ export class WorldEntityFactory {
     const alertEntity = new AlertEntity(this.canvas);
     const toastEntity = new ToastEntity(this.canvas);
 
+    // Boost related entities
+    const boostMeterEntity = new BoostMeterEntity(this.canvas);
+    const boostButtonEntity = new ButtonEntity(this.canvas, "Boost");
+    boostButtonEntity.setPosition(
+      this.canvas.width - 80,
+      this.canvas.height - 80
+    );
+    localCarEntity.setBoostButtonEntity(boostButtonEntity);
+    localCarEntity.setBoostMeterEntity(boostMeterEntity);
+
+    const padOffset = 60;
+    const boostPads = [
+      new BoostPadEntity(padOffset, padOffset),
+      new BoostPadEntity(this.canvas.width - padOffset, padOffset),
+      new BoostPadEntity(padOffset, this.canvas.height - padOffset),
+      new BoostPadEntity(this.canvas.width - padOffset, this.canvas.height - padOffset),
+    ];
+
     worldEntities.push(
       scoreboardEntity,
       ballEntity,
       goalEntity,
       localCarEntity,
-      toastEntity
+      toastEntity,
+      ...boostPads
     );
-    uiEntities.push(alertEntity, localCarEntity.getJoystickEntity());
+    uiEntities.push(
+      alertEntity,
+      localCarEntity.getJoystickEntity(),
+      boostButtonEntity,
+      boostMeterEntity
+    );
 
     return {
       scoreboardEntity,


### PR DESCRIPTION
## Summary
- add BoostPadEntity for refilling turbo
- add BoostMeterEntity UI
- expose size getters for ButtonEntity
- add boost features in CarEntity and LocalCarEntity
- create boost pads, button and meter in WorldEntityFactory

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6869556706e48327b3d51804fe180507