### PR TITLE
Refactor spawn service management

### DIFF
--- a/src/core/models/game-state.ts
+++ b/src/core/models/game-state.ts
@@ -7,8 +7,6 @@ import { DebugSettings } from "./debug-settings.js";
 import { GameKeyboard } from "./game-keyboard.js";
 import { GameGamepad } from "./game-gamepad.js";
 import { MatchStateType } from "../../game/enums/match-state-type.js";
-import { PlayerSpawnService } from "../../game/services/gameplay/player-spawn-service.js";
-import { container } from "../services/di-container.js";
 
 export class GameState {
   private debugSettings: DebugSettings;
@@ -74,15 +72,12 @@ export class GameState {
   }
 
   public setMatch(match: Match | null): void {
-    const spawnService = container.get(PlayerSpawnService);
     if (match === null) {
-      spawnService.reset();
       this.match = null;
       console.log("Match removed from game state");
       return;
     }
 
-    spawnService.reset();
     this.match = match;
 
     if (match.isHost()) {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -35,6 +35,7 @@ import { TeamType } from "../../enums/team-type.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
 import { ConfettiEntity } from "../../entities/confetti-entity.js";
 import { WebSocketService } from "../../services/network/websocket-service.js";
+import { PlayerSpawnService } from "../../services/gameplay/player-spawn-service.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
@@ -43,6 +44,7 @@ export class WorldScene extends BaseCollidingGameScene {
   private readonly matchmakingController: MatchmakingControllerService;
   private readonly eventProcessorService: EventProcessorService;
   private readonly entityOrchestrator: EntityOrchestratorService;
+  private readonly playerSpawnService: PlayerSpawnService;
 
   private scoreboardEntity: ScoreboardEntity | null = null;
   private localCarEntity: LocalCarEntity | null = null;
@@ -68,6 +70,7 @@ export class WorldScene extends BaseCollidingGameScene {
     this.matchmakingController = container.get(MatchmakingControllerService);
     this.entityOrchestrator = container.get(EntityOrchestratorService);
     this.eventProcessorService = container.get(EventProcessorService);
+    this.playerSpawnService = container.get(PlayerSpawnService);
     this.addSyncableEntities();
     this.subscribeToEvents();
   }
@@ -154,6 +157,7 @@ export class WorldScene extends BaseCollidingGameScene {
 
     alert("Could not find or advertise match, returning to main scene menu...");
 
+    this.playerSpawnService.reset();
     this.gameState.setMatch(null);
     void this.returnToMainMenuScene();
   }

--- a/src/game/services/gameplay/matchmaking-service.ts
+++ b/src/game/services/gameplay/matchmaking-service.ts
@@ -11,6 +11,7 @@ import { IntervalManagerService } from "../../../core/services/gameplay/interval
 import { MatchFinderService } from "./match-finder-service.js";
 import { MatchmakingNetworkService } from "../network/matchmaking-network-service.js";
 import { GamePlayer } from "../../models/game-player.js";
+import { PlayerSpawnService } from "./player-spawn-service.js";
 import {
   PendingIdentitiesToken,
   ReceivedIdentitiesToken,
@@ -27,6 +28,7 @@ export class MatchmakingService implements IMatchmakingService {
   private readonly webrtcService: WebRTCService;
   private readonly matchFinderService: MatchFinderService;
   private readonly networkService: IMatchmakingNetworkService;
+  private readonly playerSpawnService: PlayerSpawnService;
 
   constructor(private gameState = container.get(GameState)) {
     container.get(TimerManagerService);
@@ -37,6 +39,7 @@ export class MatchmakingService implements IMatchmakingService {
     container.get(EventProcessorService);
     this.matchFinderService = container.get(MatchFinderService);
     this.networkService = container.get(MatchmakingNetworkService);
+    this.playerSpawnService = container.get(PlayerSpawnService);
     this.registerCommandHandlers();
   }
 
@@ -108,6 +111,7 @@ export class MatchmakingService implements IMatchmakingService {
     }
 
     this.gameState.setMatch(null);
+    this.playerSpawnService.reset();
     container.get(PendingIdentitiesToken).clear();
     container.get(ReceivedIdentitiesToken).clear();
   }

--- a/src/game/services/gameplay/player-spawn-service.ts
+++ b/src/game/services/gameplay/player-spawn-service.ts
@@ -3,14 +3,15 @@ import type { GamePlayer } from "../../models/game-player.js";
 
 @injectable()
 export class PlayerSpawnService {
-  private assignedIndexes: Map<string, number> = new Map();
+  // Tracks the indexes that are currently free to be used
   private availableIndexes: number[] = [];
+  // Next index to assign in case there are no free ones
   private nextIndex = 0;
 
   public assignSpawnIndex(player: GamePlayer, index?: number): number {
-    const id = player.getId();
-    if (this.assignedIndexes.has(id)) {
-      return this.assignedIndexes.get(id)!;
+    // If the player already has a spawn index, return it
+    if (player.getSpawnIndex() !== -1) {
+      return player.getSpawnIndex();
     }
 
     let assigned: number;
@@ -32,30 +33,28 @@ export class PlayerSpawnService {
       this.nextIndex += 1;
     }
 
-    this.assignedIndexes.set(id, assigned);
     player.setSpawnIndex(assigned);
     console.log(`Assigned spawn index ${assigned} to player ${player.getName()}`);
     return assigned;
   }
 
   public releaseSpawnIndex(player: GamePlayer): void {
-    const id = player.getId();
-    const index = this.assignedIndexes.get(id);
-    if (index === undefined) return;
+    const index = player.getSpawnIndex();
+    if (index === -1) return;
 
-    this.assignedIndexes.delete(id);
     this.availableIndexes.push(index);
+    player.setSpawnIndex(-1);
     console.log(`Released spawn index ${index} from player ${player.getName()}`);
   }
 
   public reset(): void {
-    this.assignedIndexes.clear();
     this.availableIndexes = [];
     this.nextIndex = 0;
     console.log("Player spawn indexes reset");
   }
 
   public getSpawnIndex(player: GamePlayer): number | undefined {
-    return this.assignedIndexes.get(player.getId());
+    const index = player.getSpawnIndex();
+    return index === -1 ? undefined : index;
   }
 }

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -187,6 +187,7 @@ export class MatchmakingNetworkService
       MATCH_ATTRIBUTES
     );
 
+    this.playerSpawnService.reset();
     this.gameState.setMatch(match);
 
   }
@@ -411,6 +412,7 @@ export class MatchmakingNetworkService
   private handleHostDisconnected(peer: WebRTCPeer): void {
     console.log(`Host ${peer.getName()} disconnected`);
 
+    this.playerSpawnService.reset();
     this.gameState.setMatch(null);
 
     const localEvent = new LocalEvent(EventType.HostDisconnected);


### PR DESCRIPTION
## Summary
- track only unreserved spawn indexes
- remove automatic spawn reset from `GameState`
- reset spawn indexes in networking and matchmaking services
- ensure WorldScene resets spawns on matchmaking errors

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b0ff14e5c8327a7639b9322a8bef2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in player spawn state management when matches end, matchmaking fails, or a new match is started.
  * Ensured player spawn indexes are properly reset during game over, matchmaking errors, and host disconnections for smoother gameplay transitions.

* **Refactor**
  * Simplified internal logic for managing player spawn indexes, relying on player state rather than internal mappings for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->