### PR TITLE
Fix pointer events in main scene

### DIFF
--- a/src/core/scenes/base-game-scene.ts
+++ b/src/core/scenes/base-game-scene.ts
@@ -26,6 +26,32 @@ export class BaseGameScene implements GameScene {
   protected readonly cameraService: CameraService;
 
   private gamePointer: GamePointer;
+  /**
+   * Indicates whether pointer events should be cleared automatically
+   * after handling input in {@link update}. Subclasses can override
+   * {@link shouldClearPointerEvents} to delay or disable clearing
+   * when delegating events to nested scenes.
+   */
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  protected clearPointerEventsAutomatically = true;
+
+  /**
+   * Determines if pointer events should be cleared at the end of
+   * the default update cycle.
+   */
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  protected shouldClearPointerEvents(): boolean {
+    return this.clearPointerEventsAutomatically;
+  }
+
+  /**
+   * Clears the current pressed state of the game pointer. Subclasses may call
+   * this manually when deferring pointer handling to nested scenes.
+   */
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  protected clearPointerEvents(): void {
+    this.gamePointer.clearPressed();
+  }
 
   constructor(
     protected gameState: GameState,
@@ -136,6 +162,9 @@ export class BaseGameScene implements GameScene {
     }
 
     this.handlePointerEvent();
+    if (this.shouldClearPointerEvents()) {
+      this.clearPointerEvents();
+    }
   }
 
   public render(context: CanvasRenderingContext2D): void {
@@ -206,8 +235,6 @@ export class BaseGameScene implements GameScene {
         break;
       }
     }
-
-    this.gamePointer.clearPressed();
   }
 
   private updateEntities(

--- a/src/game/scenes/main/main-scene.ts
+++ b/src/game/scenes/main/main-scene.ts
@@ -14,6 +14,9 @@ export class MainScene extends BaseGameScene {
   ) {
     super(gameState, eventConsumerService);
     this.sceneManagerService = new SceneManagerService();
+    // Pointer events should be cleared only after nested scenes have processed
+    // them.
+    this.clearPointerEventsAutomatically = false;
   }
 
   public activateScene(scene: GameScene): void {
@@ -38,11 +41,14 @@ export class MainScene extends BaseGameScene {
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
-    // No need to super.update() because the sceneManagerService will handle the update
     super.update(deltaTimeStamp);
 
+    // Update nested scenes after updating the base entities
     this.sceneManagerService?.getCurrentScene()?.setOpacity(this.opacity);
     this.sceneManagerService?.update(deltaTimeStamp);
+
+    // Clear pointer events once all scenes have processed input
+    this.clearPointerEvents();
   }
 
   public override render(context: CanvasRenderingContext2D): void {


### PR DESCRIPTION
## Summary
- allow `BaseGameScene` subclasses to control pointer event clearing
- call `clearPointerEvents()` after nested scenes update in `MainScene`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a845e534083278aaaaf263615837e