### PR TITLE
Adjust effects and timer styling

### DIFF
--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -120,11 +120,6 @@ export class BoostPadEntity extends BaseStaticCollidingGameEntity {
       context.closePath();
     }
 
-    context.font = `${this.RADIUS * 0.9}px system-ui`;
-    context.textAlign = 'center';
-    context.textBaseline = 'middle';
-    context.fillStyle = '#000';
-    context.fillText('🔋', this.x, this.y + 1);
     context.restore();
     super.render(context);
   }

--- a/src/game/entities/confetti-entity.ts
+++ b/src/game/entities/confetti-entity.ts
@@ -14,7 +14,7 @@ interface ConfettiParticle {
 export class ConfettiEntity extends BaseMoveableGameEntity {
   private particles: ConfettiParticle[] = [];
   private elapsed = 0;
-  private readonly duration = 3000; // ms
+  private readonly duration = 4000; // ms, extended for clearer celebration
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();

--- a/src/game/entities/scoreboard-entity.ts
+++ b/src/game/entities/scoreboard-entity.ts
@@ -26,6 +26,8 @@ export class ScoreboardEntity
   private readonly BLUE_SHAPE_COLOR: string = BLUE_TEAM_COLOR;
   private readonly RED_SHAPE_COLOR: string = RED_TEAM_COLOR;
   private readonly TIME_BOX_FILL_COLOR: string = "#4caf50"; // Added property for time box fill color
+  private readonly FLASH_COLOR: string = "red";
+  private readonly FLASH_INTERVAL_MS: number = 500;
 
   private x: number;
   private y: number = 90;
@@ -189,7 +191,11 @@ export class ScoreboardEntity
     context.fillStyle = this.TIME_BOX_FILL_COLOR;
     this.roundedRect(context, x, y, width, height, this.CORNER_RADIUS);
     context.fill();
-    this.renderText(context, text, x + width / 2, y + 12.5 + height / 2);
+    const flash =
+      this.remainingSeconds <= 5 &&
+      Math.floor(this.elapsedMilliseconds / this.FLASH_INTERVAL_MS) % 2 === 0;
+    const color = flash ? this.FLASH_COLOR : this.TEXT_COLOR;
+    this.renderText(context, text, x + width / 2, y + 12.5 + height / 2, color);
   }
 
   private roundedRect(
@@ -213,10 +219,11 @@ export class ScoreboardEntity
     context: CanvasRenderingContext2D,
     text: string,
     x: number,
-    y: number
+    y: number,
+    color: string = this.TEXT_COLOR
   ) {
     context.textAlign = "center";
-    context.fillStyle = this.TEXT_COLOR;
+    context.fillStyle = color;
     context.font = `${this.FONT_SIZE} ${this.FONT_FAMILY}`;
     context.fillText(text, x, y);
   }

--- a/src/game/entities/thumbs-down-cloud-entity.ts
+++ b/src/game/entities/thumbs-down-cloud-entity.ts
@@ -13,7 +13,7 @@ interface EmojiParticle {
 export class ThumbsDownCloudEntity extends BaseMoveableGameEntity {
   private particles: EmojiParticle[] = [];
   private elapsed = 0;
-  private readonly duration = 3000; // ms
+  private readonly duration = 4000; // ms, extended so players notice the effect
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();


### PR DESCRIPTION
## Summary
- make confetti/defeat effects last longer
- remove boost pad emoji
- flash scoreboard timer red when under 5s

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68699f94bab48327ad0a876fa911db4c