### PR TITLE
Add main menu factory and controller

### DIFF
--- a/src/game/scenes/main/main-menu-controller.ts
+++ b/src/game/scenes/main/main-menu-controller.ts
@@ -1,0 +1,10 @@
+import { APIService } from "../../services/network/api-service.js";
+import type { MessagesResponse } from "../../interfaces/responses/messages-response.js";
+
+export class MainMenuController {
+  constructor(private readonly apiService: APIService) {}
+
+  public async fetchServerMessages(): Promise<MessagesResponse[]> {
+    return this.apiService.getMessages();
+  }
+}

--- a/src/game/scenes/main/main-menu-entity-factory.ts
+++ b/src/game/scenes/main/main-menu-entity-factory.ts
@@ -1,0 +1,47 @@
+import { TitleEntity } from "../../entities/common/title-entity.js";
+import { MenuOptionEntity } from "../../entities/common/menu-option-entity.js";
+import { ServerMessageWindowEntity } from "../../entities/server-message-window-entity.js";
+import { CloseableMessageEntity } from "../../entities/common/closeable-message-entity.js";
+import { OnlinePlayersEntity } from "../../entities/online-players-entity.js";
+
+export interface MainMenuEntities {
+  titleEntity: TitleEntity;
+  menuOptionEntities: MenuOptionEntity[];
+  serverMessageWindowEntity: ServerMessageWindowEntity;
+  closeableMessageEntity: CloseableMessageEntity;
+  onlinePlayersEntity: OnlinePlayersEntity;
+}
+
+export class MainMenuEntityFactory {
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly menuOptionsText: string[]
+  ) {}
+
+  public createEntities(): MainMenuEntities {
+    const titleEntity = new TitleEntity();
+    titleEntity.setText("MAIN MENU");
+
+    const menuOptionEntities: MenuOptionEntity[] = [];
+    let y = 100;
+    for (let i = 0; i < this.menuOptionsText.length; i++) {
+      const text = this.menuOptionsText[i];
+      const menuOptionEntity = new MenuOptionEntity(this.canvas, i, text);
+      menuOptionEntity.setPosition(30, y);
+      menuOptionEntities.push(menuOptionEntity);
+      y += menuOptionEntity.getHeight() + 30;
+    }
+
+    const serverMessageWindowEntity = new ServerMessageWindowEntity(this.canvas);
+    const closeableMessageEntity = new CloseableMessageEntity(this.canvas);
+    const onlinePlayersEntity = new OnlinePlayersEntity(this.canvas);
+
+    return {
+      titleEntity,
+      menuOptionEntities,
+      serverMessageWindowEntity,
+      closeableMessageEntity,
+      onlinePlayersEntity,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- create entity factory and controller for main menu
- use new factory and controller in the scene
- ensure online players display is created through the factory

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ab0ee597083278aeb7e976778cc22