### PR TITLE
Fix boost pad opacity on scene transitions

### DIFF
--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -88,6 +88,7 @@ export class BoostPadEntity extends BaseStaticCollidingGameEntity {
 
   public override render(context: CanvasRenderingContext2D): void {
     context.save();
+    this.applyOpacity(context);
 
     if (this.active) {
       const pulse = (Math.sin(this.glowTimer / 200) + 1) / 2;


### PR DESCRIPTION
## Summary
- apply entity opacity to boost pads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68698cd245a883279ba19dda0639f7b8