### PR TITLE
Increase smoke trail spawn rate

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -40,7 +40,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   // Smoke trail constants
   // Duration of each smoke particle in milliseconds
   private readonly SMOKE_DURATION = 1500; // ms
-  private readonly SMOKE_SPAWN_INTERVAL = 50; // ms
+  private readonly SMOKE_SPAWN_INTERVAL = 25; // ms
 
   private readonly PLAYER_NAME_PADDING = 10;
   private readonly PLAYER_NAME_RECT_HEIGHT = 24;


### PR DESCRIPTION
## Summary
- spawn smoke particles more often when boosting

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869cbf82fe88327be3c7a0801c1fc4a