### PR TITLE
Fix color & speed checks for demolitions

### DIFF
--- a/src/game/entities/alert-entity.ts
+++ b/src/game/entities/alert-entity.ts
@@ -31,6 +31,11 @@ export class AlertEntity
     colors: string[],
     duration = 0
   ): void {
+    if (textLines.length !== colors.length) {
+      throw new Error(
+        `AlertEntity.showColored: textLines length (${textLines.length}) does not match colors length (${colors.length})`
+      );
+    }
     if (this.timer !== null) {
       this.timer.stop(false);
     }

--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -236,9 +236,11 @@ export class WorldController {
 
     const attackerName = attacker?.getName() ?? "Unknown";
     const victimName = victim.getName();
+    const attackerColor = this.getPlayerColor(attacker);
+    const victimColor = this.getPlayerColor(victim);
     this.alertEntity.showColored(
       [attackerName, "\uD83D\uDCA3", victimName],
-      ["blue", "white", "red"],
+      [attackerColor, "white", victimColor],
       2
     );
   }
@@ -265,10 +267,11 @@ export class WorldController {
           return;
         }
 
+        const maxSpeed =
+          car.getTopSpeed() * car.getBoostTopSpeedMultiplier();
+        const EPSILON = 0.001;
         const carAtMax =
-          car.isBoosting() &&
-          car.getSpeed() >=
-            car.getTopSpeed() * car.getBoostTopSpeedMultiplier();
+          car.isBoosting() && car.getSpeed() >= maxSpeed - EPSILON;
 
         if (carAtMax) {
           const victim = other;
@@ -281,9 +284,11 @@ export class WorldController {
 
           const attackerName = attacker.getPlayer()?.getName() ?? "Unknown";
           const victimName = victim.getPlayer()?.getName() ?? "Unknown";
+          const attackerColor = this.getPlayerColor(attacker.getPlayer());
+          const victimColor = this.getPlayerColor(victim.getPlayer());
           this.alertEntity.showColored(
             [attackerName, "\uD83D\uDCA3", victimName],
-            ["blue", "white", "red"],
+            [attackerColor, "white", victimColor],
             2
           );
 
@@ -315,5 +320,13 @@ export class WorldController {
       return null;
     }
     return { x: spawn.getX(), y: spawn.getY() };
+  }
+
+  private getPlayerColor(player: GamePlayer | null): string {
+    if (!player) {
+      return "white";
+    }
+
+    return player === this.gameState.getGamePlayer() ? "blue" : "red";
   }
 }


### PR DESCRIPTION
## Summary
- validate text and color lengths in `AlertEntity.showColored`
- use team colors when showing demolition alerts
- add EPSILON threshold for max speed check

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703e6d4358832792239922f89b1edf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent mismatched text and color arrays in alerts, ensuring more reliable alert displays.

* **Refactor**
  * Improved color assignment for demolition alerts, dynamically setting player colors based on context.
  * Enhanced speed comparison logic for car demolitions to account for minor floating-point differences, increasing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->