### PR TITLE
Improve chat inspector window

### DIFF
--- a/src/game/debug/chat-inspector-window.ts
+++ b/src/game/debug/chat-inspector-window.ts
@@ -16,12 +16,12 @@ export class ChatInspectorWindow extends BaseWindow {
 
   protected override renderContent(): void {
     const messages = this.chatService.getMessages();
-
     ImGui.BeginChild("ChatLog", new ImVec2(0, -40), true);
     messages.forEach((msg) => ImGui.TextWrapped(msg));
     ImGui.EndChild();
 
     const inputRef = [this.inputText];
+    ImGui.SetNextItemWidth(-120);
     if (ImGui.InputText("##chatInput", inputRef, 256)) {
       this.inputText = inputRef[0];
     }
@@ -29,6 +29,10 @@ export class ChatInspectorWindow extends BaseWindow {
     if (ImGui.Button("Send") && this.inputText.trim() !== "") {
       this.chatService.sendMessage(this.inputText.trim());
       this.inputText = "";
+    }
+    ImGui.SameLine();
+    if (ImGui.Button("Clear")) {
+      this.chatService.clearMessages();
     }
   }
 }

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -26,6 +26,10 @@ export class ChatService {
     return this.messages;
   }
 
+  public clearMessages(): void {
+    this.messages.length = 0;
+  }
+
   public sendMessage(text: string): void {
     const trimmed = text.trim();
     if (trimmed.length === 0 || trimmed.length > ChatService.MAX_MESSAGE_LENGTH) {
@@ -38,9 +42,6 @@ export class ChatService {
       .toArrayBuffer();
 
     this.webSocketService.sendMessage(payload);
-
-    const playerName = this.gameState.getGamePlayer().getName();
-    this.addMessage(`${playerName}: ${trimmed}`);
   }
 
   @ServerCommandHandler(WebSocketType.ChatMessage)


### PR DESCRIPTION
## Summary
- avoid adding sent messages to history in ChatService
- add ChatService.clearMessages helper
- refine ChatInspectorWindow layout and add "Clear" button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873c0a967a48327bed0dbc7e606a8c2