### PR TITLE
Add win/loss effects

### DIFF
--- a/src/game/entities/confetti-entity.ts
+++ b/src/game/entities/confetti-entity.ts
@@ -1,0 +1,69 @@
+import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
+
+interface ConfettiParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  rotation: number;
+  size: number;
+  color: string;
+  life: number;
+}
+
+export class ConfettiEntity extends BaseMoveableGameEntity {
+  private particles: ConfettiParticle[] = [];
+  private elapsed = 0;
+  private readonly duration = 3000; // ms
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+    this.createParticles();
+  }
+
+  private createParticles(): void {
+    const count = 80;
+    for (let i = 0; i < count; i++) {
+      this.particles.push({
+        x: Math.random() * this.canvas.width,
+        y: Math.random() * -50,
+        vx: (Math.random() - 0.5) * 3,
+        vy: Math.random() * -2,
+        rotation: Math.random() * Math.PI * 2,
+        size: 4 + Math.random() * 4,
+        color: `hsl(${Math.random() * 360},100%,50%)`,
+        life: 1,
+      });
+    }
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    this.elapsed += delta;
+    this.particles.forEach((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.05; // gravity
+      p.rotation += 0.1;
+      p.life -= delta / this.duration;
+    });
+    this.particles = this.particles.filter((p) => p.life > 0);
+
+    if (this.elapsed >= this.duration && this.particles.length === 0) {
+      this.setRemoved(true);
+    }
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.particles.forEach((p) => {
+      context.fillStyle = p.color;
+      context.save();
+      context.translate(p.x, p.y);
+      context.rotate(p.rotation);
+      context.globalAlpha = Math.max(p.life, 0);
+      context.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
+      context.restore();
+    });
+    context.restore();
+  }
+}

--- a/src/game/entities/thumbs-down-cloud-entity.ts
+++ b/src/game/entities/thumbs-down-cloud-entity.ts
@@ -1,0 +1,68 @@
+import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
+
+interface EmojiParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  angle: number;
+  size: number;
+  life: number;
+}
+
+export class ThumbsDownCloudEntity extends BaseMoveableGameEntity {
+  private particles: EmojiParticle[] = [];
+  private elapsed = 0;
+  private readonly duration = 3000; // ms
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+    this.createParticles();
+  }
+
+  private createParticles(): void {
+    const count = 30;
+    for (let i = 0; i < count; i++) {
+      this.particles.push({
+        x: Math.random() * this.canvas.width,
+        y: Math.random() * this.canvas.height,
+        vx: (Math.random() - 0.5) * 1.5,
+        vy: (Math.random() - 0.5) * 1.5,
+        angle: Math.random() * Math.PI * 2,
+        size: 24 + Math.random() * 12,
+        life: 1,
+      });
+    }
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    this.elapsed += delta;
+    this.particles.forEach((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.angle += 0.05;
+      p.life -= delta / this.duration;
+    });
+    this.particles = this.particles.filter((p) => p.life > 0);
+
+    if (this.elapsed >= this.duration && this.particles.length === 0) {
+      this.setRemoved(true);
+    }
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    this.particles.forEach((p) => {
+      context.save();
+      context.translate(p.x, p.y);
+      context.rotate(p.angle);
+      context.globalAlpha = Math.max(p.life, 0);
+      context.font = `${p.size}px system-ui`;
+      context.fillText("\uD83D\uDC4E", 0, 0); // thumbs down emoji
+      context.restore();
+    });
+    context.restore();
+  }
+}

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -31,6 +31,8 @@ import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
 import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
 import { TeamType } from "../../enums/team-type.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
+import { ConfettiEntity } from "../../entities/confetti-entity.js";
+import { ThumbsDownCloudEntity } from "../../entities/thumbs-down-cloud-entity.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
@@ -109,7 +111,8 @@ export class WorldScene extends BaseCollidingGameScene {
         void this.returnToMainMenuScene();
       },
       (x: number, y: number, team: TeamType) =>
-        this.triggerGoalExplosion(x, y, team)
+        this.triggerGoalExplosion(x, y, team),
+      (won: boolean) => this.handleGameOverEffect(won)
     );
     super.load();
   }
@@ -279,6 +282,16 @@ export class WorldScene extends BaseCollidingGameScene {
     this.addEntityToSceneLayer(explosion);
     // Make the shake last a bit longer for added impact
     this.cameraService.shake(3, 8);
+  }
+
+  private handleGameOverEffect(won: boolean): void {
+    if (won) {
+      const confetti = new ConfettiEntity(this.canvas);
+      this.addEntityToSceneLayer(confetti);
+    } else {
+      const cloud = new ThumbsDownCloudEntity(this.canvas);
+      this.addEntityToSceneLayer(cloud);
+    }
   }
 
   private async returnToMainMenuScene(): Promise<void> {

--- a/src/game/services/gameplay/score-manager-service.ts
+++ b/src/game/services/gameplay/score-manager-service.ts
@@ -35,7 +35,8 @@ export class ScoreManagerService {
       x: number,
       y: number,
       team: TeamType
-    ) => void
+    ) => void,
+    private readonly gameOverEffectCallback: (won: boolean) => void
   ) {}
 
   public updateScoreboard(): void {
@@ -247,6 +248,7 @@ export class ScoreManagerService {
       winner === this.gameState.getGamePlayer() ? "blue" : "red";
 
     this.alertEntity.show([playerName, "WINS!"], playerTeam);
+    this.gameOverEffectCallback(winner === this.gameState.getGamePlayer());
     this.timerManagerService.createTimer(5, this.gameOverEndCallback);
 
     if (this.gameState.getMatch()?.isHost()) {


### PR DESCRIPTION
## Summary
- celebrate with confetti when the local player wins
- show thumbs down emojis when the local player loses
- inject new game-over effect callback into `ScoreManagerService`
- trigger the effect from `WorldScene`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68699bb4dbf08327847afb32cd6b6967