### PR TITLE
Update boost visuals

### DIFF
--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -1,11 +1,11 @@
-import { BaseTappableGameEntity } from "../../core/entities/base-tappable-game-entity.js";
+import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
 import { LIGHT_GREEN_COLOR } from "../constants/colors-constants.js";
 
-export class BoostButtonEntity extends BaseTappableGameEntity {
+export class BoostMeterEntity extends BaseAnimatedGameEntity {
   private readonly RADIUS = 32;
   private boostLevel = 1; // target level 0..1
   private displayLevel = 1; // rendered level 0..1
-  private readonly FILL_RATE = 0.003; // units/ms
+  private readonly FILL_RATE = 0.05; // units/ms, super fast
 
   constructor(canvas: HTMLCanvasElement) {
     super();
@@ -53,14 +53,6 @@ export class BoostButtonEntity extends BaseTappableGameEntity {
     this.y = y - this.height / 2;
   }
 
-  public containsPoint(x: number, y: number): boolean {
-    return (
-      x >= this.x &&
-      x <= this.x + this.width &&
-      y >= this.y &&
-      y <= this.y + this.height
-    );
-  }
 
   public override render(context: CanvasRenderingContext2D): void {
     context.save();
@@ -102,13 +94,6 @@ export class BoostButtonEntity extends BaseTappableGameEntity {
       context.restore();
     }
 
-    if (this.pressed) {
-      context.beginPath();
-      context.arc(cx, cy, this.RADIUS, 0, Math.PI * 2);
-      context.closePath();
-      context.fillStyle = "rgba(100,100,100,0.4)";
-      context.fill();
-    }
 
     context.font = `${this.RADIUS * 1.0}px system-ui`;
     context.textAlign = "center";

--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -124,7 +124,7 @@ export class BoostPadEntity extends BaseStaticCollidingGameEntity {
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.fillStyle = '#000';
-    context.fillText('🧪', this.x, this.y + 1);
+    context.fillText('🔋', this.x, this.y + 1);
     context.restore();
     super.render(context);
   }

--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -6,12 +6,12 @@ import { GameKeyboard } from "../../core/models/game-keyboard.js";
 import { EntityUtils } from "../../core/utils/entity-utils.js";
 import { GameGamepad } from "../../core/models/game-gamepad.js";
 import { GamepadButton } from "../../core/enums/gamepad-button.js";
-import { BoostButtonEntity } from "./boost-button-entity.js";
+import { BoostMeterEntity } from "./boost-meter-entity.js";
 
 export class LocalCarEntity extends CarEntity {
   private readonly joystickEntity: JoystickEntity;
   private active = true;
-  private boostButtonEntity: BoostButtonEntity | null = null;
+  private boostMeterEntity: BoostMeterEntity | null = null;
 
   constructor(
     x: number,
@@ -47,12 +47,12 @@ export class LocalCarEntity extends CarEntity {
     return this.joystickEntity;
   }
 
-  public setBoostButtonEntity(button: BoostButtonEntity): void {
-    this.boostButtonEntity = button;
+  public setBoostMeterEntity(meter: BoostMeterEntity): void {
+    this.boostMeterEntity = meter;
   }
 
-  public getBoostButtonEntity(): BoostButtonEntity | null {
-    return this.boostButtonEntity;
+  public getBoostMeterEntity(): BoostMeterEntity | null {
+    return this.boostMeterEntity;
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
@@ -71,7 +71,7 @@ export class LocalCarEntity extends CarEntity {
     } else {
       this.deactivateBoost();
     }
-    this.boostButtonEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
+    this.boostMeterEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
 
     if (this.canvas) {
       EntityUtils.fixEntityPositionIfOutOfBounds(this, this.canvas);
@@ -207,16 +207,9 @@ export class LocalCarEntity extends CarEntity {
       activating = true;
     }
 
-    if (this.boostButtonEntity) {
+    if (this.boostMeterEntity) {
       const touches = this.gamePointer.getTouchPoints();
-      if (
-        touches.some(
-          (t) => t.pressing && this.boostButtonEntity!.containsPoint(t.x, t.y)
-        )
-      ) {
-        activating = true;
-      }
-      if (!activating && touches.filter((t) => t.pressing).length >= 2) {
+      if (touches.filter((t) => t.pressing).length >= 2) {
         activating = true;
       }
     }

--- a/src/game/scenes/world/world-entity-factory.ts
+++ b/src/game/scenes/world/world-entity-factory.ts
@@ -6,7 +6,7 @@ import { ScoreboardEntity } from "../../entities/scoreboard-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { ToastEntity } from "../../entities/common/toast-entity.js";
 import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
-import { BoostButtonEntity } from "../../entities/boost-button-entity.js";
+import { BoostMeterEntity } from "../../entities/boost-meter-entity.js";
 import { getConfigurationKey } from "../../utils/configuration-utils.js";
 import { SCOREBOARD_SECONDS_DURATION } from "../../constants/configuration-constants.js";
 import type { GameState } from "../../../core/models/game-state.js";
@@ -75,8 +75,8 @@ export class WorldEntityFactory {
     const toastEntity = new ToastEntity(this.canvas);
 
     // Boost related entities
-    const boostButtonEntity = new BoostButtonEntity(this.canvas);
-    localCarEntity.setBoostButtonEntity(boostButtonEntity);
+    const boostMeterEntity = new BoostMeterEntity(this.canvas);
+    localCarEntity.setBoostMeterEntity(boostMeterEntity);
 
     const padOffset = 60;
     const boostPads = [
@@ -101,7 +101,7 @@ export class WorldEntityFactory {
     uiEntities.push(
       alertEntity,
       localCarEntity.getJoystickEntity(),
-      boostButtonEntity
+      boostMeterEntity
     );
 
     return {


### PR DESCRIPTION
## Summary
- change boost pad emoji to a battery
- refactor BoostButtonEntity into BoostMeterEntity
- boost meter now only displays boost level and activation uses a two-finger touch anywhere

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68699a2ef5f083279f31373c37b6f924