### PR TITLE
Adjust effects and scoreboard behavior

### DIFF
--- a/src/game/entities/confetti-entity.ts
+++ b/src/game/entities/confetti-entity.ts
@@ -22,7 +22,7 @@ export class ConfettiEntity extends BaseMoveableGameEntity {
   }
 
   private createParticles(): void {
-    const count = 80;
+    const count = 200;
     for (let i = 0; i < count; i++) {
       this.particles.push({
         x: Math.random() * this.canvas.width,

--- a/src/game/entities/scoreboard-entity.ts
+++ b/src/game/entities/scoreboard-entity.ts
@@ -27,7 +27,8 @@ export class ScoreboardEntity
   private readonly RED_SHAPE_COLOR: string = RED_TEAM_COLOR;
   private readonly TIME_BOX_FILL_COLOR: string = "#4caf50"; // Added property for time box fill color
   private readonly FLASH_COLOR: string = "red";
-  private readonly FLASH_INTERVAL_MS: number = 500;
+  // Interval used for fade in/out effect when the timer is below 5 seconds
+  private readonly FADE_INTERVAL_MS: number = 500;
 
   private x: number;
   private y: number = 90;
@@ -191,11 +192,20 @@ export class ScoreboardEntity
     context.fillStyle = this.TIME_BOX_FILL_COLOR;
     this.roundedRect(context, x, y, width, height, this.CORNER_RADIUS);
     context.fill();
-    const flash =
-      this.remainingSeconds <= 5 &&
-      Math.floor(this.elapsedMilliseconds / this.FLASH_INTERVAL_MS) % 2 === 0;
-    const color = flash ? this.FLASH_COLOR : this.TEXT_COLOR;
+
+    const isCritical = this.remainingSeconds <= 5;
+    let alpha = 1;
+    if (isCritical) {
+      // Fade the text in and out urgently rather than a hard flash
+      const cycle = (this.elapsedMilliseconds % this.FADE_INTERVAL_MS) / this.FADE_INTERVAL_MS;
+      alpha = Math.abs(Math.sin(cycle * Math.PI));
+    }
+
+    context.save();
+    context.globalAlpha = alpha;
+    const color = isCritical ? this.FLASH_COLOR : this.TEXT_COLOR;
     this.renderText(context, text, x + width / 2, y + 12.5 + height / 2, color);
+    context.restore();
   }
 
   private roundedRect(

--- a/src/game/entities/thumbs-down-cloud-entity.ts
+++ b/src/game/entities/thumbs-down-cloud-entity.ts
@@ -1,11 +1,9 @@
 import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
 
 interface EmojiParticle {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  angle: number;
+  angle: number; // current angle around the center point
+  radius: number; // orbit radius
+  angularVelocity: number; // angular speed
   size: number;
   life: number;
 }
@@ -14,21 +12,24 @@ export class ThumbsDownCloudEntity extends BaseMoveableGameEntity {
   private particles: EmojiParticle[] = [];
   private elapsed = 0;
   private readonly duration = 4000; // ms, extended so players notice the effect
+  private readonly centerX: number;
+  private readonly centerY: number;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();
+    this.centerX = this.canvas.width / 2;
+    this.centerY = this.canvas.height / 2;
     this.createParticles();
   }
 
   private createParticles(): void {
     const count = 30;
+    const maxRadius = Math.min(this.canvas.width, this.canvas.height) / 3;
     for (let i = 0; i < count; i++) {
       this.particles.push({
-        x: Math.random() * this.canvas.width,
-        y: Math.random() * this.canvas.height,
-        vx: (Math.random() - 0.5) * 1.5,
-        vy: (Math.random() - 0.5) * 1.5,
         angle: Math.random() * Math.PI * 2,
+        radius: 40 + Math.random() * maxRadius,
+        angularVelocity: (Math.random() - 0.5) * 0.03 + 0.05,
         size: 24 + Math.random() * 12,
         life: 1,
       });
@@ -38,9 +39,7 @@ export class ThumbsDownCloudEntity extends BaseMoveableGameEntity {
   public override update(delta: DOMHighResTimeStamp): void {
     this.elapsed += delta;
     this.particles.forEach((p) => {
-      p.x += p.vx;
-      p.y += p.vy;
-      p.angle += 0.05;
+      p.angle += p.angularVelocity;
       p.life -= delta / this.duration;
     });
     this.particles = this.particles.filter((p) => p.life > 0);
@@ -55,9 +54,10 @@ export class ThumbsDownCloudEntity extends BaseMoveableGameEntity {
     context.textAlign = "center";
     context.textBaseline = "middle";
     this.particles.forEach((p) => {
+      const x = this.centerX + Math.cos(p.angle) * p.radius;
+      const y = this.centerY + Math.sin(p.angle) * p.radius;
       context.save();
-      context.translate(p.x, p.y);
-      context.rotate(p.angle);
+      context.translate(x, y);
       context.globalAlpha = Math.max(p.life, 0);
       context.font = `${p.size}px system-ui`;
       context.fillText("\uD83D\uDC4E", 0, 0); // thumbs down emoji


### PR DESCRIPTION
## Summary
- make the victory confetti denser
- move thumbs-down particles in orbits without rotation
- fade the game timer urgently when below 5 seconds

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869a35148a08327b9eb22659ae167d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the number of confetti particles for a denser visual effect.
  * Timer display now features a smooth fade in/out effect during the final seconds, replacing the previous flashing behavior.
  * Improved the thumbs-down emoji cloud animation, with particles now orbiting smoothly around the center for a more dynamic appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->