### PR TITLE
Add audio settings modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,12 @@
     <script defer type="module" src="/src/core/main.ts"></script>
   </head>
   <body>
-    <dialog>
+    <dialog id="audio-dialog">
+      <h1>Audio</h1>
+      <p>Enable or disable game audio</p>
+      <button id="audio-toggle-button" aria-label="Toggle audio">🔊</button>
+    </dialog>
+    <dialog id="player-id-dialog">
       <h1>Player ID</h1>
       <input
         id="display-name-input"
@@ -39,7 +44,6 @@
       <hr />
       <button id="sign-in-button">Sign in</button>
     </dialog>
-    <button id="audio-toggle-button" aria-label="Toggle audio">🔊</button>
     <canvas id="debug" tabindex="1"></canvas>
     <canvas id="game" tabindex="-1"></canvas>
   </body>

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -86,10 +86,8 @@ hr {
 }
 
 #audio-toggle-button {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  display: block;
+  margin: 20px auto 0;
   width: 60px;
   height: 60px;
   border-radius: 50%;

--- a/src/game/scenes/main/login-scene.ts
+++ b/src/game/scenes/main/login-scene.ts
@@ -18,6 +18,8 @@ export class LoginScene extends BaseGameScene {
   private credentialService: CredentialService;
   private entities: LoginEntities | null = null;
   private dialogElement: HTMLDialogElement | null = null;
+  private audioDialogElement: HTMLDialogElement | null = null;
+  private audioToggleButtonElement: HTMLButtonElement | null = null;
   private displayNameInputElement: HTMLInputElement | null = null;
   private registerButtonElement: HTMLElement | null = null;
   private signInButtonElement: HTMLElement | null = null;
@@ -36,7 +38,15 @@ export class LoginScene extends BaseGameScene {
       webSocketService
     );
     this.credentialService = container.get(CredentialService);
-    this.dialogElement = document.querySelector("dialog");
+    this.dialogElement = document.querySelector(
+      "#player-id-dialog"
+    ) as HTMLDialogElement | null;
+    this.audioDialogElement = document.querySelector(
+      "#audio-dialog"
+    ) as HTMLDialogElement | null;
+    this.audioToggleButtonElement = document.querySelector(
+      "#audio-toggle-button"
+    ) as HTMLButtonElement | null;
     this.displayNameInputElement = document.querySelector(
       "#display-name-input"
     );
@@ -110,7 +120,7 @@ export class LoginScene extends BaseGameScene {
         }
 
         this.entities?.messageEntity.hide();
-        this.showDialog();
+        this.showAudioDialog().then(() => this.showDialog());
       })
       .catch((error) => {
         console.error(error);
@@ -136,6 +146,36 @@ export class LoginScene extends BaseGameScene {
     });
 
     this.dialogElement?.showModal();
+  }
+
+  private showAudioDialog(): Promise<void> {
+    this.gameState.getGamePointer().setPreventDefault(false);
+
+    return new Promise((resolve) => {
+      if (!this.audioDialogElement) {
+        resolve();
+        return;
+      }
+
+      const handleClose = () => {
+        this.audioDialogElement?.removeEventListener("close", handleClose);
+        resolve();
+      };
+
+      this.audioDialogElement.addEventListener("close", handleClose);
+
+      const handleButtonClick = () => {
+        this.audioDialogElement?.close();
+      };
+
+      this.audioToggleButtonElement?.addEventListener(
+        "click",
+        handleButtonClick,
+        { once: true }
+      );
+
+      this.audioDialogElement.showModal();
+    });
   }
 
   private handleDisplayNameInputEvent(): void {


### PR DESCRIPTION
## Summary
- introduce an audio settings dialog shown before the Player ID prompt
- adjust the audio toggle button style to work inside the dialog
- update LoginScene to display the audio dialog prior to the Player ID dialog

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a9522ac9c8327a83d653c20b8c893