### PR TITLE
Introduce WelcomeMessageEntity

### DIFF
--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -60,7 +60,7 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     const labelText = this.getText();
 
     // Style for label text
-    context.font = "bold 24px system-ui";
+    context.font = "bold 28px system-ui";
     context.fillStyle = "#ffffff";
     context.textBaseline = "middle";
     context.textAlign = "left";

--- a/src/game/entities/welcome-message-entity.ts
+++ b/src/game/entities/welcome-message-entity.ts
@@ -1,0 +1,27 @@
+import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
+import type { GameState } from "../../core/models/game-state.js";
+
+export class WelcomeMessageEntity extends BaseMoveableGameEntity {
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly gameState: GameState
+  ) {
+    super();
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    const playerName = this.gameState.getGamePlayer()?.getName() || "Unknown";
+
+    context.save();
+    this.applyOpacity(context);
+    context.font = "bold 28px system-ui";
+    context.fillStyle = "white";
+    context.textAlign = "center";
+
+    context.fillText("HEY, YOU!", this.canvas.width / 2, this.canvas.height - 140);
+
+    context.fillStyle = "#7ed321";
+    context.fillText(playerName, this.canvas.width / 2, this.canvas.height - 100);
+    context.restore();
+  }
+}

--- a/src/game/scenes/main/main-menu/main-menu-entity-factory.ts
+++ b/src/game/scenes/main/main-menu/main-menu-entity-factory.ts
@@ -3,18 +3,22 @@ import { MenuOptionEntity } from "../../../entities/common/menu-option-entity.js
 import { ServerMessageWindowEntity } from "../../../entities/server-message-window-entity.js";
 import { CloseableMessageEntity } from "../../../entities/common/closeable-message-entity.js";
 import { OnlinePlayersEntity } from "../../../entities/online-players-entity.js";
+import { WelcomeMessageEntity } from "../../../entities/welcome-message-entity.js";
+import type { GameState } from "../../../../core/models/game-state.js";
 
 export interface MainMenuEntities {
   titleEntity: TitleEntity;
   menuOptionEntities: MenuOptionEntity[];
   serverMessageWindowEntity: ServerMessageWindowEntity;
   closeableMessageEntity: CloseableMessageEntity;
+  welcomeMessageEntity: WelcomeMessageEntity;
   onlinePlayersEntity: OnlinePlayersEntity;
 }
 
 export class MainMenuEntityFactory {
   constructor(
     private readonly canvas: HTMLCanvasElement,
+    private readonly gameState: GameState,
     private readonly menuOptionsText: string[]
   ) {}
 
@@ -34,6 +38,10 @@ export class MainMenuEntityFactory {
 
     const serverMessageWindowEntity = new ServerMessageWindowEntity(this.canvas);
     const closeableMessageEntity = new CloseableMessageEntity(this.canvas);
+    const welcomeMessageEntity = new WelcomeMessageEntity(
+      this.canvas,
+      this.gameState
+    );
     const onlinePlayersEntity = new OnlinePlayersEntity(this.canvas);
 
     return {
@@ -41,6 +49,7 @@ export class MainMenuEntityFactory {
       menuOptionEntities,
       serverMessageWindowEntity,
       closeableMessageEntity,
+      welcomeMessageEntity,
       onlinePlayersEntity,
     };
   }

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -44,6 +44,7 @@ export class MainMenuScene extends BaseGameScene {
   public override load(): void {
     const factory = new MainMenuEntityFactory(
       this.canvas,
+      this.gameState,
       this.MENU_OPTIONS_TEXT
     );
     this.entities = factory.createEntities();
@@ -53,6 +54,7 @@ export class MainMenuScene extends BaseGameScene {
       menuOptionEntities,
       serverMessageWindowEntity,
       closeableMessageEntity,
+      welcomeMessageEntity,
       onlinePlayersEntity,
     } = this.entities;
 
@@ -63,6 +65,7 @@ export class MainMenuScene extends BaseGameScene {
     this.uiEntities.push(
       titleEntity,
       ...menuOptionEntities,
+      welcomeMessageEntity,
       onlinePlayersEntity,
       serverMessageWindowEntity,
       closeableMessageEntity
@@ -88,9 +91,6 @@ export class MainMenuScene extends BaseGameScene {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
-    context.globalAlpha = this.opacity;
-    this.showWelcomePlayerName(context);
-    context.globalAlpha = 1;
     super.render(context);
   }
 
@@ -251,31 +251,6 @@ export class MainMenuScene extends BaseGameScene {
     });
   }
 
-  private showWelcomePlayerName(context: CanvasRenderingContext2D): void {
-    const playerName = this.gameState.getGamePlayer()?.getName() || "Unknown";
-
-    // Draw text that says Hello
-    context.save();
-    context.font = "bold 28px system-ui";
-    context.fillStyle = "white";
-    context.textAlign = "center";
-
-    context.fillText(
-      "HEY, YOU!",
-      this.canvas.width / 2,
-      this.canvas.height - 140
-    );
-
-    context.fillStyle = "#7ed321";
-
-    context.fillText(
-      `${playerName}`,
-      this.canvas.width / 2,
-      this.canvas.height - 100
-    );
-    context.restore();
-
-  }
 
   private handleOnlinePlayersEvent(payload: OnlinePlayersPayload): void {
     this.onlinePlayersEntity?.setOnlinePlayers(payload.total);


### PR DESCRIPTION
## Summary
- add a `WelcomeMessageEntity` that renders the "HEY, YOU!" greeting
- create welcome entity from `MainMenuEntityFactory`
- push welcome entity before the online players widget
- match the online players label font size with the welcome message

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ad62863448327aea3c28bf04c688b