### PR TITLE
Enable multi-touch controls

### DIFF
--- a/src/core/entities/base-tappable-game-entity.ts
+++ b/src/core/entities/base-tappable-game-entity.ts
@@ -37,17 +37,25 @@ export class BaseTappableGameEntity extends BaseAnimatedGameEntity {
   }
 
   public handlePointerEvent(gamePointer: GamePointer): void {
-    if (this.stealFocus || this.isPointerWithinBounds(gamePointer)) {
-      const pressing = gamePointer.isPressing();
-      const mouse = gamePointer.getType() === "mouse";
+    const touches = gamePointer.getTouchPoints();
 
-      if (pressing || mouse) {
-        this.hovering = true;
-      }
+    for (const touch of touches) {
+      if (this.stealFocus || this.isPointerWithinBounds(touch.x, touch.y)) {
+        const pressing = touch.pressing;
+        const mouse = touch.type === "mouse";
 
-      if (gamePointer.isPressed()) {
-        console.log(this.constructor.name + " pressed");
-        this.pressed = true;
+        if (pressing || mouse) {
+          this.hovering = true;
+        }
+
+        if (touch.pressed) {
+          console.log(this.constructor.name + " pressed");
+          this.pressed = true;
+        }
+
+        if (this.hovering || this.pressed) {
+          break;
+        }
       }
     }
   }
@@ -76,15 +84,12 @@ export class BaseTappableGameEntity extends BaseAnimatedGameEntity {
     }
   }
 
-  private isPointerWithinBounds(gamePointer: GamePointer): boolean {
-    const pointerX = gamePointer.getX();
-    const pointerY = gamePointer.getY();
-
+  private isPointerWithinBounds(x: number, y: number): boolean {
     return (
-      pointerX >= this.x &&
-      pointerX <= this.x + this.width &&
-      pointerY >= this.y &&
-      pointerY <= this.y + this.height
+      x >= this.x &&
+      x <= this.x + this.width &&
+      y >= this.y &&
+      y <= this.y + this.height
     );
   }
 

--- a/src/core/interfaces/input/game-pointer-touch-point.ts
+++ b/src/core/interfaces/input/game-pointer-touch-point.ts
@@ -1,4 +1,12 @@
+import type { PointerType } from "./game-pointer.js";
+
 export interface GamePointerTouchPoint {
+  pointerId: number;
   x: number;
   y: number;
+  initialX: number;
+  initialY: number;
+  pressing: boolean;
+  pressed: boolean;
+  type: PointerType;
 }

--- a/src/core/interfaces/input/game-pointer.ts
+++ b/src/core/interfaces/input/game-pointer.ts
@@ -1,22 +1,32 @@
 export type PointerType = "mouse" | "touch" | "pen";
 
+import type { GamePointerTouchPoint } from "./game-pointer-touch-point.js";
+
 export interface IGamePointer {
+  /** Primary pointer X coordinate */
   getX(): number;
+  /** Primary pointer Y coordinate */
   getY(): number;
+  /** Primary pointer initial X coordinate */
   getInitialX(): number;
+  /** Primary pointer initial Y coordinate */
   getInitialY(): number;
-  setX(x: number): void;
-  setY(y: number): void;
-  setInitialX(x: number): void;
-  setInitialY(y: number): void;
+  /** Allow disabling default behaviour of pointer events */
   setPreventDefault(preventDefault: boolean): void;
+  /** Whether the primary pointer is currently pressed */
   isPressing(): boolean;
-  setPressing(pressing: boolean): void;
+  /** Whether the primary pointer was released on the last frame */
   isPressed(): boolean;
-  setPressed(pressed: boolean): void;
+  /** Type of the primary pointer */
   getType(): PointerType;
-  setType(type: PointerType): void;
+  /** Returns true if the primary pointer is a touch */
   isTouch(): boolean;
+  /** Reset all pointer states */
   reset(): void;
+  /** Clear pressed state for all touches */
+  clearPressed(): void;
+  /** Get all active pointer touch points */
+  getTouchPoints(): GamePointerTouchPoint[];
+  /** Render debug pointer visuals */
   renderDebugInformation(context: CanvasRenderingContext2D): void;
 }

--- a/src/core/scenes/base-game-scene.ts
+++ b/src/core/scenes/base-game-scene.ts
@@ -197,7 +197,7 @@ export class BaseGameScene implements GameScene {
       }
     }
 
-    this.gamePointer.setPressed(false);
+    this.gamePointer.clearPressed();
   }
 
   private updateEntities(

--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -208,11 +208,11 @@ export class LocalCarEntity extends CarEntity {
     }
 
     if (this.boostButtonEntity) {
-      const x = this.gamePointer.getX();
-      const y = this.gamePointer.getY();
+      const touches = this.gamePointer.getTouchPoints();
       if (
-        this.gamePointer.isPressing() &&
-        this.boostButtonEntity.containsPoint(x, y)
+        touches.some(
+          (t) => t.pressing && this.boostButtonEntity!.containsPoint(t.x, t.y)
+        )
       ) {
         activating = true;
       }


### PR DESCRIPTION
## Summary
- extend `GamePointer` to track multiple touch points
- expose multi-touch info via new interface methods
- update button tap detection for multi-touch
- clear pressed state per frame
- support multi-touch in tappable entities

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6869744bef5c8327845988351229cd55