### PR TITLE
Refactor car demolition

### DIFF
--- a/src/game/entities/alert-entity.ts
+++ b/src/game/entities/alert-entity.ts
@@ -11,6 +11,7 @@ export class AlertEntity
   implements MultiplayerGameEntity
 {
   private textLines: string[] = ["Unknown", "message"];
+  private lineColors: string[] = [];
   private color: string = "white";
   private fontSize: number = 44;
 
@@ -22,18 +23,28 @@ export class AlertEntity
   }
 
   public show(textLines: string[], color = "white", duration = 0): void {
+    this.showColored(textLines, textLines.map(() => color), duration);
+  }
+
+  public showColored(
+    textLines: string[],
+    colors: string[],
+    duration = 0
+  ): void {
     if (this.timer !== null) {
       this.timer.stop(false);
     }
 
     this.textLines = textLines;
+    this.lineColors = colors;
 
-    if (color === "blue") {
+    const baseColor = colors[0] ?? "white";
+    if (baseColor === "blue") {
       this.color = BLUE_TEAM_COLOR;
-    } else if (color === "red") {
+    } else if (baseColor === "red") {
       this.color = RED_TEAM_COLOR;
     } else {
-      this.color = color;
+      this.color = baseColor;
     }
 
     if (textLines.length === 1) {
@@ -97,6 +108,8 @@ export class AlertEntity
 
     this.textLines.forEach((line, index) => {
       const yPosition = startY + index * lineHeight;
+      const color = this.resolveColor(this.lineColors[index] ?? this.color);
+      context.fillStyle = color;
       this.drawText(context, line, this.x, yPosition);
     });
   }
@@ -109,6 +122,15 @@ export class AlertEntity
   ): void {
     // Draw filled text with shadow applied
     context.fillText(text, x, y);
+  }
+
+  private resolveColor(color: string): string {
+    if (color === "blue") {
+      return BLUE_TEAM_COLOR;
+    } else if (color === "red") {
+      return RED_TEAM_COLOR;
+    }
+    return color;
   }
 
   private setInitialValues() {


### PR DESCRIPTION
## Summary
- add per-line color support to `AlertEntity`
- move car demolition and remote demolition handling to `WorldController`
- delegate demolition logic from `WorldScene` to controller
- color attacker blue and victim red using scoreboard colors

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870389c1fc08327919dc91e3965aa5f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts can now display multi-line messages with different colors for each line.
  * Car demolition events in multiplayer games now show colored alerts indicating the attacker and victim, with visual explosion effects.

* **Refactor**
  * Car demolition handling and remote event processing have been moved from the scene to the controller for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->