### PR TITLE
Fix online players label visibility

### DIFF
--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -24,7 +24,7 @@ export class OnlinePlayersEntity extends BaseMoveableGameEntity {
     const labelX = this.canvas.width / 2;
 
     context.font = "bold 20px system-ui";
-    context.fillStyle = "#4a90e2";
+    context.fillStyle = "#ffffff";
     context.textAlign = "center";
     context.textBaseline = "middle";
 


### PR DESCRIPTION
## Summary
- make online player count and label white to stand out on menu

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686ac13771088327b45b37fee41b1d97