### PR TITLE
Update help display duration and formatting

### DIFF
--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -130,7 +130,7 @@ export class WorldScene extends BaseCollidingGameScene {
     this.scoreboardEntity?.reset();
     if (!this.helpShown) {
       const text = this.getHelpText();
-      this.helpEntity?.show(text, 2);
+      this.helpEntity?.show(text, 4);
       this.helpShown = true;
     }
     this.matchmakingController
@@ -301,7 +301,7 @@ export class WorldScene extends BaseCollidingGameScene {
 
   private getHelpText(): string {
     if (this.isMobile()) {
-      return "Use first finger to drive. Use second finger to boost.";
+      return "Use first finger to drive.\nUse second finger to boost.";
     }
     return "Drive with WASD or arrow keys. Press Shift or Space to boost.";
   }


### PR DESCRIPTION
## Summary
- show the help overlay for longer in `WorldScene`
- format the mobile help text with a line break for better readability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a41c9eae08327a7a187b97f17bbf9