### PR TITLE
Fix spawn point assignment

### DIFF
--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -151,22 +151,29 @@ export class WorldController {
       this.spawnPointService.getAndConsumeSpawnPointIndex();
 
     const gamePlayer = this.gameState.getGamePlayer();
+    if (spawnPointIndex === -1) {
+      console.warn("No spawn points available for local player");
+      return;
+    }
+
     gamePlayer.setSpawnPointIndex(spawnPointIndex);
 
-    this.spawnPointEntities.forEach((spawnPoint) => {
-      if (spawnPoint.getIndex() === spawnPointIndex) {
-        const x = spawnPoint.getX();
-        const y = spawnPoint.getY();
-        this.localCarEntity.setX(x);
-        this.localCarEntity.setY(y);
-      }
-    });
+    this.updateLocalCarPosition(spawnPointIndex);
   }
 
   private moveCarToSpawnPoint(): void {
     const gamePlayer = this.gameState.getGamePlayer();
     const spawnPointIndex = gamePlayer.getSpawnPointIndex();
 
+    if (spawnPointIndex === -1) {
+      console.warn("Local player does not have a spawn point index");
+      return;
+    }
+
+    this.updateLocalCarPosition(spawnPointIndex);
+  }
+
+  private updateLocalCarPosition(spawnPointIndex: number): void {
     this.spawnPointEntities.forEach((spawnPoint) => {
       if (spawnPoint.getIndex() === spawnPointIndex) {
         const x = spawnPoint.getX();

--- a/src/game/services/gameplay/spawn-point-service.ts
+++ b/src/game/services/gameplay/spawn-point-service.ts
@@ -22,7 +22,8 @@ export class SpawnPointService {
 
   public getAndConsumeSpawnPointIndex(): number {
     if (this.availableSpawnPointIndexes.size === 0) {
-      return 0;
+      // -1 indicates that no spawn points are currently available
+      return -1;
     }
 
     const index = [...this.availableSpawnPointIndexes][0];

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -173,7 +173,11 @@ export class MatchmakingNetworkService
 
     const spawnPointIndex =
       this.spawnPointService.getAndConsumeSpawnPointIndex();
-    gamePlayer.setSpawnPointIndex(spawnPointIndex);
+    if (spawnPointIndex === -1) {
+      console.warn("No spawn points available for joining player");
+    } else {
+      gamePlayer.setSpawnPointIndex(spawnPointIndex);
+    }
 
     match.addPlayer(gamePlayer);
 


### PR DESCRIPTION
## Summary
- factor duplicate spawn point lookup into `updateLocalCarPosition`
- handle no available spawn points by returning `-1`
- guard against `-1` in world controller and matchmaking service

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bf3e7f0408327a3ee1f0a7502ec0a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no spawn points are available, preventing errors and logging appropriate warnings.
  * Ensured players are not assigned invalid spawn points during game join or respawn scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->