### PR TITLE
Fix online players counter after matches

### DIFF
--- a/src/game/interfaces/services/network/websocket-service-interface.ts
+++ b/src/game/interfaces/services/network/websocket-service-interface.ts
@@ -5,4 +5,5 @@ export interface IWebSocketService {
   connectToServer(): void;
   sendMessage(arrayBuffer: ArrayBuffer): void;
   handleNotificationMessage(binaryReader: BinaryReader): void;
+  getOnlinePlayers(): number;
 }

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -16,6 +16,7 @@ import { EventConsumerService } from "../../../../core/services/gameplay/event-c
 import { MainMenuEntityFactory } from "./main-menu-entity-factory.js";
 import type { MainMenuEntities } from "./main-menu-entity-factory.js";
 import { MainMenuController } from "./main-menu-controller.js";
+import { WebSocketService } from "../../../services/network/websocket-service.js";
 
 export class MainMenuScene extends BaseGameScene {
   private MENU_OPTIONS_TEXT: string[] = ["Join game", "Scoreboard", "Settings"];
@@ -61,6 +62,9 @@ export class MainMenuScene extends BaseGameScene {
     this.serverMessageWindowEntity = serverMessageWindowEntity;
     this.closeableMessageEntity = closeableMessageEntity;
     this.onlinePlayersEntity = onlinePlayersEntity;
+
+    const total = container.get(WebSocketService).getOnlinePlayers();
+    this.onlinePlayersEntity.setOnlinePlayers(total);
 
     this.uiEntities.push(
       titleEntity,

--- a/src/game/services/network/websocket-service.ts
+++ b/src/game/services/network/websocket-service.ts
@@ -20,6 +20,8 @@ export class WebSocketService {
   private baseURL: string;
   private webSocket: WebSocket | null = null;
 
+  private onlinePlayers = 0;
+
   private eventProcessorService: EventProcessorService;
   private dispatcherService: WebSocketDispatcherService;
 
@@ -28,6 +30,10 @@ export class WebSocketService {
     this.eventProcessorService = container.get(EventProcessorService);
     this.dispatcherService = new WebSocketDispatcherService();
     this.dispatcherService.registerCommandHandlers(this);
+  }
+
+  public getOnlinePlayers(): number {
+    return this.onlinePlayers;
   }
 
   public registerCommandHandlers(instance: object): void {
@@ -93,6 +99,8 @@ export class WebSocketService {
   @ServerCommandHandler(WebSocketType.OnlinePlayers)
   public handleOnlinePlayers(binaryReader: BinaryReader) {
     const total = binaryReader.unsignedInt16();
+
+    this.onlinePlayers = total;
 
     const localEvent = new LocalEvent<OnlinePlayersPayload>(
       EventType.OnlinePlayers


### PR DESCRIPTION
## Summary
- store online player count inside `WebSocketService`
- expose `getOnlinePlayers` from the service interface
- initialize online players badge on main menu scene load

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686adcb2d49c8327bc695e25dca1ca0c