### PR TITLE
Improve confetti and boost animations

### DIFF
--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -5,8 +5,8 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
   private readonly RADIUS = 32;
   private boostLevel = 1; // target level 0..1
   private displayLevel = 1; // rendered level 0..1
-  // Fill or drain the meter in roughly 0.3 seconds
-  private readonly FILL_RATE = 1 / 300; // units/ms
+  // Fill or drain the meter in roughly 0.2 seconds
+  private readonly FILL_RATE = 1 / 200; // units/ms
 
   constructor(canvas: HTMLCanvasElement) {
     super();

--- a/src/game/entities/confetti-entity.ts
+++ b/src/game/entities/confetti-entity.ts
@@ -15,9 +15,10 @@ export class ConfettiEntity extends BaseMoveableGameEntity {
   private particles: ConfettiParticle[] = [];
   private elapsed = 0;
   private spawnElapsed = 0;
-  // Keep spawning particles for three seconds so the celebration is visible
-  private readonly duration = 3000; // ms
-  private readonly spawnRate = 50; // particles per second
+  // Keep spawning particles for five seconds so the celebration is visible
+  private readonly duration = 5000; // ms
+  // Increased spawn rate for denser confetti
+  private readonly spawnRate = 100; // particles per second
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();


### PR DESCRIPTION
## Summary
- extend confetti effect to five seconds and spawn more particles
- speed up boost meter fill animation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869ae64a4008327a152210adbe47a0c