### PR TITLE
Improve chat input handling

### DIFF
--- a/src/core/interfaces/input/game-keyboard.ts
+++ b/src/core/interfaces/input/game-keyboard.ts
@@ -1,3 +1,4 @@
 export interface IGameKeyboard {
   getPressedKeys(): Set<string>;
+  setEnabled(enabled: boolean): void;
 }

--- a/src/core/models/game-keyboard.ts
+++ b/src/core/models/game-keyboard.ts
@@ -2,6 +2,7 @@ import type { IGameKeyboard } from "../interfaces/input/game-keyboard.js";
 
 export class GameKeyboard implements IGameKeyboard {
   private pressedKeys: Set<string> = new Set();
+  private enabled = true;
 
   constructor() {
     this.addEventListeners();
@@ -11,16 +12,27 @@ export class GameKeyboard implements IGameKeyboard {
     return this.pressedKeys;
   }
 
+  public setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.pressedKeys.clear();
+    }
+  }
+
   private addEventListeners(): void {
     window.addEventListener("keydown", this.handleKeyDown.bind(this));
     window.addEventListener("keyup", this.handleKeyUp.bind(this));
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
-    this.pressedKeys.add(event.key);
+    if (this.enabled) {
+      this.pressedKeys.add(event.key);
+    }
   }
 
   private handleKeyUp(event: KeyboardEvent): void {
-    this.pressedKeys.delete(event.key);
+    if (this.enabled) {
+      this.pressedKeys.delete(event.key);
+    }
   }
 }

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -43,6 +43,7 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     this.inputElement.value = "";
     this.inputElement.focus();
     this.gamePointer.setPreventDefault(false);
+    this.gameKeyboard.setEnabled(false);
     this.inputVisible = true;
     this.setActive(false);
   }
@@ -51,6 +52,7 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     this.inputElement.blur();
     this.inputElement.style.display = "none";
     this.gamePointer.setPreventDefault(true);
+    this.gameKeyboard.setEnabled(true);
     this.inputVisible = false;
     this.setActive(true);
   }

--- a/src/game/entities/chat-history-entity.ts
+++ b/src/game/entities/chat-history-entity.ts
@@ -62,7 +62,7 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
 
   private setPosition(): void {
     this.x = 20;
-    this.y = this.canvas.height - this.height - 80;
+    this.y = this.canvas.height - this.height - 110;
   }
 
   private drawBackground(ctx: CanvasRenderingContext2D): void {


### PR DESCRIPTION
## Summary
- move chat history farther from the bottom
- disable keyboard controls while typing in chat

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873deb07da083279b7f890d3783ebea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable keyboard input for gameplay.
  * Keyboard input is now automatically disabled when the chat input is open and re-enabled when the chat input is closed.

* **Enhancements**
  * Chat history display has been moved 30 pixels higher on the canvas for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->