### PR TITLE
Handle connection loss mid-match

### DIFF
--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -16,6 +16,7 @@ import { GAME_VERSION } from "../../../game/constants/game-constants.js";
 import { EventConsumerService } from "./event-consumer-service.js";
 import { DebugEntity } from "../../entities/debug-entity.js";
 import { GameState } from "../../models/game-state.js";
+import { MatchStateType } from "../../../game/enums/match-state-type.js";
 import { SceneTransitionService } from "./scene-transition-service.js";
 import { MatchmakingService } from "../../../game/services/gameplay/matchmaking-service.js";
 import { DebugService } from "../../../game/services/debug/debug-service.js";
@@ -153,6 +154,15 @@ export class GameLoopService {
   private handleServerDisconnectedEvent(
     payload: ServerDisconnectedPayload
   ): void {
+    const match = this.gameState.getMatch();
+    const state = match?.getState();
+
+    if (state !== undefined && state !== MatchStateType.WaitingPlayers) {
+      console.warn("WebSocket disconnected during active match");
+      // Wait to reconnect when returning to the main menu
+      return;
+    }
+
     if (payload.connectionLost) {
       alert("Connection to server was lost");
     } else {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -33,6 +33,7 @@ import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
 import { TeamType } from "../../enums/team-type.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
 import { ConfettiEntity } from "../../entities/confetti-entity.js";
+import { WebSocketService } from "../../services/network/websocket-service.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
@@ -322,6 +323,14 @@ export class WorldScene extends BaseCollidingGameScene {
       container.get(EventConsumerService),
       false
     );
+
+    if (!this.gameState.getGameServer().isConnected()) {
+      try {
+        container.get(WebSocketService).connectToServer();
+      } catch (error) {
+        console.error("Failed to reconnect to server", error);
+      }
+    }
 
     mainScene.activateScene(mainMenuScene);
     mainScene.load();


### PR DESCRIPTION
## Summary
- mute server disconnect alerts during an active match and reconnect on main menu
- retry websocket connection when returning to the main menu

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686a6aa7af648327ab5b2e17355b06b5