### PR TITLE
Add audio toggle with service

### DIFF
--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -25,6 +25,7 @@ import { IntervalManagerService } from "./interval-manager-service.js";
 import { ServiceRegistry } from "../service-registry.js";
 import { LoadingIndicatorEntity } from "../../entities/loading-indicator-entity.js";
 import { container } from "../di-container.js";
+import { AudioService } from "../../../game/services/audio/audio-service.js";
 
 export class GameLoopService {
   private context: CanvasRenderingContext2D;
@@ -49,6 +50,7 @@ export class GameLoopService {
   private eventConsumerService: EventConsumerService;
   private matchmakingService: MatchmakingService;
   private webrtcService: WebRTCService;
+  private audioService: AudioService;
   private loadingIndicatorEntity: LoadingIndicatorEntity | null = null;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
@@ -64,6 +66,8 @@ export class GameLoopService {
     this.eventConsumerService = container.get(EventConsumerService);
     this.matchmakingService = container.get(MatchmakingService);
     this.webrtcService = container.get(WebRTCService);
+    this.audioService = container.get(AudioService);
+    this.audioService.disable();
     this.addWindowAndGameListeners();
     this.setCanvasSize();
     this.loadEntities();

--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -15,6 +15,7 @@ import {
 } from "../../game/services/gameplay/matchmaking-tokens.js";
 import { CredentialService } from "../../game/services/security/credential-service.js";
 import { CameraService } from "./gameplay/camera-service.js";
+import { AudioService } from "../../game/services/audio/audio-service.js";
 
 export class ServiceRegistry {
   public static register(canvas: HTMLCanvasElement, debugging: boolean): void {
@@ -49,6 +50,7 @@ export class ServiceRegistry {
     });
     container.bind({ provide: WebRTCService, useClass: WebRTCService });
     container.bind({ provide: CameraService, useClass: CameraService });
+    container.bind({ provide: AudioService, useClass: AudioService });
     container.bind({
       provide: PendingIdentitiesToken,
       useValue: new Map<string, boolean>(),

--- a/src/game/entities/common/audio-toggle-entity.ts
+++ b/src/game/entities/common/audio-toggle-entity.ts
@@ -1,0 +1,77 @@
+import { BaseTappableGameEntity } from "../../../core/entities/base-tappable-game-entity.js";
+import { LIGHT_GREEN_COLOR } from "../../constants/colors-constants.js";
+import { AudioService } from "../../services/audio/audio-service.js";
+
+export class AudioToggleEntity extends BaseTappableGameEntity {
+  private radius = 30;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly audioService: AudioService
+  ) {
+    super();
+    this.width = this.radius * 2;
+    this.height = this.radius * 2;
+    this.setPosition();
+  }
+
+  public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    if (this.pressed) {
+      this.audioService.toggle();
+    }
+    super.update(deltaTimeStamp);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    context.translate(this.x + this.radius, this.y + this.radius);
+
+    context.beginPath();
+    context.arc(0, 0, this.radius, 0, Math.PI * 2);
+    context.closePath();
+
+    if (this.audioService.isEnabled()) {
+      context.fillStyle = LIGHT_GREEN_COLOR;
+    } else {
+      context.fillStyle = "rgba(0,0,0,0)";
+    }
+    context.strokeStyle = "#fff";
+    context.lineWidth = 3;
+    context.fill();
+    context.stroke();
+
+    this.drawSpeakerIcon(context);
+
+    context.restore();
+    super.render(context);
+  }
+
+  private drawSpeakerIcon(context: CanvasRenderingContext2D): void {
+    context.fillStyle = "#fff";
+    context.beginPath();
+    context.moveTo(-12, -10);
+    context.lineTo(-2, -10);
+    context.lineTo(8, -18);
+    context.lineTo(8, 18);
+    context.lineTo(-2, 10);
+    context.lineTo(-12, 10);
+    context.closePath();
+    context.fill();
+
+    if (this.audioService.isEnabled()) {
+      context.strokeStyle = "#fff";
+      context.lineWidth = 3;
+      context.beginPath();
+      context.arc(12, 0, 10, -Math.PI / 4, Math.PI / 4);
+      context.stroke();
+      context.beginPath();
+      context.arc(12, 0, 16, -Math.PI / 4, Math.PI / 4);
+      context.stroke();
+    }
+  }
+
+  private setPosition(): void {
+    this.x = this.canvas.width / 2 - this.radius;
+    this.y = this.canvas.height - this.radius * 2 - 20;
+  }
+}

--- a/src/game/scenes/main/login-entity-factory.ts
+++ b/src/game/scenes/main/login-entity-factory.ts
@@ -1,9 +1,13 @@
 import { MessageEntity } from "../../entities/common/message-entity.js";
 import { CloseableMessageEntity } from "../../entities/common/closeable-message-entity.js";
+import { AudioToggleEntity } from "../../entities/common/audio-toggle-entity.js";
+import { AudioService } from "../../services/audio/audio-service.js";
+import { container } from "../../../core/services/di-container.js";
 
 export interface LoginEntities {
   messageEntity: MessageEntity;
   closeableMessageEntity: CloseableMessageEntity;
+  audioToggleEntity: AudioToggleEntity;
 }
 
 export class LoginEntityFactory {
@@ -12,6 +16,8 @@ export class LoginEntityFactory {
   public createEntities(): LoginEntities {
     const messageEntity = new MessageEntity(this.canvas);
     const closeableMessageEntity = new CloseableMessageEntity(this.canvas);
-    return { messageEntity, closeableMessageEntity };
+    const audioService = container.get(AudioService);
+    const audioToggleEntity = new AudioToggleEntity(this.canvas, audioService);
+    return { messageEntity, closeableMessageEntity, audioToggleEntity };
   }
 }

--- a/src/game/scenes/main/login-scene.ts
+++ b/src/game/scenes/main/login-scene.ts
@@ -51,7 +51,8 @@ export class LoginScene extends BaseGameScene {
 
     this.uiEntities.push(
       this.entities.messageEntity,
-      this.entities.closeableMessageEntity
+      this.entities.closeableMessageEntity,
+      this.entities.audioToggleEntity
     );
 
     super.load();

--- a/src/game/services/audio/audio-service.ts
+++ b/src/game/services/audio/audio-service.ts
@@ -1,0 +1,22 @@
+import { injectable } from "@needle-di/core";
+
+@injectable()
+export class AudioService {
+  private enabled = false;
+
+  public isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  public enable(): void {
+    this.enabled = true;
+  }
+
+  public disable(): void {
+    this.enabled = false;
+  }
+
+  public toggle(): void {
+    this.enabled = !this.enabled;
+  }
+}


### PR DESCRIPTION
## Summary
- create `AudioService` for global audio state
- hook AudioService into `ServiceRegistry` and `GameLoopService`
- add `AudioToggleEntity` for circular speaker button
- update login scene to include new audio toggle button

## Testing
- `npx tsc` *(fails: vite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869b34f64e8832787c9809e6f7259ee