### PR TITLE
Add online players display

### DIFF
--- a/src/game/enums/event-type.ts
+++ b/src/game/enums/event-type.ts
@@ -13,4 +13,5 @@ export enum EventType {
   GameOver,
   BoostPadConsumed,
   MatchmakingStarted,
+  OnlinePlayers,
 }

--- a/src/game/enums/websocket-type.ts
+++ b/src/game/enums/websocket-type.ts
@@ -2,4 +2,5 @@ export enum WebSocketType {
   Notification = 0,
   PlayerIdentity = 1,
   Tunnel = 2,
+  OnlinePlayers = 3,
 }

--- a/src/game/interfaces/events/online-players-payload.ts
+++ b/src/game/interfaces/events/online-players-payload.ts
@@ -1,0 +1,3 @@
+export interface OnlinePlayersPayload {
+  total: number;
+}

--- a/src/game/scenes/main/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu-scene.ts
@@ -10,6 +10,7 @@ import { ScoreboardScene } from "./scoreboard-scene.js";
 import { SettingsScene } from "./settings-scene.js";
 import { EventType } from "../../enums/event-type.js";
 import type { GameState } from "../../../core/models/game-state.js";
+import type { OnlinePlayersPayload } from "../../interfaces/events/online-players-payload.js";
 import { container } from "../../../core/services/di-container.js";
 import { EventConsumerService } from "../../../core/services/gameplay/event-consumer-service.js";
 
@@ -22,6 +23,7 @@ export class MainMenuScene extends BaseGameScene {
 
   private serverMessageWindowEntity: ServerMessageWindowEntity | null = null;
   private closeableMessageEntity: CloseableMessageEntity | null = null;
+  private onlinePlayers: number = 0;
 
   constructor(
     gameState: GameState,
@@ -74,6 +76,10 @@ export class MainMenuScene extends BaseGameScene {
     this.subscribeToLocalEvent(
       EventType.DebugChanged,
       this.updateDebugStateForEntities.bind(this)
+    );
+    this.subscribeToLocalEvent(
+      EventType.OnlinePlayers,
+      this.handleOnlinePlayersEvent.bind(this)
     );
   }
 
@@ -272,5 +278,19 @@ export class MainMenuScene extends BaseGameScene {
       this.canvas.width / 2,
       this.canvas.height - 100
     );
+
+    this.showTotalOnlinePlayers(context);
+  }
+
+  private handleOnlinePlayersEvent(payload: OnlinePlayersPayload): void {
+    this.onlinePlayers = payload.total;
+  }
+
+  private showTotalOnlinePlayers(context: CanvasRenderingContext2D): void {
+    const text = `${this.onlinePlayers} ONLINE`;
+    context.font = "bold 20px system-ui";
+    context.fillStyle = "#4a90e2";
+    context.textAlign = "center";
+    context.fillText(text, this.canvas.width / 2, this.canvas.height - 40);
   }
 }

--- a/src/game/services/network/websocket-service.ts
+++ b/src/game/services/network/websocket-service.ts
@@ -4,6 +4,7 @@ import { LocalEvent } from "../../../core/models/local-event.js";
 import { EventType } from "../../enums/event-type.js";
 import type { ServerDisconnectedPayload } from "../../interfaces/events/server-disconnected-payload.js";
 import type { ServerNotificationPayload } from "../../interfaces/events/server-notification-payload.js";
+import type { OnlinePlayersPayload } from "../../interfaces/events/online-players-payload.js";
 import { WebSocketType } from "../../enums/websocket-type.js";
 import { APIUtils } from "../../utils/api-utils.js";
 import { GameState } from "../../../core/models/game-state.js";
@@ -84,6 +85,20 @@ export class WebSocketService {
 
     localEvent.setData({
       message,
+    });
+
+    this.eventProcessorService.addLocalEvent(localEvent);
+  }
+
+  @ServerCommandHandler(WebSocketType.OnlinePlayers)
+  public handleOnlinePlayers(binaryReader: BinaryReader) {
+    const total = binaryReader.unsignedInt16();
+
+    const localEvent = new LocalEvent<OnlinePlayersPayload>(
+      EventType.OnlinePlayers
+    );
+    localEvent.setData({
+      total,
     });
 
     this.eventProcessorService.addLocalEvent(localEvent);


### PR DESCRIPTION
## Summary
- add `OnlinePlayers` to websocket and event enums
- create payload interface for online player counts
- handle `OnlinePlayers` websocket message
- show total online players in the main menu

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a61b9ccd08327a5d1dfb381a91f88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The main menu now displays the current number of online players in real time.

* **Enhancements**
  * Real-time updates are shown as the online player count changes during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->