### PR TITLE
Make smoke trail more visible

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -462,8 +462,8 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   private renderSmokeTrail(context: CanvasRenderingContext2D): void {
     context.save();
     this.smokeParticles.forEach((p) => {
-      context.globalAlpha = 0.5 * Math.max(p.life / this.SMOKE_DURATION, 0);
-      context.fillStyle = "#888";
+      context.globalAlpha = 0.75 * Math.max(p.life / this.SMOKE_DURATION, 0);
+      context.fillStyle = "#555";
       context.beginPath();
       context.arc(p.x, p.y, p.size, 0, Math.PI * 2);
       context.fill();


### PR DESCRIPTION
## Summary
- darken car smoke by increasing opacity and using a darker gray color

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869cad71fd48327a0b56ae60c53090d