### PR TITLE
Remove spawn point number overlay

### DIFF
--- a/src/game/entities/common/spawn-point-entity.ts
+++ b/src/game/entities/common/spawn-point-entity.ts
@@ -24,13 +24,6 @@ export class SpawnPointEntity extends BaseMoveableGameEntity {
       context.fill();
       context.closePath();
 
-      // Draw the index centered above the circle in white
-      context.fillStyle = "white";
-      context.font = "16px system-ui";
-      context.textAlign = "center";
-      context.textBaseline = "bottom";
-      context.fillText(`${this.index}`, this.x, this.y - radius - 4);
-
       context.restore();
     }
   }


### PR DESCRIPTION
## Summary
- remove index drawing from SpawnPointEntity

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c18a218e48327bcf48a6ebfc1a969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the display of index numbers above spawn points. The orange circle for spawn points remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->