### PR TITLE
Add chat button and history display

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <hr />
       <button id="sign-in-button">Sign in</button>
     </dialog>
+    <input id="chat-input" type="text" placeholder="Type a message..." />
     <canvas id="debug" tabindex="1"></canvas>
     <canvas id="game" tabindex="-1"></canvas>
   </body>

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -89,6 +89,9 @@ hr {
   left: 50%;
   transform: translateX(-50%);
   width: 200px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
   display: none;
   z-index: 2;
 }

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -83,3 +83,13 @@ hr {
   z-index: 1;
 }
 
+#chat-input {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 200px;
+  display: none;
+  z-index: 2;
+}
+

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -89,8 +89,9 @@ hr {
   left: 50%;
   transform: translateX(-50%);
   width: 200px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  background: rgba(0, 0, 0, 0.5);
+  border: 0;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 4px;
   color: #fff;
   display: none;
   z-index: 2;

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -23,6 +23,7 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     super();
     this.width = this.SIZE;
     this.height = this.SIZE;
+    this.opacity = 0.7;
     this.inputElement.addEventListener("blur", () => {
       if (this.inputVisible) {
         this.hideInput();

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -23,6 +23,11 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     super();
     this.width = this.SIZE;
     this.height = this.SIZE;
+    this.inputElement.addEventListener("blur", () => {
+      if (this.inputVisible) {
+        this.hideInput();
+      }
+    });
   }
 
   private showInput(): void {

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -1,0 +1,75 @@
+import { BaseTappableGameEntity } from "../../core/entities/base-tappable-game-entity.js";
+import { BoostMeterEntity } from "./boost-meter-entity.js";
+import { ChatService } from "../services/network/chat-service.js";
+import { GamePointer } from "../../core/models/game-pointer.js";
+
+export class ChatButtonEntity extends BaseTappableGameEntity {
+  private readonly SIZE = 32;
+  private readonly OFFSET = 10;
+  private readonly emoji = "\u2328\uFE0F"; // keyboard emoji
+
+  constructor(
+    private readonly boostMeter: BoostMeterEntity,
+    private readonly inputElement: HTMLInputElement,
+    private readonly chatService: ChatService,
+    private readonly gamePointer: GamePointer
+  ) {
+    super();
+    this.width = this.SIZE;
+    this.height = this.SIZE;
+    this.addInputListeners();
+  }
+
+  private addInputListeners(): void {
+    this.inputElement.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        const text = this.inputElement.value.trim();
+        if (text !== "") {
+          this.chatService.sendMessage(text);
+        }
+        this.hideInput();
+      } else if (e.key === "Escape") {
+        this.hideInput();
+      }
+    });
+  }
+
+  private showInput(): void {
+    this.inputElement.style.display = "block";
+    this.inputElement.value = "";
+    this.inputElement.focus();
+    this.gamePointer.setPreventDefault(false);
+  }
+
+  private hideInput(): void {
+    this.inputElement.blur();
+    this.inputElement.style.display = "none";
+    this.gamePointer.setPreventDefault(true);
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    const x =
+      this.boostMeter.getX() + this.boostMeter.getWidth() + this.OFFSET;
+    const y =
+      this.boostMeter.getY() + this.boostMeter.getHeight() / 2 - this.SIZE / 2;
+    this.x = x;
+    this.y = y;
+
+    if (this.pressed) {
+      this.showInput();
+    }
+
+    super.update(delta);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    this.applyOpacity(context);
+    context.font = `${this.SIZE * 0.8}px system-ui`;
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(this.emoji, this.x + this.SIZE / 2, this.y + this.SIZE / 2 + 1);
+    context.restore();
+    super.render(context);
+  }
+}

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -2,36 +2,27 @@ import { BaseTappableGameEntity } from "../../core/entities/base-tappable-game-e
 import { BoostMeterEntity } from "./boost-meter-entity.js";
 import { ChatService } from "../services/network/chat-service.js";
 import { GamePointer } from "../../core/models/game-pointer.js";
+import { GameKeyboard } from "../../core/models/game-keyboard.js";
 
 export class ChatButtonEntity extends BaseTappableGameEntity {
   private readonly SIZE = 32;
   private readonly OFFSET = 10;
   private readonly emoji = "\u2328\uFE0F"; // keyboard emoji
 
+  private inputVisible = false;
+  private prevEnterPressed = false;
+  private prevEscapePressed = false;
+
   constructor(
-    private readonly boostMeter: BoostMeterEntity,
+    private readonly boostMeterEntity: BoostMeterEntity,
     private readonly inputElement: HTMLInputElement,
     private readonly chatService: ChatService,
-    private readonly gamePointer: GamePointer
+    private readonly gamePointer: GamePointer,
+    private readonly gameKeyboard: GameKeyboard
   ) {
     super();
     this.width = this.SIZE;
     this.height = this.SIZE;
-    this.addInputListeners();
-  }
-
-  private addInputListeners(): void {
-    this.inputElement.addEventListener("keydown", (e: KeyboardEvent) => {
-      if (e.key === "Enter") {
-        const text = this.inputElement.value.trim();
-        if (text !== "") {
-          this.chatService.sendMessage(text);
-        }
-        this.hideInput();
-      } else if (e.key === "Escape") {
-        this.hideInput();
-      }
-    });
   }
 
   private showInput(): void {
@@ -39,24 +30,49 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     this.inputElement.value = "";
     this.inputElement.focus();
     this.gamePointer.setPreventDefault(false);
+    this.inputVisible = true;
   }
 
   private hideInput(): void {
     this.inputElement.blur();
     this.inputElement.style.display = "none";
     this.gamePointer.setPreventDefault(true);
+    this.inputVisible = false;
   }
 
   public override update(delta: DOMHighResTimeStamp): void {
     const x =
-      this.boostMeter.getX() + this.boostMeter.getWidth() + this.OFFSET;
+      this.boostMeterEntity.getX() +
+      this.boostMeterEntity.getWidth() +
+      this.OFFSET;
     const y =
-      this.boostMeter.getY() + this.boostMeter.getHeight() / 2 - this.SIZE / 2;
+      this.boostMeterEntity.getY() +
+      this.boostMeterEntity.getHeight() / 2 -
+      this.SIZE / 2;
     this.x = x;
     this.y = y;
 
     if (this.pressed) {
       this.showInput();
+    }
+
+    if (this.inputVisible) {
+      const pressedKeys = this.gameKeyboard.getPressedKeys();
+      const enterPressed = pressedKeys.has("Enter");
+      const escapePressed = pressedKeys.has("Escape");
+
+      if (!this.prevEnterPressed && enterPressed) {
+        const text = this.inputElement.value.trim();
+        if (text !== "") {
+          this.chatService.sendMessage(text);
+        }
+        this.hideInput();
+      } else if (!this.prevEscapePressed && escapePressed) {
+        this.hideInput();
+      }
+
+      this.prevEnterPressed = enterPressed;
+      this.prevEscapePressed = escapePressed;
     }
 
     super.update(delta);

--- a/src/game/entities/chat-history-entity.ts
+++ b/src/game/entities/chat-history-entity.ts
@@ -1,0 +1,84 @@
+import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
+import { TimerService } from "../../core/services/gameplay/timer-service.js";
+
+export class ChatHistoryEntity extends BaseAnimatedGameEntity {
+  private readonly padding = 10;
+  private readonly cornerRadius = 8;
+  private readonly lineHeight = 18;
+  private messages: string[] = [];
+  private timer: TimerService | null = null;
+  private context: CanvasRenderingContext2D;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super();
+    this.context = this.canvas.getContext("2d") as CanvasRenderingContext2D;
+    this.opacity = 0;
+  }
+
+  public show(messages: string[]): void {
+    this.messages = messages.slice(-5); // show last 5 messages
+    this.measure();
+    this.setPosition();
+    this.timer?.stop(false);
+    this.fadeIn(0.2);
+    this.timer = new TimerService(3, this.hide.bind(this));
+  }
+
+  public hide(): void {
+    this.fadeOut(0.2);
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    this.timer?.update(delta);
+    super.update(delta);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    if (this.opacity === 0) return;
+    context.save();
+    this.applyOpacity(context);
+    this.drawBackground(context);
+    this.drawText(context);
+    context.restore();
+  }
+
+  private measure(): void {
+    this.context.font = "16px system-ui";
+    const maxWidth = this.messages.reduce((acc, m) => Math.max(acc, this.context.measureText(m).width), 0);
+    this.width = maxWidth + this.padding * 2;
+    this.height = this.messages.length * this.lineHeight + this.padding * 2;
+  }
+
+  private setPosition(): void {
+    this.x = 20;
+    this.y = this.canvas.height - this.height - 80;
+  }
+
+  private drawBackground(ctx: CanvasRenderingContext2D): void {
+    ctx.fillStyle = "rgba(0,0,0,0.6)";
+    ctx.beginPath();
+    ctx.moveTo(this.x + this.cornerRadius, this.y);
+    ctx.lineTo(this.x + this.width - this.cornerRadius, this.y);
+    ctx.quadraticCurveTo(this.x + this.width, this.y, this.x + this.width, this.y + this.cornerRadius);
+    ctx.lineTo(this.x + this.width, this.y + this.height - this.cornerRadius);
+    ctx.quadraticCurveTo(this.x + this.width, this.y + this.height, this.x + this.width - this.cornerRadius, this.y + this.height);
+    ctx.lineTo(this.x + this.cornerRadius, this.y + this.height);
+    ctx.quadraticCurveTo(this.x, this.y + this.height, this.x, this.y + this.height - this.cornerRadius);
+    ctx.lineTo(this.x, this.y + this.cornerRadius);
+    ctx.quadraticCurveTo(this.x, this.y, this.x + this.cornerRadius, this.y);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  private drawText(ctx: CanvasRenderingContext2D): void {
+    ctx.fillStyle = "white";
+    ctx.font = "16px system-ui";
+    ctx.textBaseline = "top";
+    let y = this.y + this.padding;
+    const x = this.x + this.padding;
+    for (const line of this.messages) {
+      ctx.fillText(line, x, y);
+      y += this.lineHeight;
+    }
+  }
+}

--- a/src/game/entities/chat-history-entity.ts
+++ b/src/game/entities/chat-history-entity.ts
@@ -4,10 +4,12 @@ import { TimerService } from "../../core/services/gameplay/timer-service.js";
 export class ChatHistoryEntity extends BaseAnimatedGameEntity {
   private readonly padding = 10;
   private readonly cornerRadius = 8;
+  private readonly fontSize = 16;
   private readonly lineHeight = 18;
   private messages: string[] = [];
   private timer: TimerService | null = null;
   private context: CanvasRenderingContext2D;
+  private localPlayerName = "";
 
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();
@@ -15,8 +17,9 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
     this.opacity = 0;
   }
 
-  public show(messages: string[]): void {
+  public show(messages: string[], localPlayerName: string): void {
     this.messages = messages.slice(-5); // show last 5 messages
+    this.localPlayerName = localPlayerName;
     this.measure();
     this.setPosition();
     this.timer?.stop(false);
@@ -43,10 +46,16 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
   }
 
   private measure(): void {
-    this.context.font = "16px system-ui";
-    const maxWidth = this.messages.reduce((acc, m) => Math.max(acc, this.context.measureText(m).width), 0);
+    this.context.font = `${this.fontSize}px system-ui`;
+    const maxWidth = this.messages.reduce(
+      (acc, m) => Math.max(acc, this.context.measureText(m).width),
+      0
+    );
     this.width = maxWidth + this.padding * 2;
-    this.height = this.messages.length * this.lineHeight + this.padding * 2;
+    this.height =
+      this.messages.length * this.lineHeight -
+      (this.lineHeight - this.fontSize) +
+      this.padding * 2;
   }
 
   private setPosition(): void {
@@ -71,13 +80,27 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
   }
 
   private drawText(ctx: CanvasRenderingContext2D): void {
-    ctx.fillStyle = "white";
-    ctx.font = "16px system-ui";
+    ctx.font = `${this.fontSize}px system-ui`;
     ctx.textBaseline = "top";
     let y = this.y + this.padding;
     const x = this.x + this.padding;
     for (const line of this.messages) {
-      ctx.fillText(line, x, y);
+      const colonIndex = line.indexOf(":");
+      if (colonIndex > -1) {
+        const name = line.substring(0, colonIndex);
+        const message = line.substring(colonIndex + 1).trimStart();
+        const nameColor =
+          name === this.localPlayerName ? "#2196f3" : "#ff4d4d";
+        ctx.fillStyle = nameColor;
+        const nameText = name + ":";
+        ctx.fillText(nameText, x, y);
+        const nameWidth = ctx.measureText(nameText + " ").width;
+        ctx.fillStyle = "white";
+        ctx.fillText(message, x + nameWidth, y);
+      } else {
+        ctx.fillStyle = "white";
+        ctx.fillText(line, x, y);
+      }
       y += this.lineHeight;
     }
   }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -366,7 +366,7 @@ export class WorldScene extends BaseCollidingGameScene {
     );
     this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
     this.chatService.onMessage((msgs: string[]) =>
-      this.chatHistoryEntity?.show(msgs)
+      this.chatHistoryEntity?.show(msgs, this.gameState.getGamePlayer().getName())
     );
   }
 

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -105,23 +105,7 @@ export class WorldScene extends BaseCollidingGameScene {
     this.boostPadsEntities = entities.boostPadsEntities;
     this.spawnPointEntities = entities.spawnPointEntities;
 
-    const chatInput = document.querySelector("#chat-input") as HTMLInputElement | null;
-    if (chatInput) {
-      this.chatHistoryEntity = new ChatHistoryEntity(this.canvas);
-      const boostMeter = this.localCarEntity.getBoostMeterEntity();
-      if (boostMeter) {
-        this.chatButtonEntity = new ChatButtonEntity(
-          boostMeter,
-          chatInput,
-          this.chatService,
-          this.gameState.getGamePointer()
-        );
-        this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
-        this.chatService.onMessage((msgs: string[]) =>
-          this.chatHistoryEntity?.show(msgs)
-        );
-      }
-    }
+    this.setupChatUi();
 
     // Set total spawn points created to service
     this.spawnPointService.setTotalSpawnPoints(this.spawnPointEntities.length);
@@ -351,6 +335,38 @@ export class WorldScene extends BaseCollidingGameScene {
     } else {
       console.warn(`Cannot find player with id ${playerId}`);
     }
+  }
+
+  private setupChatUi(): void {
+    const chatInputElement = document.querySelector("#chat-input") as HTMLInputElement | null;
+
+    if (!chatInputElement) {
+      console.error("Chat input element not found");
+      return;
+    }
+
+    this.chatHistoryEntity = new ChatHistoryEntity(this.canvas);
+
+    const boostMeterEntity = this.localCarEntity?.getBoostMeterEntity();
+    if (!boostMeterEntity) {
+      console.error("Boost meter entity not found");
+      return;
+    }
+
+    if (!this.uiEntities.includes(boostMeterEntity)) {
+      this.uiEntities.push(boostMeterEntity);
+    }
+
+    this.chatButtonEntity = new ChatButtonEntity(
+      boostMeterEntity,
+      chatInputElement,
+      this.chatService,
+      this.gameState.getGamePointer()
+    );
+    this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
+    this.chatService.onMessage((msgs: string[]) =>
+      this.chatHistoryEntity?.show(msgs)
+    );
   }
 
 

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -361,7 +361,8 @@ export class WorldScene extends BaseCollidingGameScene {
       boostMeterEntity,
       chatInputElement,
       this.chatService,
-      this.gameState.getGamePointer()
+      this.gameState.getGamePointer(),
+      this.gameState.getGameKeyboard()
     );
     this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
     this.chatService.onMessage((msgs: string[]) =>

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -13,6 +13,7 @@ export class ChatService {
   private static readonly MAX_HISTORY_SIZE = 50;
 
   private readonly messages: string[] = [];
+  private readonly listeners: ((messages: string[]) => void)[] = [];
   private readonly webSocketService: WebSocketService;
   private readonly gameState: GameState;
 
@@ -24,6 +25,10 @@ export class ChatService {
 
   public getMessages(): string[] {
     return this.messages;
+  }
+
+  public onMessage(listener: (messages: string[]) => void): void {
+    this.listeners.push(listener);
   }
 
   public clearMessages(): void {
@@ -70,5 +75,6 @@ export class ChatService {
     }
 
     this.messages.push(message);
+    this.listeners.forEach((l) => l(this.messages));
   }
 }


### PR DESCRIPTION
## Summary
- implement `ChatButtonEntity` for quick chat input
- implement `ChatHistoryEntity` with timed fade-out
- emit chat events via `ChatService`
- show chat UI in the world scene
- include chat input element and styling
- place chat input before debug canvas and improve placeholder text

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873c3742058832788a2919adfd3f344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a chat input box and a chat button to the game interface, allowing players to send messages.
  * Added an on-screen chat history overlay that displays recent messages with smooth fade-in and fade-out animations.
  * Chat messages can be sent by pressing Enter and the chat input can be dismissed with Escape.
  * Chat history updates dynamically as new messages arrive.

* **Style**
  * Added new styles to position and display the chat input box at the bottom center of the screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->