### PR TITLE
Improve HUD feedback

### DIFF
--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -5,7 +5,8 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
   private readonly RADIUS = 32;
   private boostLevel = 1; // target level 0..1
   private displayLevel = 1; // rendered level 0..1
-  private readonly FILL_RATE = 0.05; // units/ms, super fast
+  // Fill or drain the meter in roughly 0.2 seconds
+  private readonly FILL_RATE = 0.005; // units/ms
 
   constructor(canvas: HTMLCanvasElement) {
     super();

--- a/src/game/entities/confetti-entity.ts
+++ b/src/game/entities/confetti-entity.ts
@@ -14,7 +14,8 @@ interface ConfettiParticle {
 export class ConfettiEntity extends BaseMoveableGameEntity {
   private particles: ConfettiParticle[] = [];
   private elapsed = 0;
-  private readonly duration = 4000; // ms, extended for clearer celebration
+  // Keep particles alive for at least three seconds so the celebration is visible
+  private readonly duration = 3000; // ms
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();

--- a/src/game/entities/scoreboard-entity.ts
+++ b/src/game/entities/scoreboard-entity.ts
@@ -193,17 +193,21 @@ export class ScoreboardEntity
     this.roundedRect(context, x, y, width, height, this.CORNER_RADIUS);
     context.fill();
 
-    const isCritical = this.remainingSeconds <= 5;
+    const atZero = this.remainingSeconds <= 0;
+    const underFive = this.remainingSeconds > 0 && this.remainingSeconds <= 5;
+
+    const flashing = (atZero && this.active) || underFive;
     let alpha = 1;
-    if (isCritical) {
-      // Fade the text in and out urgently rather than a hard flash
-      const cycle = (this.elapsedMilliseconds % this.FADE_INTERVAL_MS) / this.FADE_INTERVAL_MS;
+    if (flashing) {
+      // After time is up flash quicker for urgency
+      const interval = atZero ? this.FADE_INTERVAL_MS / 2 : this.FADE_INTERVAL_MS;
+      const cycle = (this.elapsedMilliseconds % interval) / interval;
       alpha = Math.abs(Math.sin(cycle * Math.PI));
     }
 
     context.save();
-    context.globalAlpha = alpha;
-    const color = isCritical ? this.FLASH_COLOR : this.TEXT_COLOR;
+    context.globalAlpha = flashing ? alpha : 1;
+    const color = atZero || underFive ? this.FLASH_COLOR : this.TEXT_COLOR;
     this.renderText(context, text, x + width / 2, y + 12.5 + height / 2, color);
     context.restore();
   }


### PR DESCRIPTION
## Summary
- ensure confetti displays for at least three seconds
- make timer flash red when at 0 and match continues, or stay red when game over
- refill boost instantly and animate meter over 0.2s

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869a7166a0483279fc3e69675d090d8