### PR TITLE
Update help dialog padding and main menu text

### DIFF
--- a/src/core/main.css
+++ b/src/core/main.css
@@ -30,9 +30,7 @@ dialog {
   border-radius: 6px;
   text-align: center;
   top: -170px;
-  background: rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  background: #fff;
 }
 
 dialog h1 {

--- a/src/game/entities/help-emtity.ts
+++ b/src/game/entities/help-emtity.ts
@@ -2,7 +2,8 @@ import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity
 import { TimerService } from "../../core/services/gameplay/timer-service.js";
 
 export class HelpEntity extends BaseAnimatedGameEntity {
-  private readonly padding = 20;
+  private readonly paddingX = 20;
+  private readonly paddingY = 10;
   private readonly cornerRadius = 12;
   private readonly bottomMargin = 40;
   private readonly lineHeight = 24;
@@ -63,8 +64,8 @@ export class HelpEntity extends BaseAnimatedGameEntity {
     const maxWidth = this.lines.reduce((acc, line) => {
       return Math.max(acc, this.context.measureText(line).width);
     }, 0);
-    this.width = maxWidth + this.padding * 2;
-    this.height = this.lines.length * this.lineHeight + this.padding * 2;
+    this.width = maxWidth + this.paddingX * 2;
+    this.height = this.lines.length * this.lineHeight + this.paddingY * 2;
   }
 
   private setPosition(): void {
@@ -117,7 +118,7 @@ export class HelpEntity extends BaseAnimatedGameEntity {
     ctx.font = "18px system-ui";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    let y = this.y + this.padding + this.lineHeight / 2;
+    let y = this.y + this.paddingY + this.lineHeight / 2;
     for (const line of this.lines) {
       ctx.fillText(line, this.x + this.width / 2, y);
       y += this.lineHeight;

--- a/src/game/scenes/main/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu-scene.ts
@@ -287,7 +287,7 @@ export class MainMenuScene extends BaseGameScene {
   }
 
   private showTotalOnlinePlayers(context: CanvasRenderingContext2D): void {
-    const text = `${this.onlinePlayers} ONLINE`;
+    const text = `${this.onlinePlayers} ONLINE PLAYERS`;
     context.font = "bold 20px system-ui";
     context.fillStyle = "#4a90e2";
     context.textAlign = "center";


### PR DESCRIPTION
## Summary
- rename the online players label in the main menu
- adjust help entity padding so top/bottom is smaller than left/right
- remove frosted glass effect from login dialog

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aaa207e7c8327bb7a92250df94cda