### PR TITLE
Fix context leak hiding online players entity

### DIFF
--- a/src/game/entities/common/closeable-message-entity.ts
+++ b/src/game/entities/common/closeable-message-entity.ts
@@ -45,10 +45,11 @@ export class CloseableMessageEntity extends BaseTappableGameEntity {
   }
 
   public render(context: CanvasRenderingContext2D): void {
+    context.save();
     this.applyOpacity(context);
     this.drawRoundedRectangle(context);
     this.drawText(context);
-    this.applyOpacity(context);
+    context.restore();
 
     super.render(context);
   }


### PR DESCRIPTION
## Summary
- fix `CloseableMessageEntity` render method so it restores the canvas context

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ac6dfb80c8327a564657e55bd2f08