### PR TITLE
Improve car demolition visuals

### DIFF
--- a/src/game/entities/car-explosion-entity.ts
+++ b/src/game/entities/car-explosion-entity.ts
@@ -10,16 +10,32 @@ interface ExplosionParticle {
   color: string;
 }
 
+interface DebrisParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  angle: number;
+  spin: number;
+  life: number;
+  size: number;
+}
+
 export class CarExplosionEntity extends BaseMoveableGameEntity {
   private particles: ExplosionParticle[] = [];
+  private debris: DebrisParticle[] = [];
   private elapsed = 0;
-  private readonly duration = 1000; // ms
+  private readonly duration = 1200; // ms
+  private shockwaveRadius = 0;
+  private shockwaveOpacity = 1;
+  private readonly shockwaveMaxRadius = 60;
 
   constructor(x: number, y: number) {
     super();
     this.x = x;
     this.y = y;
     this.createParticles();
+    this.createDebris();
   }
 
   private createParticles(): void {
@@ -41,8 +57,29 @@ export class CarExplosionEntity extends BaseMoveableGameEntity {
     }
   }
 
+  private createDebris(): void {
+    for (let i = 0; i < 8; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 1 + Math.random() * 1.5;
+      this.debris.push({
+        x: this.x,
+        y: this.y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        angle: Math.random() * Math.PI * 2,
+        spin: (Math.random() - 0.5) * 0.2,
+        life: 1,
+        size: 6 + Math.random() * 6,
+      });
+    }
+  }
+
   public override update(delta: DOMHighResTimeStamp): void {
     this.elapsed += delta;
+    const t = Math.min(this.elapsed / this.duration, 1);
+    this.shockwaveRadius = this.shockwaveMaxRadius * t;
+    this.shockwaveOpacity = 1 - t;
+
     this.particles.forEach((p) => {
       p.x += p.vx;
       p.y += p.vy;
@@ -52,13 +89,36 @@ export class CarExplosionEntity extends BaseMoveableGameEntity {
     });
     this.particles = this.particles.filter((p) => p.life > 0);
 
-    if (this.elapsed >= this.duration && this.particles.length === 0) {
+    this.debris.forEach((d) => {
+      d.x += d.vx;
+      d.y += d.vy;
+      d.vx *= 0.97;
+      d.vy *= 0.97;
+      d.angle += d.spin;
+      d.life -= delta / this.duration;
+    });
+    this.debris = this.debris.filter((d) => d.life > 0);
+
+    if (
+      this.elapsed >= this.duration &&
+      this.particles.length === 0 &&
+      this.debris.length === 0
+    ) {
       this.setRemoved(true);
     }
   }
 
   public override render(context: CanvasRenderingContext2D): void {
     context.save();
+
+    if (this.shockwaveOpacity > 0) {
+      context.strokeStyle = `rgba(255,255,255,${this.shockwaveOpacity})`;
+      context.lineWidth = 2;
+      context.beginPath();
+      context.arc(this.x, this.y, this.shockwaveRadius, 0, Math.PI * 2);
+      context.stroke();
+    }
+
     this.particles.forEach((p) => {
       context.globalAlpha = Math.max(p.life, 0);
       context.fillStyle = p.color;
@@ -66,6 +126,17 @@ export class CarExplosionEntity extends BaseMoveableGameEntity {
       context.arc(p.x, p.y, p.size, 0, Math.PI * 2);
       context.fill();
     });
+
+    this.debris.forEach((d) => {
+      context.save();
+      context.translate(d.x, d.y);
+      context.rotate(d.angle);
+      context.globalAlpha = Math.max(d.life, 0);
+      context.fillStyle = "#888";
+      context.fillRect(-d.size / 2, -d.size / 4, d.size, d.size / 2);
+      context.restore();
+    });
+
     context.globalAlpha = 1;
     context.restore();
   }


### PR DESCRIPTION
## Summary
- add debris particles and shockwave to car explosions
- tweak explosion duration

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687041e8e40c83278d559d71eb690878