### PR TITLE
Enable bouncing for dynamic entities

### DIFF
--- a/src/core/entities/base-dynamic-colliding-game-entity.ts
+++ b/src/core/entities/base-dynamic-colliding-game-entity.ts
@@ -14,6 +14,7 @@ export class BaseDynamicCollidingGameEntity extends BaseStaticCollidingGameEntit
   protected vx: number = 0;
   protected vy: number = 0;
   protected mass: number = 0;
+  protected bounciness: number = 1;
 
   public override isDynamic(): boolean {
     return true;
@@ -41,6 +42,14 @@ export class BaseDynamicCollidingGameEntity extends BaseStaticCollidingGameEntit
 
   public getMass(): number {
     return this.mass;
+  }
+
+  public getBounciness(): number {
+    return this.bounciness;
+  }
+
+  public setBounciness(bounciness: number): void {
+    this.bounciness = bounciness;
   }
 
   public render(context: CanvasRenderingContext2D): void {

--- a/src/core/scenes/base-colliding-game-scene.ts
+++ b/src/core/scenes/base-colliding-game-scene.ts
@@ -133,8 +133,9 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
   private simulateCollisionBetweenDynamicAndStaticEntities(
     dynamicCollidingEntity: BaseDynamicCollidingGameEntity
   ) {
-    let vx = -dynamicCollidingEntity.getVX();
-    let vy = -dynamicCollidingEntity.getVY();
+    const restitution = dynamicCollidingEntity.getBounciness();
+    let vx = -dynamicCollidingEntity.getVX() * restitution;
+    let vy = -dynamicCollidingEntity.getVY() * restitution;
 
     // Impulse to avoid becoming stuck
     if (vx > -1 && vx < 1) {
@@ -221,9 +222,13 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
       return;
     }
 
-    // Calculate impulse
+    // Calculate impulse with restitution
+    const restitution = Math.min(
+      dynamicCollidingEntity.getBounciness(),
+      otherDynamicCollidingEntity.getBounciness()
+    );
     const impulse =
-      (2 * speed) /
+      ((1 + restitution) * speed) /
       (dynamicCollidingEntity.getMass() +
         otherDynamicCollidingEntity.getMass());
 

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -35,6 +35,7 @@ export class BallEntity
     this.x = x;
     this.y = y;
     this.mass = this.MASS;
+    this.setBounciness(0.8);
     this.setSyncableValues();
   }
 

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -85,6 +85,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     this.y = y;
     this.angle = angle;
     this.mass = this.MASS;
+    this.setBounciness(0.5);
 
     if (remote) {
       this.imagePath = this.IMAGE_RED_PATH;


### PR DESCRIPTION
## Summary
- make dynamic entities store a `bounciness` factor
- use restitution when colliding
- assign bounciness to ball and car entities

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870597b069883278efc84f33b8963ae