### PR TITLE
Improve online players indicator

### DIFF
--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -1,7 +1,8 @@
 import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
 
 export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
-  private readonly TEXT = "ONLINE PLAYERS";
+  // Display text that will be followed by a badge containing the number
+  private readonly TEXT = "PLAYERS ONLINE";
   private onlinePlayers = 0;
 
   private baseX: number;
@@ -54,12 +55,37 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     context.save();
     this.applyOpacity(context);
 
+    // Style for label text
     context.font = "bold 20px system-ui";
     context.fillStyle = "#ffffff";
-    context.textAlign = "center";
     context.textBaseline = "middle";
 
-    context.fillText(`${this.TEXT} (${this.onlinePlayers})`, this.x, this.y);
+    const textWidth = context.measureText(this.TEXT).width;
+    const badgeRadius = 14;
+    const spacing = 10;
+    const totalWidth = textWidth + spacing + badgeRadius * 2;
+    const startX = this.x - totalWidth / 2;
+
+    // Draw the label text aligned to the left so we can position the badge
+    context.textAlign = "left";
+    context.fillText(this.TEXT, startX, this.y);
+
+    const badgeX = startX + textWidth + spacing + badgeRadius;
+
+    // Draw badge background with a subtle shadow
+    context.shadowColor = "black";
+    context.shadowBlur = 4;
+    context.fillStyle = "#7ed321";
+    context.beginPath();
+    context.arc(badgeX, this.y, badgeRadius, 0, Math.PI * 2);
+    context.fill();
+
+    // Draw the number in the badge
+    context.shadowBlur = 0;
+    context.fillStyle = "#000000";
+    context.font = "bold 16px system-ui";
+    context.textAlign = "center";
+    context.fillText(this.onlinePlayers.toString(), badgeX, this.y);
 
     context.restore();
   }


### PR DESCRIPTION
## Summary
- freshen online player label
- move count into a colored badge for a stylish look

## Testing
- `npm run build`
- `npx eslint .` *(fails: Cannot find package 'globals' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_686ac9157228832787ac84db383c3d4e