### PR TITLE
Add HelpEmtity UI

### DIFF
--- a/src/game/entities/help-emtity.ts
+++ b/src/game/entities/help-emtity.ts
@@ -1,0 +1,126 @@
+import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
+import { TimerService } from "../../core/services/gameplay/timer-service.js";
+
+export class HelpEmtity extends BaseAnimatedGameEntity {
+  private readonly padding = 20;
+  private readonly cornerRadius = 12;
+  private readonly bottomMargin = 40;
+  private readonly lineHeight = 24;
+
+  private lines: string[] = [];
+  private timer: TimerService | null = null;
+  private context: CanvasRenderingContext2D;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+    this.context = canvas.getContext("2d") as CanvasRenderingContext2D;
+    this.reset();
+  }
+
+  public show(text: string, duration = 0): void {
+    this.lines = text.split("\n");
+    this.measure();
+    this.reset();
+    this.fadeIn(0.2);
+    this.scaleTo(1, 0.2);
+    if (duration > 0) {
+      this.timer = new TimerService(duration, this.hide.bind(this));
+    }
+  }
+
+  public hide(): void {
+    this.fadeOut(0.2);
+    this.scaleTo(0, 0.2);
+  }
+
+  public override reset(): void {
+    this.opacity = 0;
+    this.scale = 0;
+    this.setPosition();
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    this.timer?.update(delta);
+    super.update(delta);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.applyOpacity(context);
+
+    context.translate(this.x + this.width / 2, this.y + this.height / 2);
+    context.scale(this.scale, this.scale);
+    context.translate(-(this.x + this.width / 2), -(this.y + this.height / 2));
+
+    this.drawBackground(context);
+    this.drawText(context);
+
+    context.restore();
+  }
+
+  private measure(): void {
+    this.context.font = "18px system-ui";
+    const maxWidth = this.lines.reduce((acc, line) => {
+      return Math.max(acc, this.context.measureText(line).width);
+    }, 0);
+    this.width = maxWidth + this.padding * 2;
+    this.height = this.lines.length * this.lineHeight + this.padding * 2;
+  }
+
+  private setPosition(): void {
+    this.x = (this.canvas.width - this.width) / 2;
+    this.y = this.canvas.height - this.height - this.bottomMargin;
+  }
+
+  private drawBackground(ctx: CanvasRenderingContext2D): void {
+    const gradient = ctx.createLinearGradient(
+      this.x,
+      this.y,
+      this.x,
+      this.y + this.height
+    );
+    gradient.addColorStop(0, "rgba(0,0,0,0.8)");
+    gradient.addColorStop(1, "rgba(40,40,40,0.8)");
+
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.moveTo(this.x + this.cornerRadius, this.y);
+    ctx.lineTo(this.x + this.width - this.cornerRadius, this.y);
+    ctx.quadraticCurveTo(
+      this.x + this.width,
+      this.y,
+      this.x + this.width,
+      this.y + this.cornerRadius
+    );
+    ctx.lineTo(this.x + this.width, this.y + this.height - this.cornerRadius);
+    ctx.quadraticCurveTo(
+      this.x + this.width,
+      this.y + this.height,
+      this.x + this.width - this.cornerRadius,
+      this.y + this.height
+    );
+    ctx.lineTo(this.x + this.cornerRadius, this.y + this.height);
+    ctx.quadraticCurveTo(
+      this.x,
+      this.y + this.height,
+      this.x,
+      this.y + this.height - this.cornerRadius
+    );
+    ctx.lineTo(this.x, this.y + this.cornerRadius);
+    ctx.quadraticCurveTo(this.x, this.y, this.x + this.cornerRadius, this.y);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  private drawText(ctx: CanvasRenderingContext2D): void {
+    ctx.fillStyle = "white";
+    ctx.font = "18px system-ui";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    let y = this.y + this.padding + this.lineHeight / 2;
+    for (const line of this.lines) {
+      ctx.fillText(line, this.x + this.width / 2, y);
+      y += this.lineHeight;
+    }
+  }
+}

--- a/src/game/scenes/world/world-entity-factory.ts
+++ b/src/game/scenes/world/world-entity-factory.ts
@@ -5,6 +5,7 @@ import { BallEntity } from "../../entities/ball-entity.js";
 import { ScoreboardEntity } from "../../entities/scoreboard-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { ToastEntity } from "../../entities/common/toast-entity.js";
