### PR TITLE
Add Chat inspector debug window

### DIFF
--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -16,6 +16,7 @@ import {
 import { CredentialService } from "../../game/services/security/credential-service.js";
 import { CameraService } from "./gameplay/camera-service.js";
 import { SpawnPointService } from "../../game/services/gameplay/spawn-point-service.js";
+import { ChatService } from "../../game/services/network/chat-service.js";
 
 export class ServiceRegistry {
   public static register(canvas: HTMLCanvasElement, debugging: boolean): void {
@@ -49,6 +50,7 @@ export class ServiceRegistry {
       useClass: EntityOrchestratorService,
     });
     container.bind({ provide: WebRTCService, useClass: WebRTCService });
+    container.bind({ provide: ChatService, useClass: ChatService });
     container.bind({ provide: CameraService, useClass: CameraService });
     container.bind({ provide: SpawnPointService, useClass: SpawnPointService });
     container.bind({

--- a/src/game/debug/chat-inspector-window.ts
+++ b/src/game/debug/chat-inspector-window.ts
@@ -1,0 +1,34 @@
+import { ImGui, ImVec2 } from "@mori2003/jsimgui";
+import { BaseWindow } from "../../core/debug/base-window.js";
+import { ChatService } from "../services/network/chat-service.js";
+import { container } from "../../core/services/di-container.js";
+import { injectable } from "@needle-di/core";
+
+@injectable()
+export class ChatInspectorWindow extends BaseWindow {
+  private readonly chatService: ChatService;
+  private inputText: string = "";
+
+  constructor() {
+    super("Chat inspector", new ImVec2(300, 250));
+    this.chatService = container.get(ChatService);
+  }
+
+  protected override renderContent(): void {
+    const messages = this.chatService.getMessages();
+
+    ImGui.BeginChild("ChatLog", new ImVec2(0, -40), true);
+    messages.forEach((msg) => ImGui.TextWrapped(msg));
+    ImGui.EndChild();
+
+    const inputRef = [this.inputText];
+    if (ImGui.InputText("##chatInput", inputRef, 256)) {
+      this.inputText = inputRef[0];
+    }
+    ImGui.SameLine();
+    if (ImGui.Button("Send") && this.inputText.trim() !== "") {
+      this.chatService.sendMessage(this.inputText.trim());
+      this.inputText = "";
+    }
+  }
+}

--- a/src/game/debug/debug-window.ts
+++ b/src/game/debug/debug-window.ts
@@ -4,6 +4,7 @@ import { EventInspectorWindow } from "./event-inspector-window.js";
 import { MatchInspectorWindow } from "./match-inspector-window.js";
 import { BaseWindow } from "../../core/debug/base-window.js";
 import { PeerInspectorWindow } from "./peer-inspector-window.js";
+import { ChatInspectorWindow } from "./chat-inspector-window.js";
 import type { GameState } from "../../core/models/game-state.js";
 
 export class DebugWindow extends BaseWindow {
@@ -11,6 +12,7 @@ export class DebugWindow extends BaseWindow {
   private sceneInspectorWindow: SceneInspectorWindow;
   private matchInspectorWindow: MatchInspectorWindow;
   private peerInspectorWindow: PeerInspectorWindow;
+  private chatInspectorWindow: ChatInspectorWindow;
 
   constructor(private gameState: GameState) {
     super("Debug menu", new ImVec2(220, 220), false, ImGui.WindowFlags.MenuBar);
@@ -18,6 +20,7 @@ export class DebugWindow extends BaseWindow {
     this.sceneInspectorWindow = new SceneInspectorWindow(gameState);
     this.matchInspectorWindow = new MatchInspectorWindow(gameState);
     this.peerInspectorWindow = new PeerInspectorWindow();
+    this.chatInspectorWindow = new ChatInspectorWindow();
     this.open();
   }
 
@@ -45,6 +48,10 @@ export class DebugWindow extends BaseWindow {
     if (this.peerInspectorWindow.isOpen()) {
       this.peerInspectorWindow.render();
     }
+
+    if (this.chatInspectorWindow.isOpen()) {
+      this.chatInspectorWindow.render();
+    }
   }
 
   private renderMenu(): void {
@@ -70,6 +77,10 @@ export class DebugWindow extends BaseWindow {
 
         if (ImGui.MenuItem("Peers", "P")) {
           this.peerInspectorWindow.toggle();
+        }
+
+        if (ImGui.MenuItem("Chat", "C")) {
+          this.chatInspectorWindow.toggle();
         }
 
         ImGui.EndMenu();

--- a/src/game/enums/websocket-type.ts
+++ b/src/game/enums/websocket-type.ts
@@ -4,4 +4,5 @@ export enum WebSocketType {
   Tunnel = 2,
   OnlinePlayers = 3,
   MatchPlayer = 4,
+  ChatMessage = 5,
 }

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -1,0 +1,47 @@
+import { WebSocketService } from "./websocket-service.js";
+import { WebSocketType } from "../../enums/websocket-type.js";
+import { BinaryWriter } from "../../../core/utils/binary-writer-utils.js";
+import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
+import { ServerCommandHandler } from "../../decorators/server-command-handler.js";
+import { GameState } from "../../../core/models/game-state.js";
+import { container } from "../../../core/services/di-container.js";
+import { injectable } from "@needle-di/core";
+
+@injectable()
+export class ChatService {
+  private readonly messages: string[] = [];
+  private readonly webSocketService: WebSocketService;
+  private readonly gameState: GameState;
+
+  constructor() {
+    this.webSocketService = container.get(WebSocketService);
+    this.gameState = container.get(GameState);
+    this.webSocketService.registerCommandHandlers(this);
+  }
+
+  public getMessages(): string[] {
+    return this.messages;
+  }
+
+  public sendMessage(text: string): void {
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebSocketType.ChatMessage)
+      .variableLengthString(text)
+      .toArrayBuffer();
+
+    this.webSocketService.sendMessage(payload);
+
+    const playerName = this.gameState.getGamePlayer().getName();
+    this.messages.push(`${playerName}: ${text}`);
+  }
+
+  @ServerCommandHandler(WebSocketType.ChatMessage)
+  public handleChatMessage(binaryReader: BinaryReader): void {
+    const playerId = binaryReader.fixedLengthString(32);
+    const text = binaryReader.variableLengthString();
+    const playerName =
+      this.gameState.getMatch()?.getPlayer(playerId)?.getName() ?? playerId;
+
+    this.messages.push(`${playerName}: ${text}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add new `ChatService` to handle chat messages via WebSocket
- register service in the service registry
- create `ChatInspectorWindow` for viewing and sending chat
- integrate chat inspector into the debug menu
- extend `WebSocketType` enum with `ChatMessage`
- rename `ChatMessageService` to `ChatService`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873ab0116e48327817617409523947b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a chat inspector debug window, allowing users to view and send chat messages within the debug interface.
  * Added chat message handling and display, enabling real-time chat functionality through a new chat service.
  * Integrated a new chat message type for WebSocket communication.
  * Added a menu item and shortcut to access the chat inspector from the debug window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->