### PR TITLE
Move camera service to scene

### DIFF
--- a/src/core/scenes/base-game-scene.ts
+++ b/src/core/scenes/base-game-scene.ts
@@ -6,6 +6,8 @@ import type { GameScene } from "../interfaces/scenes/game-scene.js";
 import type { SceneManager } from "../interfaces/scenes/scene-manager.js";
 import { SceneManagerService } from "../services/gameplay/scene-manager-service.js";
 import { EventConsumerService } from "../services/gameplay/event-consumer-service.js";
+import { CameraService } from "../services/gameplay/camera-service.js";
+import { container } from "../services/di-container.js";
 import { EventType } from "../../game/enums/event-type.js";
 import type { GameState } from "../models/game-state.js";
 
@@ -21,6 +23,8 @@ export class BaseGameScene implements GameScene {
   protected worldEntities: GameEntity[] = [];
   protected uiEntities: GameEntity[] = [];
 
+  protected readonly cameraService: CameraService;
+
   private gamePointer: GamePointer;
 
   constructor(
@@ -31,6 +35,7 @@ export class BaseGameScene implements GameScene {
     this.canvas = gameState.getCanvas();
     this.gamePointer = gameState.getGamePointer();
     this.eventConsumerService = eventConsumerService;
+    this.cameraService = container.get(CameraService);
   }
 
   public isActive(): boolean {
@@ -118,6 +123,7 @@ export class BaseGameScene implements GameScene {
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    this.cameraService.update(deltaTimeStamp);
     this.updateEntities(this.worldEntities, deltaTimeStamp);
     this.updateEntities(this.uiEntities, deltaTimeStamp);
 
@@ -133,12 +139,16 @@ export class BaseGameScene implements GameScene {
   }
 
   public render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.cameraService.applyTransform(context);
+
     context.globalAlpha = this.opacity;
 
     this.renderEntities(this.worldEntities, context);
     this.renderEntities(this.uiEntities, context);
 
     context.globalAlpha = 1;
+    context.restore();
   }
 
   protected updateDebugStateForEntities(): void {

--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -25,7 +25,6 @@ import { IntervalManagerService } from "./interval-manager-service.js";
 import { ServiceRegistry } from "../service-registry.js";
 import { LoadingIndicatorEntity } from "../../entities/loading-indicator-entity.js";
 import { container } from "../di-container.js";
-import { CameraService } from "./camera-service.js";
 
 export class GameLoopService {
   private context: CanvasRenderingContext2D;
@@ -50,7 +49,6 @@ export class GameLoopService {
   private eventConsumerService: EventConsumerService;
   private matchmakingService: MatchmakingService;
   private webrtcService: WebRTCService;
-  private cameraService: CameraService;
   private loadingIndicatorEntity: LoadingIndicatorEntity | null = null;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
@@ -66,7 +64,6 @@ export class GameLoopService {
     this.eventConsumerService = container.get(EventConsumerService);
     this.matchmakingService = container.get(MatchmakingService);
     this.webrtcService = container.get(WebRTCService);
-    this.cameraService = container.get(CameraService);
     this.addWindowAndGameListeners();
     this.setCanvasSize();
     this.loadEntities();
@@ -253,7 +250,6 @@ export class GameLoopService {
 
     this.timerManagerService.update(deltaTimeStamp);
     this.intervalManagerService.update(deltaTimeStamp);
-    this.cameraService.update(deltaTimeStamp);
     this.sceneTransitionService.update(deltaTimeStamp);
 
     this.gameFrame.getCurrentScene()?.update(deltaTimeStamp);
@@ -269,13 +265,8 @@ export class GameLoopService {
   private render(): void {
     this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
-    this.context.save();
-    this.cameraService.applyTransform(this.context);
-
     this.gameFrame.getCurrentScene()?.render(this.context);
     this.gameFrame.getNextScene()?.render(this.context);
-
-    this.context.restore();
 
     this.gameFrame.getNotificationEntity()?.render(this.context);
     this.gameFrame.getLoadingIndicatorEntity()?.render(this.context);

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -30,7 +30,6 @@ import { RemoteCarEntity } from "../../entities/remote-car-entity.js";
 import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
 import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
 import { TeamType } from "../../enums/team-type.js";
-import { CameraService } from "../../../core/services/gameplay/camera-service.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
 
 export class WorldScene extends BaseCollidingGameScene {
@@ -40,7 +39,6 @@ export class WorldScene extends BaseCollidingGameScene {
   private readonly matchmakingController: MatchmakingControllerService;
   private readonly eventProcessorService: EventProcessorService;
   private readonly entityOrchestrator: EntityOrchestratorService;
-  private readonly cameraService: CameraService;
 
   private scoreboardEntity: ScoreboardEntity | null = null;
   private localCarEntity: LocalCarEntity | null = null;
@@ -64,7 +62,6 @@ export class WorldScene extends BaseCollidingGameScene {
     this.matchmakingController = container.get(MatchmakingControllerService);
     this.entityOrchestrator = container.get(EntityOrchestratorService);
     this.eventProcessorService = container.get(EventProcessorService);
-    this.cameraService = container.get(CameraService);
     this.addSyncableEntities();
     this.subscribeToEvents();
   }


### PR DESCRIPTION
## Summary
- manage camera effects at scene level
- update scene base class with camera service
- remove camera logic from game loop
- rely on base class for camera in world scene

## Testing
- `npx tsc` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869881158508327ad58e368567d972f