### PR TITLE
Adjust main scene background

### DIFF
--- a/src/game/entities/backgrounds/car-silhouette-entity.ts
+++ b/src/game/entities/backgrounds/car-silhouette-entity.ts
@@ -13,12 +13,13 @@ interface Car {
 
 export class CarSilhouetteEntity extends BaseGameEntity {
   private cars: Car[] = [];
-  private readonly carCount = 8;
+  private readonly carCount = 4;
   private carImage: HTMLImageElement | null = null;
   private readonly IMAGE_PATH = "./images/car-silhouette.png";
   private readonly BASE_SPEED = 0.07;
-  private readonly SIZE = 40;
+  private readonly SIZE = 60;
   private readonly TRANSITION_SPEED_MULTIPLIER = 2;
+  private currentMultiplier = 1;
   private readonly transitionService: SceneTransitionService;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
@@ -40,9 +41,13 @@ export class CarSilhouetteEntity extends BaseGameEntity {
       const fromLeft = i < this.carCount / 2;
       const vx = fromLeft ? this.BASE_SPEED : -this.BASE_SPEED;
       const vy = this.BASE_SPEED;
+      const x = fromLeft
+        ? Math.random() * (this.canvas.width / 3)
+        : this.canvas.width - Math.random() * (this.canvas.width / 3);
+      const y = Math.random() * (this.canvas.height / 3);
       this.cars.push({
-        x: Math.random() * this.canvas.width,
-        y: Math.random() * this.canvas.height,
+        x,
+        y,
         vx,
         vy,
         size: this.SIZE,
@@ -52,12 +57,14 @@ export class CarSilhouetteEntity extends BaseGameEntity {
   }
 
   public override update(delta: DOMHighResTimeStamp): void {
-    const multiplier = this.transitionService.isTransitionActive()
+    const targetMultiplier = this.transitionService.isTransitionActive()
       ? this.TRANSITION_SPEED_MULTIPLIER
       : 1;
+    this.currentMultiplier +=
+      (targetMultiplier - this.currentMultiplier) * 0.05;
     this.cars.forEach((car) => {
-      car.x += car.vx * delta * multiplier;
-      car.y += car.vy * delta * multiplier;
+      car.x += car.vx * delta * this.currentMultiplier;
+      car.y += car.vy * delta * this.currentMultiplier;
 
       if (car.x > this.canvas.width + car.size) {
         car.x = -car.size;

--- a/src/game/entities/backgrounds/main-background-entity.ts
+++ b/src/game/entities/backgrounds/main-background-entity.ts
@@ -2,7 +2,7 @@ import { BaseGameEntity } from "../../../core/entities/base-game-entity.js";
 import { CarSilhouetteEntity } from "./car-silhouette-entity.js";
 
 export class MainBackgroundEntity extends BaseGameEntity {
-  private gradientOffset = 0; // Offset for moving gradient
+  private gradientOffset = 0; // Static gradient, offset remains 0
   private readonly carSilhouettes: CarSilhouetteEntity;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
@@ -15,13 +15,9 @@ export class MainBackgroundEntity extends BaseGameEntity {
     super.load();
   }
 
-  // Update the gradient offset to animate the background
+  // Update only the car silhouettes. Gradient remains static.
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {
-    this.gradientOffset += deltaTimeStamp * 0.01; // Adjust speed as needed
-    if (this.gradientOffset > this.canvas.width) {
-      this.gradientOffset = 0; // Loop the gradient
-    }
-
+    this.gradientOffset = 0;
     this.carSilhouettes.update(deltaTimeStamp);
   }
 


### PR DESCRIPTION
## Summary
- keep main scene gradient static
- make car silhouettes larger and fewer
- spawn cars in more organized directions
- fade car speed toward a transition multiplier

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a88f0b6ac8327b8ed8ba6e6595bf5