### PR TITLE
Remove loss effect & highlight empty boost attempts

### DIFF
--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -5,6 +5,7 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
   private readonly RADIUS = 32;
   private boostLevel = 1; // target level 0..1
   private displayLevel = 1; // rendered level 0..1
+  private boostAttemptWhileEmpty = false;
   // Fill or drain the meter in roughly 0.2 seconds
   private readonly FILL_RATE_UP = 1 / 100; // units/ms
   private readonly FILL_RATE_DOWN = 1 / 200; // units/ms
@@ -18,6 +19,10 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
 
   public setBoostLevel(level: number): void {
     this.boostLevel = Math.max(0, Math.min(1, level));
+  }
+
+  public setAttemptingBoostWhileEmpty(active: boolean): void {
+    this.boostAttemptWhileEmpty = active;
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
@@ -76,8 +81,11 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
     context.beginPath();
     context.arc(cx, cy, this.RADIUS, 0, Math.PI * 2);
     context.closePath();
-    context.fillStyle =
-      this.displayLevel === 0 ? "rgba(255,0,0,0.3)" : "rgba(0,0,0,0.2)";
+    context.fillStyle = this.displayLevel === 0
+      ? this.boostAttemptWhileEmpty
+        ? "rgba(255,0,0,0.6)"
+        : "rgba(255,0,0,0.3)"
+      : "rgba(0,0,0,0.2)";
     context.fill();
 
     if (this.displayLevel > 0) {

--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -201,18 +201,28 @@ export class LocalCarEntity extends CarEntity {
 
   private handleBoostInput(): void {
     let activating = false;
+    let attemptingWhileEmpty = false;
 
     const pressedKeys = this.gameKeyboard.getPressedKeys();
 
-    if (pressedKeys.has("Shift") || pressedKeys.has(" ")) {
+    const spacePressed = pressedKeys.has(" ");
+    if (pressedKeys.has("Shift") || spacePressed) {
       activating = true;
+      if (spacePressed && this.getBoost() === 0) {
+        attemptingWhileEmpty = true;
+      }
     }
 
     if (this.boostMeterEntity) {
       const touches = this.gamePointer.getTouchPoints();
-      if (touches.filter((t) => t.pressing).length >= 2) {
+      const twoFingers = touches.filter((t) => t.pressing).length >= 2;
+      if (twoFingers) {
         activating = true;
+        if (this.getBoost() === 0) {
+          attemptingWhileEmpty = true;
+        }
       }
+      this.boostMeterEntity.setAttemptingBoostWhileEmpty(attemptingWhileEmpty);
     }
 
     if (this.gameGamepad.isButtonPressed(GamepadButton.R1)) {
@@ -223,6 +233,7 @@ export class LocalCarEntity extends CarEntity {
       this.activateBoost();
     } else {
       this.deactivateBoost();
+      this.boostMeterEntity?.setAttemptingBoostWhileEmpty(false);
     }
   }
 }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -32,7 +32,6 @@ import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
 import { TeamType } from "../../enums/team-type.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
 import { ConfettiEntity } from "../../entities/confetti-entity.js";
-import { ThumbsDownCloudEntity } from "../../entities/thumbs-down-cloud-entity.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
@@ -288,9 +287,6 @@ export class WorldScene extends BaseCollidingGameScene {
     if (won) {
       const confetti = new ConfettiEntity(this.canvas);
       this.addEntityToSceneLayer(confetti);
-    } else {
-      const cloud = new ThumbsDownCloudEntity(this.canvas);
-      this.addEntityToSceneLayer(cloud);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove thumbs down cloud when the player loses
- show a visual indicator when trying to boost with no boost

## Testing
- `npx --yes tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cecab82483279c0651ef5784fe15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The boost meter now visually indicates when a boost attempt is made while empty, displaying a stronger red tint for clearer feedback.

* **Refactor**
  * Removed the "thumbs down" cloud effect when losing a game; only confetti is shown for wins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->