### PR TITLE
Add continue button to audio dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       <h1>Audio</h1>
       <p>Enable or disable game audio</p>
       <button id="audio-toggle-button" aria-label="Toggle audio">🔊</button>
+      <button id="audio-continue-button">Continue</button>
     </dialog>
     <dialog id="player-id-dialog">
       <h1>Player ID</h1>

--- a/src/game/scenes/main/login-scene.ts
+++ b/src/game/scenes/main/login-scene.ts
@@ -19,7 +19,7 @@ export class LoginScene extends BaseGameScene {
   private entities: LoginEntities | null = null;
   private dialogElement: HTMLDialogElement | null = null;
   private audioDialogElement: HTMLDialogElement | null = null;
-  private audioToggleButtonElement: HTMLButtonElement | null = null;
+  private audioContinueButtonElement: HTMLButtonElement | null = null;
   private displayNameInputElement: HTMLInputElement | null = null;
   private registerButtonElement: HTMLElement | null = null;
   private signInButtonElement: HTMLElement | null = null;
@@ -44,8 +44,8 @@ export class LoginScene extends BaseGameScene {
     this.audioDialogElement = document.querySelector(
       "#audio-dialog"
     ) as HTMLDialogElement | null;
-    this.audioToggleButtonElement = document.querySelector(
-      "#audio-toggle-button"
+    this.audioContinueButtonElement = document.querySelector(
+      "#audio-continue-button"
     ) as HTMLButtonElement | null;
     this.displayNameInputElement = document.querySelector(
       "#display-name-input"
@@ -164,13 +164,13 @@ export class LoginScene extends BaseGameScene {
 
       this.audioDialogElement.addEventListener("close", handleClose);
 
-      const handleButtonClick = () => {
+      const handleContinueClick = () => {
         this.audioDialogElement?.close();
       };
 
-      this.audioToggleButtonElement?.addEventListener(
+      this.audioContinueButtonElement?.addEventListener(
         "click",
-        handleButtonClick,
+        handleContinueClick,
         { once: true }
       );
 


### PR DESCRIPTION
## Summary
- make audio modal closable without enabling audio
- remove toggle listener from login scene

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a97022ea08327b18f5e8878cf707d