### PR TITLE
Update chat UI behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <hr />
       <button id="sign-in-button">Sign in</button>
     </dialog>
-    <input id="chat-input" type="text" placeholder="Type a message..." />
+    <input id="chat-input" type="text" placeholder="Type a message..." maxlength="35" />
     <canvas id="debug" tabindex="1"></canvas>
     <canvas id="game" tabindex="-1"></canvas>
   </body>

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -90,6 +90,7 @@ hr {
   transform: translateX(-50%);
   width: 200px;
   border: 0;
+  border-radius: 4px;
   background: rgba(0, 0, 0, 0.8);
   padding: 4px;
   color: #fff;

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -3,11 +3,12 @@ import { BoostMeterEntity } from "./boost-meter-entity.js";
 import { ChatService } from "../services/network/chat-service.js";
 import { GamePointer } from "../../core/models/game-pointer.js";
 import { GameKeyboard } from "../../core/models/game-keyboard.js";
+import { HelpEntity } from "./help-entity.js";
 
 export class ChatButtonEntity extends BaseTappableGameEntity {
   private readonly SIZE = 32;
   private readonly OFFSET = 10;
-  private readonly emoji = "\u2328\uFE0F"; // keyboard emoji
+  private readonly emoji = "\uD83D\uDCAC"; // chat emoji
 
   private inputVisible = false;
   private prevEnterPressed = false;
@@ -18,7 +19,8 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     private readonly inputElement: HTMLInputElement,
     private readonly chatService: ChatService,
     private readonly gamePointer: GamePointer,
-    private readonly gameKeyboard: GameKeyboard
+    private readonly gameKeyboard: GameKeyboard,
+    private readonly helpEntity: HelpEntity
   ) {
     super();
     this.width = this.SIZE;
@@ -32,11 +34,16 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
   }
 
   private showInput(): void {
+    if (this.helpEntity.getOpacity() > 0) {
+      return;
+    }
+
     this.inputElement.style.display = "block";
     this.inputElement.value = "";
     this.inputElement.focus();
     this.gamePointer.setPreventDefault(false);
     this.inputVisible = true;
+    this.setActive(false);
   }
 
   private hideInput(): void {
@@ -44,6 +51,7 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     this.inputElement.style.display = "none";
     this.gamePointer.setPreventDefault(true);
     this.inputVisible = false;
+    this.setActive(true);
   }
 
   public override update(delta: DOMHighResTimeStamp): void {
@@ -85,6 +93,10 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
   }
 
   public override render(context: CanvasRenderingContext2D): void {
+    if (this.inputVisible) {
+      return;
+    }
+
     context.save();
     this.applyOpacity(context);
     context.font = `${this.SIZE * 0.8}px system-ui`;

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -362,7 +362,8 @@ export class WorldScene extends BaseCollidingGameScene {
       chatInputElement,
       this.chatService,
       this.gameState.getGamePointer(),
-      this.gameState.getGameKeyboard()
+      this.gameState.getGameKeyboard(),
+      this.helpEntity as HelpEntity
     );
     this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
     this.chatService.onMessage((msgs: string[]) =>

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -9,7 +9,7 @@ import { injectable } from "@needle-di/core";
 
 @injectable()
 export class ChatService {
-  private static readonly MAX_MESSAGE_LENGTH = 256;
+  private static readonly MAX_MESSAGE_LENGTH = 35;
   private static readonly MAX_HISTORY_SIZE = 50;
 
   private readonly messages: string[] = [];
@@ -37,7 +37,13 @@ export class ChatService {
 
   public sendMessage(text: string): void {
     const trimmed = text.trim();
-    if (trimmed.length === 0 || trimmed.length > ChatService.MAX_MESSAGE_LENGTH) {
+    if (trimmed.length === 0) {
+      console.warn("Chat message empty");
+      return;
+    }
+
+    if (trimmed.length > ChatService.MAX_MESSAGE_LENGTH) {
+      console.warn("Chat message exceeds max length");
       return;
     }
 
@@ -59,7 +65,13 @@ export class ChatService {
     }
 
     const trimmed = text.trim();
-    if (trimmed.length === 0 || trimmed.length > ChatService.MAX_MESSAGE_LENGTH) {
+    if (trimmed.length === 0) {
+      console.warn("Received empty chat message");
+      return;
+    }
+
+    if (trimmed.length > ChatService.MAX_MESSAGE_LENGTH) {
+      console.warn("Received chat message exceeding max length");
       return;
     }
 


### PR DESCRIPTION
## Summary
- cap chat messages to 35 characters and log validation warnings
- switch chat button emoji to 💬 and hide button when input active
- delay chat input until help overlay fades out
- style chat input with border radius and max length attribute

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873d8743da4832795e79b6f1338f93f