### PR TITLE
Fix remote player float at world bounds

### DIFF
--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -72,11 +72,11 @@ export class LocalCarEntity extends CarEntity {
       this.deactivateBoost();
     }
 
+    super.update(deltaTimeStamp);
+
     if (this.canvas) {
       EntityUtils.fixEntityPositionIfOutOfBounds(this, this.canvas);
     }
-
-    super.update(deltaTimeStamp);
 
     this.boostMeterEntity?.setBoostLevel(this.getBoost() / this.MAX_BOOST);
   }


### PR DESCRIPTION
## Summary
- clamp local player's position after the physics update so the host sees an accurate position

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a5696368083278417b69bc0502fa7