### PR TITLE
Update online players badge layout and button width

### DIFF
--- a/src/game/entities/common/button-entity.ts
+++ b/src/game/entities/common/button-entity.ts
@@ -32,7 +32,14 @@ export class ButtonEntity extends BaseTappableGameEntity {
   }
 
   private setSize(canvas: HTMLCanvasElement): void {
-    this.width = canvas.getContext("2d")?.measureText(this.text).width || 0;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.font = "bold 28px system-ui";
+      this.width = ctx.measureText(this.text).width;
+    } else {
+      this.width = 0;
+    }
+
     this.width *= 3;
     this.height = 60;
   }

--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -1,9 +1,11 @@
 import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
 
 export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
-  // Display text that will be followed by a badge containing the number
-  private readonly TEXT = "PLAYERS ONLINE";
   private onlinePlayers = 0;
+
+  private getText(): string {
+    return this.onlinePlayers === 1 ? "PLAYER" : "PLAYERS";
+  }
 
   private baseX: number;
   private baseY: number;
@@ -55,37 +57,34 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     context.save();
     this.applyOpacity(context);
 
+    const labelText = this.getText();
+
     // Style for label text
     context.font = "bold 20px system-ui";
     context.fillStyle = "#ffffff";
     context.textBaseline = "middle";
+    context.textAlign = "center";
 
-    const textWidth = context.measureText(this.TEXT).width;
     const badgeRadius = 14;
     const spacing = 10;
-    const totalWidth = textWidth + spacing + badgeRadius * 2;
-    const startX = this.x - totalWidth / 2;
 
-    // Draw the label text aligned to the left so we can position the badge
-    context.textAlign = "left";
-    context.fillText(this.TEXT, startX, this.y);
+    const badgeX = this.x;
+    const badgeY = this.y - badgeRadius - spacing;
 
-    const badgeX = startX + textWidth + spacing + badgeRadius;
+    // Draw the label text centered under the badge
+    context.fillText(labelText, this.x, this.y);
 
-    // Draw badge background with a subtle shadow
-    context.shadowColor = "black";
-    context.shadowBlur = 4;
+    // Draw badge background
     context.fillStyle = "#7ed321";
     context.beginPath();
-    context.arc(badgeX, this.y, badgeRadius, 0, Math.PI * 2);
+    context.arc(badgeX, badgeY, badgeRadius, 0, Math.PI * 2);
     context.fill();
 
     // Draw the number in the badge
-    context.shadowBlur = 0;
-    context.fillStyle = "#000000";
+    context.fillStyle = "#ffffff";
     context.font = "bold 16px system-ui";
     context.textAlign = "center";
-    context.fillText(this.onlinePlayers.toString(), badgeX, this.y);
+    context.fillText(this.onlinePlayers.toString(), badgeX, badgeY);
 
     context.restore();
   }


### PR DESCRIPTION
## Summary
- update button entity to calculate width using actual font
- simplify online players badge layout and text logic

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686acbbdf0448327b696bcf81f685bd0