+import { HelpEmtity } from "../../entities/help-emtity.js";
 import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
 import { BoostMeterEntity } from "../../entities/boost-meter-entity.js";
 import { getConfigurationKey } from "../../utils/configuration-utils.js";
@@ -19,6 +20,7 @@ export interface WorldEntities {
   goalEntity: GoalEntity;
   alertEntity: AlertEntity;
   toastEntity: ToastEntity;
+  helpEntity: HelpEmtity;
   boostPads: BoostPadEntity[];
 }
 
@@ -73,6 +75,7 @@ export class WorldEntityFactory {
 
     const alertEntity = new AlertEntity(this.canvas);
     const toastEntity = new ToastEntity(this.canvas);
+    const helpEntity = new HelpEmtity(this.canvas);
 
     // Boost related entities
     const boostMeterEntity = new BoostMeterEntity(this.canvas);
@@ -101,7 +104,8 @@ export class WorldEntityFactory {
     uiEntities.push(
       alertEntity,
       localCarEntity.getJoystickEntity(),
-      boostMeterEntity
+      boostMeterEntity,
+      helpEntity
     );
 
     return {
@@ -111,6 +115,7 @@ export class WorldEntityFactory {
       goalEntity,
       alertEntity,
       toastEntity,
+      helpEntity,
       boostPads,
     };
   }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -4,6 +4,7 @@ import { BallEntity } from "../../entities/ball-entity.js";
 import { ScoreboardEntity } from "../../entities/scoreboard-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { ToastEntity } from "../../entities/common/toast-entity.js";
+import { HelpEmtity } from "../../entities/help-emtity.js";
 import { BaseCollidingGameScene } from "../../../core/scenes/base-colliding-game-scene.js";
 import { GameState } from "../../../core/models/game-state.js";
 import { EntityStateType } from "../../../core/enums/entity-state-type.js";
@@ -47,9 +48,11 @@ export class WorldScene extends BaseCollidingGameScene {
   private goalEntity: GoalEntity | null = null;
   private alertEntity: AlertEntity | null = null;
   private toastEntity: ToastEntity | null = null;
+  private helpEntity: HelpEmtity | null = null;
   private scoreManagerService: ScoreManagerService | null = null;
   private matchFlowController: MatchFlowController | null = null;
   private boostPads: BoostPadEntity[] = [];
+  private helpShown = false;
 
   constructor(
     protected gameState: GameState,
@@ -81,6 +84,7 @@ export class WorldScene extends BaseCollidingGameScene {
     this.goalEntity = entities.goalEntity;
     this.alertEntity = entities.alertEntity;
     this.toastEntity = entities.toastEntity;
+    this.helpEntity = entities.helpEntity;
     this.boostPads = entities.boostPads;
 
     this.matchFlowController = new MatchFlowController(
@@ -124,6 +128,11 @@ export class WorldScene extends BaseCollidingGameScene {
     super.onTransitionEnd();
 
     this.scoreboardEntity?.reset();
+    if (!this.helpShown) {
+      const text = this.getHelpText();
+      this.helpEntity?.show(text, 2);
+      this.helpShown = true;
+    }
     this.matchmakingController
       .startMatchmaking()
       .catch(this.handleMatchmakingError.bind(this));
@@ -288,6 +297,19 @@ export class WorldScene extends BaseCollidingGameScene {
       const confetti = new ConfettiEntity(this.canvas);
       this.addEntityToSceneLayer(confetti);
     }
+  }
+
+  private getHelpText(): string {
+    if (this.isMobile()) {
+      return "Use first finger to drive. Use second finger to boost.";
+    }
+    return "Drive with WASD or arrow keys. Press Shift or Space to boost.";
+  }
+
+  private isMobile(): boolean {
+    return (
+      "ontouchstart" in window || navigator.maxTouchPoints > 0
+    );
   }
 
   private async returnToMainMenuScene(): Promise<void> {


### PR DESCRIPTION
## Summary
- create `HelpEmtity` for displaying short help messages
- integrate help dialog with world scene
- build help entity in `WorldEntityFactory`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a3f8e35108327a7ef5986a7ac3532