### PR TITLE
Fix remote player position near bounds

### DIFF
--- a/src/game/constants/webrtc-constants.ts
+++ b/src/game/constants/webrtc-constants.ts
@@ -1,2 +1,6 @@
 export const SCALE_FACTOR_FOR_ANGLES = 32767 / Math.PI;
 export const SCALE_FACTOR_FOR_SPEED = 100;
+// Improves precision of position values sent over the network while still
+// keeping them within the 16-bit range. Coordinates are multiplied by this
+// factor before serialization and divided by it when deserialized.
+export const SCALE_FACTOR_FOR_COORDINATES = 10;

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -8,6 +8,7 @@ import {
 import {
   SCALE_FACTOR_FOR_ANGLES,
   SCALE_FACTOR_FOR_SPEED,
+  SCALE_FACTOR_FOR_COORDINATES,
 } from "../constants/webrtc-constants.js";
 import { DebugUtils } from "../../core/utils/debug-utils.js";
 import { BinaryWriter } from "../../core/utils/binary-writer-utils.js";
@@ -105,9 +106,12 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     const boost = Math.round(this.boost);
     const boosting = this.boosting ? 1 : 0;
 
+    const scaledX = Math.round(this.x * SCALE_FACTOR_FOR_COORDINATES);
+    const scaledY = Math.round(this.y * SCALE_FACTOR_FOR_COORDINATES);
+
     const arrayBuffer = BinaryWriter.build()
-      .unsignedInt16(this.x)
-      .unsignedInt16(this.y)
+      .unsignedInt16(scaledX)
+      .unsignedInt16(scaledY)
       .signedInt16(angle)
       .signedInt16(speed)
       .unsignedInt8(boosting)

--- a/src/game/entities/remote-car-entity.ts
+++ b/src/game/entities/remote-car-entity.ts
@@ -4,6 +4,7 @@ import type { MultiplayerGameEntity } from "../../core/interfaces/entities/multi
 import {
   SCALE_FACTOR_FOR_ANGLES,
   SCALE_FACTOR_FOR_SPEED,
+  SCALE_FACTOR_FOR_COORDINATES,
 } from "../constants/webrtc-constants.js";
 import { BinaryReader } from "../../core/utils/binary-reader-utils.js";
 
@@ -34,8 +35,10 @@ export class RemoteCarEntity extends CarEntity {
   ): MultiplayerGameEntity {
     const binaryReader = BinaryReader.fromArrayBuffer(arrayBuffer);
 
-    const x = binaryReader.unsignedInt16();
-    const y = binaryReader.unsignedInt16();
+    const x =
+      binaryReader.unsignedInt16() / SCALE_FACTOR_FOR_COORDINATES;
+    const y =
+      binaryReader.unsignedInt16() / SCALE_FACTOR_FOR_COORDINATES;
     const angle = binaryReader.signedInt16() / SCALE_FACTOR_FOR_ANGLES;
     const speed = binaryReader.signedInt16() / SCALE_FACTOR_FOR_SPEED;
     const boosting = binaryReader.unsignedInt8() === 1;
@@ -55,8 +58,8 @@ export class RemoteCarEntity extends CarEntity {
   public override synchronize(arrayBuffer: ArrayBuffer): void {
     const binaryReader = BinaryReader.fromArrayBuffer(arrayBuffer);
 
-    this.x = binaryReader.unsignedInt16();
-    this.y = binaryReader.unsignedInt16();
+    this.x = binaryReader.unsignedInt16() / SCALE_FACTOR_FOR_COORDINATES;
+    this.y = binaryReader.unsignedInt16() / SCALE_FACTOR_FOR_COORDINATES;
     this.angle = binaryReader.signedInt16() / SCALE_FACTOR_FOR_ANGLES;
     this.speed = binaryReader.signedInt16() / SCALE_FACTOR_FOR_SPEED;
     this.boosting = binaryReader.unsignedInt8() === 1;


### PR DESCRIPTION
## Summary
- improve coordinate precision in network messages
- scale car positions before serializing them and adjust deserialization

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a587d5a9c83278814fc67616a47d1