### PR TITLE
Add car demolition on turbo collisions

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -70,6 +70,11 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   protected boost: number = this.MAX_BOOST;
   protected boosting: boolean = false;
 
+  private demolished = false;
+  private respawnTimer = 0;
+  private respawnX = 0;
+  private respawnY = 0;
+
   private carImage: HTMLImageElement | null = null;
   private imagePath = this.IMAGE_BLUE_PATH;
 
@@ -122,6 +127,21 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    if (this.demolished) {
+      this.respawnTimer -= deltaTimeStamp;
+      if (this.respawnTimer <= 0) {
+        this.demolished = false;
+        this.opacity = 1;
+        this.angle = 1.5708;
+        this.speed = 0;
+        this.x = this.respawnX;
+        this.y = this.respawnY;
+        this.updateHitbox();
+      }
+      super.update(deltaTimeStamp);
+      return;
+    }
+
     this.handleBoostPads();
 
     if (this.boosting) {
@@ -151,6 +171,9 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
+    if (this.demolished) {
+      return;
+    }
     this.renderSmokeTrail(context);
     context.save();
 
@@ -195,6 +218,34 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
 
   public isBoosting(): boolean {
     return this.boosting;
+  }
+
+  public getSpeed(): number {
+    return this.speed;
+  }
+
+  public getTopSpeed(): number {
+    return this.TOP_SPEED;
+  }
+
+  public getBoostTopSpeedMultiplier(): number {
+    return this.BOOST_TOP_SPEED_MULTIPLIER;
+  }
+
+  public demolish(respawnX: number, respawnY: number, delay: number): void {
+    this.demolished = true;
+    this.respawnTimer = delay;
+    this.respawnX = respawnX;
+    this.respawnY = respawnY;
+    this.speed = 0;
+    this.vx = 0;
+    this.vy = 0;
+    this.boosting = false;
+    this.opacity = 0;
+  }
+
+  public isDemolished(): boolean {
+    return this.demolished;
   }
 
   public activateBoost(): void {

--- a/src/game/entities/car-explosion-entity.ts
+++ b/src/game/entities/car-explosion-entity.ts
@@ -1,0 +1,72 @@
+import { BaseMoveableGameEntity } from "../../core/entities/base-moveable-game-entity.js";
+
+interface ExplosionParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  size: number;
+  color: string;
+}
+
+export class CarExplosionEntity extends BaseMoveableGameEntity {
+  private particles: ExplosionParticle[] = [];
+  private elapsed = 0;
+  private readonly duration = 1000; // ms
+
+  constructor(x: number, y: number) {
+    super();
+    this.x = x;
+    this.y = y;
+    this.createParticles();
+  }
+
+  private createParticles(): void {
+    for (let i = 0; i < 40; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 2 + Math.random() * 2;
+      const fire = i < 20;
+      this.particles.push({
+        x: this.x,
+        y: this.y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 1,
+        size: fire ? 4 + Math.random() * 2 : 6 + Math.random() * 4,
+        color: fire
+          ? `rgba(255,${100 + Math.random() * 155},0,1)`
+          : `rgba(80,80,80,1)`,
+      });
+    }
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    this.elapsed += delta;
+    this.particles.forEach((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vx *= 0.98;
+      p.vy *= 0.98;
+      p.life -= delta / this.duration;
+    });
+    this.particles = this.particles.filter((p) => p.life > 0);
+
+    if (this.elapsed >= this.duration && this.particles.length === 0) {
+      this.setRemoved(true);
+    }
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.particles.forEach((p) => {
+      context.globalAlpha = Math.max(p.life, 0);
+      context.fillStyle = p.color;
+      context.beginPath();
+      context.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      context.fill();
+    });
+    context.globalAlpha = 1;
+    context.restore();
+  }
+}

--- a/src/game/enums/event-type.ts
+++ b/src/game/enums/event-type.ts
@@ -14,4 +14,5 @@ export enum EventType {
   BoostPadConsumed,
   MatchmakingStarted,
   OnlinePlayers,
+  CarDemolished,
 }

--- a/src/game/interfaces/events/car-demolished-payload.ts
+++ b/src/game/interfaces/events/car-demolished-payload.ts
@@ -1,0 +1,4 @@
+export interface CarDemolishedPayload {
+  attackerId: string;
+  victimId: string;
+}

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -33,10 +33,15 @@ import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
 import { TeamType } from "../../enums/team-type.js";
 import { GoalExplosionEntity } from "../../entities/goal-explosion-entity.js";
 import { ConfettiEntity } from "../../entities/confetti-entity.js";
+import { CarExplosionEntity } from "../../entities/car-explosion-entity.js";
 import { WebSocketService } from "../../services/network/websocket-service.js";
+import { BinaryWriter } from "../../../core/utils/binary-writer-utils.js";
+import { RemoteEvent } from "../../../core/models/remote-event.js";
 import type { SpawnPointEntity } from "../../entities/common/spawn-point-entity.js";
 import { SpawnPointService } from "../../services/gameplay/spawn-point-service.js";
 import type { IMatchmakingService } from "../../interfaces/services/gameplay/matchmaking-service-interface.js";
+import type { GamePlayer } from "../../models/game-player.js";
+import type { CarDemolishedPayload } from "../../interfaces/events/car-demolished-payload.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
@@ -157,6 +162,8 @@ export class WorldScene extends BaseCollidingGameScene {
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
     super.update(deltaTimeStamp);
 
+    this.handleCarDemolitions();
+
     this.worldController?.handleMatchState();
     this.scoreManagerService?.detectScoresIfHost();
 
@@ -272,6 +279,11 @@ export class WorldScene extends BaseCollidingGameScene {
       EventType.BoostPadConsumed,
       (data: ArrayBuffer | null) => this.handleRemoteBoostPadConsumed(data)
     );
+
+    this.subscribeToRemoteEvent(
+      EventType.CarDemolished,
+      (data: ArrayBuffer | null) => this.handleRemoteCarDemolished(data)
+    );
   }
 
   private handleWaitingForPlayers(): void {
@@ -312,11 +324,132 @@ export class WorldScene extends BaseCollidingGameScene {
     }
   }
 
+  private handleRemoteCarDemolished(data: ArrayBuffer | null): void {
+    if (data === null) {
+      console.warn("Array buffer is null");
+      return;
+    }
+
+    if (this.gameState.getMatch()?.isHost()) {
+      console.warn("Host should not receive car demolished event");
+      return;
+    }
+
+    const binaryReader = BinaryReader.fromArrayBuffer(data);
+    const payload: CarDemolishedPayload = {
+      attackerId: binaryReader.fixedLengthString(32),
+      victimId: binaryReader.fixedLengthString(32),
+    };
+
+    const attacker =
+      this.gameState.getMatch()?.getPlayer(payload.attackerId) ?? null;
+    const victim = this.gameState.getMatch()?.getPlayer(payload.victimId) ?? null;
+
+    if (!victim) {
+      console.warn(`Cannot find victim with id ${payload.victimId}`);
+      return;
+    }
+
+    const victimCar = this.getEntitiesByOwner(victim).find(
+      (e): e is CarEntity => e instanceof CarEntity
+    );
+
+    if (!victimCar) {
+      console.warn(`Cannot find car for victim ${payload.victimId}`);
+      return;
+    }
+
+    const spawn = this.getSpawnPoint(victim);
+    if (spawn) {
+      victimCar.demolish(spawn.x, spawn.y, 3000);
+    }
+    this.triggerCarExplosion(victimCar.getX(), victimCar.getY());
+
+    const attackerName = attacker?.getName() ?? "Unknown";
+    const victimName = victim.getName();
+    this.alertEntity?.show([attackerName, "💣", victimName], "white", 2);
+  }
+
   private triggerGoalExplosion(x: number, y: number, team: TeamType): void {
     const explosion = new GoalExplosionEntity(this.canvas, x, y, team);
     this.addEntityToSceneLayer(explosion);
     // Make the shake last a bit longer for added impact
     this.cameraService.shake(3, 8);
+  }
+
+  private triggerCarExplosion(x: number, y: number): void {
+    const explosion = new CarExplosionEntity(x, y);
+    this.addEntityToSceneLayer(explosion);
+    this.cameraService.shake(1, 5);
+  }
+
+  private handleCarDemolitions(): void {
+    if (!this.gameState.getMatch()?.isHost()) {
+      return;
+    }
+
+    const cars = this.worldEntities.filter(
+      (e): e is CarEntity => e instanceof CarEntity
+    );
+
+    cars.forEach((car) => {
+      car
+        .getCollidingEntities()
+        .forEach((other) => {
+          if (!(other instanceof CarEntity)) {
+            return;
+          }
+
+          if (car.isDemolished() || other.isDemolished()) {
+            return;
+          }
+
+          const carAtMax =
+            car.isBoosting() &&
+            car.getSpeed() >=
+              car.getTopSpeed() * car.getBoostTopSpeedMultiplier();
+
+          if (carAtMax) {
+            const victim = other;
+            const attacker = car;
+            const spawn = this.getSpawnPoint(victim.getPlayer());
+            if (spawn) {
+              victim.demolish(spawn.x, spawn.y, 3000);
+            }
+            this.triggerCarExplosion(victim.getX(), victim.getY());
+
+            const attackerName = attacker.getPlayer()?.getName() ?? "Unknown";
+            const victimName = victim.getPlayer()?.getName() ?? "Unknown";
+            this.alertEntity?.show([attackerName, "💣", victimName], "white", 2);
+
+            const attackerPlayer = attacker.getPlayer();
+            const victimPlayer = victim.getPlayer();
+            if (attackerPlayer && victimPlayer) {
+              const payload = BinaryWriter.build()
+                .fixedLengthString(attackerPlayer.getId(), 32)
+                .fixedLengthString(victimPlayer.getId(), 32)
+                .toArrayBuffer();
+
+              const event = new RemoteEvent(EventType.CarDemolished);
+              event.setData(payload);
+              this.eventProcessorService.sendEvent(event);
+            }
+          }
+        });
+    });
+  }
+
+  private getSpawnPoint(player: GamePlayer | null): { x: number; y: number } | null {
+    if (!player) {
+      return null;
+    }
+
+    const index = player.getSpawnPointIndex();
+    const spawn = this.spawnPointEntities.find((s) => s.getIndex() === index);
+    if (!spawn) {
+      return null;
+    }
+    return { x: spawn.getX(), y: spawn.getY() };
   }
 
   private handleGameOverEffect(won: boolean): void {


### PR DESCRIPTION
## Summary
- trigger demolitions when cars collide at max turbo
- add explosion animation for demolished cars
- respawn demolished cars after delay and show alert
- use alert entity instead of toast for demolition message
- broadcast demolition events so other players see victim explode

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68702d87fee88327872ee1f69727de59