### PR TITLE
Enhance login modal styles

### DIFF
--- a/src/core/main.css
+++ b/src/core/main.css
@@ -25,11 +25,16 @@ canvas {
 }
 
 dialog {
-  border: 0;
+  border: 2px solid rgba(255, 255, 255, 0.2);
   padding: 20px;
   border-radius: 6px;
   text-align: center;
   top: -170px;
+}
+
+dialog::backdrop {
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
 }
 
 dialog h1 {


### PR DESCRIPTION
## Summary
- apply a subtle backdrop blur to the login modal
- outline the modal with a transparent white border

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a58e9deb4832786c914dc72f0b488