### PR TITLE
Shrink boost pad size

### DIFF
--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -19,7 +19,7 @@ function colorWithAlpha(hex: string, alpha: number): string {
 const PAD_COOLDOWN_MS = 10000;
 
 export class BoostPadEntity extends BaseStaticCollidingGameEntity {
-  private readonly RADIUS = 20;
+  private readonly RADIUS = 16;
   private active = true;
   private cooldownRemaining = 0;
   private glowTimer = 0;


### PR DESCRIPTION
## Summary
- shrink boost pads so they're not as large

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a378624908327b472495b502074ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced the size of boost pads, resulting in a smaller hitbox and visual radius.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->