### PR TITLE
Fix boost meter refill timing

### DIFF
--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -71,13 +71,14 @@ export class LocalCarEntity extends CarEntity {
     } else {
       this.deactivateBoost();
     }
-    this.boostMeterEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
 
     if (this.canvas) {
       EntityUtils.fixEntityPositionIfOutOfBounds(this, this.canvas);
     }
 
     super.update(deltaTimeStamp);
+
+    this.boostMeterEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
   }
 
   private setSyncableValues(): void {


### PR DESCRIPTION
## Summary
- ensure boost meter updates after boost pad collision

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869b40725288327813efaf163056413