### PR TITLE
Show online player count in menu circle

### DIFF
--- a/src/game/entities/common/online-players-entity.ts
+++ b/src/game/entities/common/online-players-entity.ts
@@ -1,0 +1,40 @@
+import { BaseGameEntity } from "../../../core/entities/base-game-entity.js";
+
+export class OnlinePlayersEntity extends BaseGameEntity {
+  private onlinePlayers = 0;
+  private readonly LABEL = "ONLINE PLAYERS";
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+  }
+
+  public setOnlinePlayers(total: number): void {
+    this.onlinePlayers = total;
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    const y = this.canvas.height - 40;
+
+    context.font = "bold 20px system-ui";
+    context.fillStyle = "#4a90e2";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+
+    context.fillText(this.LABEL, this.canvas.width / 2, y);
+
+    const metrics = context.measureText(this.LABEL);
+    const padding = 10;
+    const radius = 12;
+    const circleX =
+      this.canvas.width / 2 + metrics.width / 2 + padding + radius;
+
+    context.beginPath();
+    context.arc(circleX, y, radius, 0, Math.PI * 2);
+    context.closePath();
+    context.strokeStyle = "#4a90e2";
+    context.lineWidth = 2;
+    context.stroke();
+
+    context.fillText(String(this.onlinePlayers), circleX, y);
+  }
+}

--- a/src/game/scenes/main/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu-scene.ts
@@ -2,6 +2,7 @@ import { CloseableMessageEntity } from "../../entities/common/closeable-message-
 import { MenuOptionEntity } from "../../entities/common/menu-option-entity.js";
 import { TitleEntity } from "../../entities/common/title-entity.js";
 import { ServerMessageWindowEntity } from "../../entities/server-message-window-entity.js";
+import { OnlinePlayersEntity } from "../../entities/common/online-players-entity.js";
 import { APIService } from "../../services/network/api-service.js";
 import type { MessagesResponse } from "../../interfaces/responses/messages-response.js";
 import { BaseGameScene } from "../../../core/scenes/base-game-scene.js";
@@ -23,7 +24,7 @@ export class MainMenuScene extends BaseGameScene {
 
   private serverMessageWindowEntity: ServerMessageWindowEntity | null = null;
   private closeableMessageEntity: CloseableMessageEntity | null = null;
-  private onlinePlayers: number = 0;
+  private onlinePlayersEntity: OnlinePlayersEntity | null = null;
 
   constructor(
     gameState: GameState,
@@ -41,6 +42,7 @@ export class MainMenuScene extends BaseGameScene {
     this.loadMenuOptionEntities();
     this.loadServerMessageWindow();
     this.loadCloseableMessageEntity();
+    this.loadOnlinePlayersEntity();
 
     super.load();
   }
@@ -107,6 +109,11 @@ export class MainMenuScene extends BaseGameScene {
   private loadCloseableMessageEntity(): void {
     this.closeableMessageEntity = new CloseableMessageEntity(this.canvas);
     this.uiEntities.push(this.closeableMessageEntity);
+  }
+
+  private loadOnlinePlayersEntity(): void {
+    this.onlinePlayersEntity = new OnlinePlayersEntity(this.canvas);
+    this.uiEntities.push(this.onlinePlayersEntity);
   }
 
   private loadServerMessageWindow(): void {
@@ -279,18 +286,10 @@ export class MainMenuScene extends BaseGameScene {
       this.canvas.height - 100
     );
 
-    this.showTotalOnlinePlayers(context);
   }
 
   private handleOnlinePlayersEvent(payload: OnlinePlayersPayload): void {
-    this.onlinePlayers = payload.total;
+    this.onlinePlayersEntity?.setOnlinePlayers(payload.total);
   }
 
-  private showTotalOnlinePlayers(context: CanvasRenderingContext2D): void {
-    const text = `${this.onlinePlayers} ONLINE PLAYERS`;
-    context.font = "bold 20px system-ui";
-    context.fillStyle = "#4a90e2";
-    context.textAlign = "center";
-    context.fillText(text, this.canvas.width / 2, this.canvas.height - 40);
-  }
 }


### PR DESCRIPTION
## Summary
- display "ONLINE PLAYERS" label
- draw the online player count inside a circle next to the label using new `OnlinePlayersEntity`
- integrate the entity into `MainMenuScene`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aabc797b883279d9510a8fb7f0e5a