### PR TITLE
Implement animated online players entity

### DIFF
--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -1,80 +1,66 @@
-import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
+import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
 
-export class OnlinePlayersEntity extends BaseMoveableGameEntity {
+export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
+  private readonly TEXT = "ONLINE PLAYERS";
   private onlinePlayers = 0;
-  private readonly LABEL = "ONLINE PLAYERS";
-  private readonly RECT_CORNER_RADIUS: number = 6;
+
+  private baseX: number;
+  private baseY: number;
+
+  private shakeDuration = 0;
+  private shakeElapsed = 0;
+  private readonly shakeMagnitude = 4;
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();
-    this.x = this.canvas.width / 2;
-    this.y = this.canvas.height - 40;
-    this.width = 0;
-    this.height = 0;
+    this.baseX = this.canvas.width / 2;
+    this.baseY = this.canvas.height - 40;
+    this.x = this.baseX;
+    this.y = this.baseY;
   }
 
   public setOnlinePlayers(total: number): void {
-    this.onlinePlayers = total;
+    if (this.onlinePlayers !== total) {
+      this.onlinePlayers = total;
+      this.startShake();
+    } else {
+      this.onlinePlayers = total;
+    }
+  }
+
+  private startShake(): void {
+    this.shakeDuration = 500; // milliseconds
+    this.shakeElapsed = 0;
+  }
+
+  public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    if (this.shakeElapsed < this.shakeDuration) {
+      this.shakeElapsed += deltaTimeStamp;
+      const progress =
+        (this.shakeDuration - this.shakeElapsed) / this.shakeDuration;
+      const offsetX = (Math.random() * 2 - 1) * this.shakeMagnitude * progress;
+      const offsetY = (Math.random() * 2 - 1) * this.shakeMagnitude * progress;
+      this.x = this.baseX + offsetX;
+      this.y = this.baseY + offsetY;
+    } else {
+      this.x = this.baseX;
+      this.y = this.baseY;
+    }
+
+    super.update(deltaTimeStamp);
   }
 
   public override render(context: CanvasRenderingContext2D): void {
     context.save();
-
-    const y = this.canvas.height - 40;
-    const labelX = this.canvas.width / 2;
+    this.applyOpacity(context);
 
     context.font = "bold 20px system-ui";
     context.fillStyle = "#ffffff";
     context.textAlign = "center";
     context.textBaseline = "middle";
 
-    context.fillText(this.LABEL, labelX, y);
-
-    const labelMetrics = context.measureText(this.LABEL);
-    const padding = 10;
-    const playersText = String(this.onlinePlayers);
-    const textWidth = context.measureText(playersText).width;
-    const rectPadding = 6;
-    const rectHeight = 24;
-    const rectWidth = textWidth + rectPadding * 2;
-    const rectX = labelX + labelMetrics.width / 2 + padding + rectWidth / 2;
-
-    this.width = labelMetrics.width + padding + rectWidth;
-    this.height = rectHeight;
-    this.x = labelX - labelMetrics.width / 2 + this.width / 2;
-    this.y = y;
-
-    this.roundedRect(
-      context,
-      rectX - rectWidth / 2,
-      y - rectHeight / 2,
-      rectWidth,
-      rectHeight,
-      this.RECT_CORNER_RADIUS
-    );
-    context.strokeStyle = "#4a90e2";
-    context.lineWidth = 2;
-    context.stroke();
-
-    context.fillText(playersText, rectX, y);
+    context.fillText(`${this.TEXT} (${this.onlinePlayers})`, this.x, this.y);
 
     context.restore();
-  }
-
-  private roundedRect(
-    ctx: CanvasRenderingContext2D,
-    x: number,
-    y: number,
-    width: number,
-    height: number,
-    radius: number
-  ) {
-    ctx.beginPath();
-    ctx.moveTo(x + radius, y);
-    ctx.arcTo(x + width, y, x + width, y + height, radius);
-    ctx.arcTo(x + width, y + height, x, y + height, radius);
-    ctx.arcTo(x, y + height, x, y, radius);
-    ctx.arcTo(x, y, x + width, y, radius);
-    ctx.closePath();
   }
 }


### PR DESCRIPTION
## Summary
- replace OnlinePlayersEntity with animated version
- display `ONLINE PLAYERS (0)` centered at bottom of canvas
- shake the text whenever the count changes
- run project build to ensure compilation

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ac50543ec83278105017bfa51b687