### PR TITLE
Fix canvas context leak in main menu

### DIFF
--- a/src/game/scenes/main/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu-scene.ts
@@ -255,6 +255,7 @@ export class MainMenuScene extends BaseGameScene {
     const playerName = this.gameState.getGamePlayer()?.getName() || "Unknown";
 
     // Draw text that says Hello
+    context.save();
     context.font = "bold 28px system-ui";
     context.fillStyle = "white";
     context.textAlign = "center";
@@ -272,6 +273,7 @@ export class MainMenuScene extends BaseGameScene {
       this.canvas.width / 2,
       this.canvas.height - 100
     );
+    context.restore();
 
   }
 


### PR DESCRIPTION
## Summary
- prevent canvas state leakage from `showWelcomePlayerName`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ac8b2ed948327a5b64233ff9861b7