### PR TITLE
Update chat UI positions

### DIFF
--- a/src/core/main.css
+++ b/src/core/main.css
@@ -85,7 +85,7 @@ hr {
 
 #chat-input {
   position: absolute;
-  bottom: 20px;
+  bottom: 40px;
   left: 50%;
   transform: translateX(-50%);
   width: 300px;

--- a/src/game/entities/chat-history-entity.ts
+++ b/src/game/entities/chat-history-entity.ts
@@ -61,7 +61,7 @@ export class ChatHistoryEntity extends BaseAnimatedGameEntity {
 
   private setPosition(): void {
     this.x = 20;
-    this.y = this.canvas.height - this.height - 100;
+    this.y = 20;
   }
 
   private drawBackground(ctx: CanvasRenderingContext2D): void {


### PR DESCRIPTION
## Summary
- reposition chat history to the top left of the canvas
- add more bottom offset to the chat input box

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873ec8684888327b4418b4746064aec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the vertical offset of the chat input from the bottom of the screen for improved layout.

* **New Features**
  * Moved the chat history display to the top of the canvas for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->