### PR TITLE
Handle disconnect during active match

### DIFF
--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -16,7 +16,6 @@ import { GAME_VERSION } from "../../../game/constants/game-constants.js";
 import { EventConsumerService } from "./event-consumer-service.js";
 import { DebugEntity } from "../../entities/debug-entity.js";
 import { GameState } from "../../models/game-state.js";
-import { MatchStateType } from "../../../game/enums/match-state-type.js";
 import { SceneTransitionService } from "./scene-transition-service.js";
 import { MatchmakingService } from "../../../game/services/gameplay/matchmaking-service.js";
 import { DebugService } from "../../../game/services/debug/debug-service.js";
@@ -150,14 +149,6 @@ export class GameLoopService {
   private handleServerDisconnectedEvent(
     payload: ServerDisconnectedPayload
   ): void {
-    const match = this.gameState.getMatch();
-    const state = match?.getState();
-
-    if (state !== undefined && state !== MatchStateType.WaitingPlayers) {
-      console.warn("WebSocket disconnected during active match");
-      // Wait to reconnect when returning to the main menu
-      return;
-    }
 
     if (payload.connectionLost) {
       alert("Connection to server was lost");


### PR DESCRIPTION
## Summary
- always show the disconnected alert and reload the page
  regardless of active match state
- remove match state check in server disconnect handler

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c065524e0832787f1f7022a1e3180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users are now always alerted and the page reloads immediately upon connection loss or failure, regardless of the current match state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->