### PR TITLE
Adjust boost pad pulse to 80%

### DIFF
--- a/src/game/entities/boost-pad-entity.ts
+++ b/src/game/entities/boost-pad-entity.ts
@@ -100,7 +100,7 @@ export class BoostPadEntity extends BaseStaticCollidingGameEntity {
 
     if (this.active) {
       const pulse = (Math.sin(this.glowTimer / 200) + 1) / 2;
-      const radius = this.RADIUS * (0.9 + 0.1 * pulse);
+      const radius = this.RADIUS * (0.8 + 0.2 * pulse);
       const gradient = context.createRadialGradient(
         this.x,
         this.y,
@@ -120,7 +120,7 @@ export class BoostPadEntity extends BaseStaticCollidingGameEntity {
       context.closePath();
     } else {
       const ratio = 1 - this.cooldownRemaining / PAD_COOLDOWN_MS;
-      const radius = this.RADIUS * 0.9;
+      const radius = this.RADIUS * 0.8;
       context.fillStyle = `rgba(100,100,100,${0.3 + 0.7 * ratio})`;
       context.beginPath();
       context.arc(this.x, this.y, radius, 0, Math.PI * 2);


### PR DESCRIPTION
## Summary
- make boost pad pulse down to 80% size

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68704c830d8c8327a04b92d0d4742709