### PR TITLE
Fix goal explosion fade and extend camera shake

### DIFF
--- a/src/game/entities/goal-explosion-entity.ts
+++ b/src/game/entities/goal-explosion-entity.ts
@@ -61,7 +61,7 @@ export class GoalExplosionEntity extends BaseMoveableGameEntity {
     });
     this.particles = this.particles.filter((p) => p.life > 0);
 
-    if (this.elapsed >= this.duration) {
+    if (this.elapsed >= this.duration && this.particles.length === 0) {
       this.setRemoved(true);
     }
   }
@@ -81,7 +81,7 @@ export class GoalExplosionEntity extends BaseMoveableGameEntity {
 
     // Shockwave
     context.strokeStyle = this.color;
-    context.lineWidth = 4 * (1 - this.elapsed / this.duration);
+    context.lineWidth = 4 * (1 - Math.min(this.elapsed / this.duration, 1));
     context.beginPath();
     context.arc(this.x, this.y, this.shockwaveRadius, 0, Math.PI * 2);
     context.stroke();

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -278,7 +278,7 @@ export class WorldScene extends BaseCollidingGameScene {
     const explosion = new GoalExplosionEntity(this.canvas, x, y, team);
     this.addEntityToSceneLayer(explosion);
     // Make the shake last a bit longer for added impact
-    this.cameraService.shake(0.5, 8);
+    this.cameraService.shake(3, 8);
   }
 
   private async returnToMainMenuScene(): Promise<void> {


### PR DESCRIPTION
## Summary
- fix the shockwave so it's removed after debris fades
- let the camera shake last 3 seconds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68698bee0ee48327bef7f76994763d54