### PR TITLE
Fix chat UI padding and refactor button

### DIFF
--- a/src/core/main.css
+++ b/src/core/main.css
@@ -90,7 +90,7 @@ hr {
   transform: translateX(-50%);
   width: 200px;
   border: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   background: rgba(0, 0, 0, 0.8);
   padding: 8px;
   color: #fff;

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -55,6 +55,36 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     this.setActive(true);
   }
 
+  private updatePosition(): void {
+    this.x =
+      this.boostMeterEntity.getX() +
+      this.boostMeterEntity.getWidth() +
+      this.OFFSET;
+    this.y =
+      this.boostMeterEntity.getY() +
+      this.boostMeterEntity.getHeight() / 2 -
+      this.SIZE / 2;
+  }
+
+  private handleKeyboardInput(): void {
+    const pressedKeys = this.gameKeyboard.getPressedKeys();
+    const enterPressed = pressedKeys.has("Enter");
+    const escapePressed = pressedKeys.has("Escape");
+
+    if (!this.prevEnterPressed && enterPressed) {
+      const text = this.inputElement.value.trim();
+      if (text !== "") {
+        this.chatService.sendMessage(text);
+      }
+      this.hideInput();
+    } else if (!this.prevEscapePressed && escapePressed) {
+      this.hideInput();
+    }
+
+    this.prevEnterPressed = enterPressed;
+    this.prevEscapePressed = escapePressed;
+  }
+
   public override update(delta: DOMHighResTimeStamp): void {
     if (this.helpEntity.getOpacity() > 0) {
       if (!this.inputVisible) {
@@ -64,38 +94,14 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
       this.setActive(true);
     }
 
-    const x =
-      this.boostMeterEntity.getX() +
-      this.boostMeterEntity.getWidth() +
-      this.OFFSET;
-    const y =
-      this.boostMeterEntity.getY() +
-      this.boostMeterEntity.getHeight() / 2 -
-      this.SIZE / 2;
-    this.x = x;
-    this.y = y;
+    this.updatePosition();
 
     if (this.pressed) {
       this.showInput();
     }
 
     if (this.inputVisible) {
-      const pressedKeys = this.gameKeyboard.getPressedKeys();
-      const enterPressed = pressedKeys.has("Enter");
-      const escapePressed = pressedKeys.has("Escape");
-
-      if (!this.prevEnterPressed && enterPressed) {
-        const text = this.inputElement.value.trim();
-        if (text !== "") {
-          this.chatService.sendMessage(text);
-        }
-        this.hideInput();
-      } else if (!this.prevEscapePressed && escapePressed) {
-        this.hideInput();
-      }
-
-      this.prevEnterPressed = enterPressed;
-      this.prevEscapePressed = escapePressed;
+      this.handleKeyboardInput();
     }
 
     super.update(delta);

--- a/src/game/entities/chat-history-entity.ts
+++ b/src/game/entities/chat-history-entity.ts
@@ -55,8 +55,7 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
     this.width = maxWidth + this.padding * 2;
     this.height =
       this.messages.length * this.lineHeight +
-      (this.messages.length - 1) * this.messageMargin -
-      (this.lineHeight - this.fontSize) +
+      (this.messages.length - 1) * this.messageMargin +
       this.padding * 2;
   }
 
@@ -83,8 +82,8 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
 
   private drawText(ctx: CanvasRenderingContext2D): void {
     ctx.font = `${this.fontSize}px system-ui`;
-    ctx.textBaseline = "top";
-    let y = this.y + this.padding;
+    ctx.textBaseline = "middle";
+    let y = this.y + this.padding + this.lineHeight / 2;
     const x = this.x + this.padding;
     for (let i = 0; i < this.messages.length; i++) {
       const line = this.messages[i];


### PR DESCRIPTION
## Summary
- smooth out padding for chat history panel
- round chat input slightly more
- refactor chat button entity positioning and keyboard handling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873e58bdb44832797821a26b1bc8853