### PR TITLE
Spawn cars with spacing

### DIFF
--- a/src/game/constants/game-constants.ts
+++ b/src/game/constants/game-constants.ts
@@ -1,1 +1,6 @@
 export const GAME_VERSION = "2.0.0";
+
+// Horizontal distance in pixels used when spawning cars. Cars are distributed
+// around the center of the screen using this value as spacing so they don't
+// overlap on spawn.
+export const CAR_SPAWN_SPACING = 80;

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -83,8 +83,6 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     if (remote) {
       this.imagePath = this.IMAGE_RED_PATH;
     }
-
-    this.addCollisionExclusion(CarEntity);
   }
 
   public override load(): void {

--- a/src/game/scenes/world/match-flow-controller.ts
+++ b/src/game/scenes/world/match-flow-controller.ts
@@ -12,6 +12,7 @@ import { BallEntity } from "../../entities/ball-entity.js";
 import { LocalCarEntity } from "../../entities/local-car-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { BoostPadEntity } from "../../entities/boost-pad-entity.js";
+import { CAR_SPAWN_SPACING } from "../../constants/game-constants.js";
 
 export class MatchFlowController {
   private readonly COUNTDOWN_START_NUMBER = 4;
@@ -112,6 +113,7 @@ export class MatchFlowController {
   private resetForCountdown(): void {
     this.ballEntity.reset();
     this.localCarEntity.reset();
+    this.positionLocalCar();
     this.localCarEntity.refillBoost();
     this.boostPads.forEach((pad) => pad.reset());
   }
@@ -122,6 +124,7 @@ export class MatchFlowController {
 
     this.alertEntity.hide();
     this.localCarEntity.reset();
+    this.positionLocalCar();
     this.ballEntity.reset();
     this.scoreboardEntity.startTimer();
   }
@@ -135,5 +138,33 @@ export class MatchFlowController {
     countdownEvent.setData(arrayBuffer);
 
     this.eventProcessorService.sendEvent(countdownEvent);
+  }
+
+  private positionLocalCar(): void {
+    const match = this.gameState.getMatch();
+    if (!match) {
+      return;
+    }
+
+    const players = match
+      .getPlayers()
+      .slice()
+      .sort((a, b) => a.getId().localeCompare(b.getId()));
+
+    const player = this.localCarEntity.getPlayer();
+    if (!player) {
+      return;
+    }
+
+    const index = players.findIndex((p) => p.getId() === player.getId());
+    if (index === -1) {
+      return;
+    }
+
+    const canvas = this.gameState.getCanvas();
+    const startX =
+      canvas.width / 2 - ((players.length - 1) * CAR_SPAWN_SPACING) / 2;
+
+    this.localCarEntity.setX(startX + index * CAR_SPAWN_SPACING);
   }
 }


### PR DESCRIPTION
## Summary
- add `CAR_SPAWN_SPACING` constant
- space out local car position based on player index during countdown
- enable collisions between cars

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a45fad4f083278a238fe762574bd9