### PR TITLE
Update online players entity

### DIFF
--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -1,4 +1,5 @@
 import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
+import { LIGHT_GREEN_COLOR } from "../constants/colors-constants.js";
 
 export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
   private onlinePlayers = 0;
@@ -58,40 +59,25 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     this.applyOpacity(context);
 
     const labelText = this.getText();
+    const countText = this.onlinePlayers.toString();
 
-    // Style for label text
     context.font = "bold 28px system-ui";
-    context.fillStyle = "#ffffff";
     context.textBaseline = "middle";
     context.textAlign = "left";
 
-    const badgeRadius = 14;
     const spacing = 10;
+    const labelWidth = context.measureText(labelText).width;
+    const countWidth = context.measureText(countText).width;
+    const totalWidth = countWidth + spacing + labelWidth;
 
-    const textWidth = context.measureText(labelText).width;
-    const totalWidth = badgeRadius * 2 + spacing + textWidth;
+    const countX = this.x - totalWidth / 2;
+    const labelX = countX + countWidth + spacing;
 
-    const badgeX = this.x - totalWidth / 2 + badgeRadius;
-    const badgeY = this.y;
-    const textX = badgeX + badgeRadius + spacing;
+    context.fillStyle = LIGHT_GREEN_COLOR;
+    context.fillText(countText, countX, this.y);
 
-    // Draw the badge first followed by the label text
-    // Use the same color as the menu buttons for visual consistency
-    context.fillStyle = "#4a90e2";
-    context.beginPath();
-    context.arc(badgeX, badgeY, badgeRadius, 0, Math.PI * 2);
-    context.fill();
-
-    // Draw the label text
     context.fillStyle = "#ffffff";
-    context.fillText(labelText, textX, this.y);
-    // Draw badge number
-    
-    // Draw the number in the badge
-    context.fillStyle = "#ffffff";
-    context.font = "bold 18px system-ui";
-    context.textAlign = "center";
-    context.fillText(this.onlinePlayers.toString(), badgeX, badgeY);
+    context.fillText(labelText, labelX, this.y);
 
     context.restore();
   }


### PR DESCRIPTION
## Summary
- replace badge in online players display with light green count followed by white `ONLINE`
- use constant `LIGHT_GREEN_COLOR`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ae54b92708327b4f88dedce059bd2