### PR TITLE
Fix boost pad layer order

### DIFF
--- a/src/game/scenes/world/world-entity-factory.ts
+++ b/src/game/scenes/world/world-entity-factory.ts
@@ -68,9 +68,9 @@ export class WorldEntityFactory {
       scoreboardEntity,
       ballEntity,
       goalEntity,
+      ...boostPadsEntities,
       localCarEntity,
       toastEntity,
-      ...boostPadsEntities,
       ...spawnPointEntities
     );
 


### PR DESCRIPTION
## Summary
- put Boost Pads in the world layer before the LocalCar so the pads render below the car

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68704e97de4c8327b17171ae7624b581