### PR TITLE
Optimize entity rendering

### DIFF
--- a/src/game/entities/backgrounds/main-background-entity.ts
+++ b/src/game/entities/backgrounds/main-background-entity.ts
@@ -1,11 +1,24 @@
 import { BaseGameEntity } from "../../../core/entities/base-game-entity.js";
 
 export class MainBackgroundEntity extends BaseGameEntity {
+  private gradient: CanvasGradient | null = null;
+
   constructor(private readonly canvas: HTMLCanvasElement) {
     super();
   }
 
   public override load(): void {
+    const ctx = this.canvas.getContext("2d");
+    if (ctx) {
+      this.gradient = ctx.createLinearGradient(
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height / 2
+      );
+      this.gradient.addColorStop(0, "#000428");
+      this.gradient.addColorStop(1, "#004e92");
+    }
     super.load();
   }
 
@@ -14,15 +27,18 @@ export class MainBackgroundEntity extends BaseGameEntity {
   }
 
   private drawGradientSky(context: CanvasRenderingContext2D): void {
-    const gradient = context.createLinearGradient(
-      0,
-      0,
-      this.canvas.width,
-      this.canvas.height / 2
-    );
-    gradient.addColorStop(0, "#000428");
-    gradient.addColorStop(1, "#004e92");
-    context.fillStyle = gradient;
+    if (!this.gradient) {
+      this.gradient = context.createLinearGradient(
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height / 2
+      );
+      this.gradient.addColorStop(0, "#000428");
+      this.gradient.addColorStop(1, "#004e92");
+    }
+
+    context.fillStyle = this.gradient;
     context.fillRect(0, 0, this.canvas.width, this.canvas.height);
   }
 }

--- a/src/game/entities/boost-meter-entity.ts
+++ b/src/game/entities/boost-meter-entity.ts
@@ -10,11 +10,31 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
   private readonly FILL_RATE_UP = 1 / 100; // units/ms
   private readonly FILL_RATE_DOWN = 1 / 200; // units/ms
 
+  private gradient: CanvasGradient | null = null;
+
+  private readonly canvas: HTMLCanvasElement;
+
   constructor(canvas: HTMLCanvasElement) {
     super();
+    this.canvas = canvas;
     this.width = this.RADIUS * 2;
     this.height = this.RADIUS * 2;
     this.setPosition(canvas.width / 2, canvas.height - this.RADIUS - 30);
+    const ctx = this.canvas.getContext("2d");
+    if (ctx) {
+      this.updateGradient(ctx);
+    }
+  }
+
+  private updateGradient(context: CanvasRenderingContext2D): void {
+    this.gradient = context.createLinearGradient(
+      0,
+      this.y + this.height,
+      0,
+      this.y
+    );
+    this.gradient.addColorStop(0, "#ffe066");
+    this.gradient.addColorStop(1, LIGHT_GREEN_COLOR);
   }
 
   public setBoostLevel(level: number): void {
@@ -59,6 +79,10 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
   public setPosition(x: number, y: number): void {
     this.x = x - this.width / 2;
     this.y = y - this.height / 2;
+    const ctx = this.canvas.getContext("2d");
+    if (ctx) {
+      this.updateGradient(ctx);
+    }
   }
 
 
@@ -68,14 +92,12 @@ export class BoostMeterEntity extends BaseAnimatedGameEntity {
 
     const cx = this.x + this.RADIUS;
     const cy = this.y + this.RADIUS;
-    const gradient = context.createLinearGradient(
-      0,
-      this.y + this.height,
-      0,
-      this.y
-    );
-    gradient.addColorStop(0, "#ffe066");
-    gradient.addColorStop(1, LIGHT_GREEN_COLOR);
+
+    if (!this.gradient) {
+      this.updateGradient(context);
+    }
+
+    const gradient = this.gradient!;
 
     // base background when empty
     context.beginPath();

--- a/src/game/entities/common/closeable-window-entity.ts
+++ b/src/game/entities/common/closeable-window-entity.ts
@@ -23,10 +23,13 @@ export class CloseableWindowEntity extends BaseTappableGameEntity {
   protected content: string = "Content goes here";
 
   private opened: boolean = false;
+  private context: CanvasRenderingContext2D;
+  private wrappedContentLines: string[] = [];
 
   constructor(private canvas: HTMLCanvasElement) {
     super(true);
     this.backdropEntity = new BackdropEntity(this.canvas);
+    this.context = this.canvas.getContext("2d") as CanvasRenderingContext2D;
     this.setInitialState();
   }
 
@@ -53,6 +56,7 @@ export class CloseableWindowEntity extends BaseTappableGameEntity {
     this.title = title;
     this.content = content;
     this.active = true;
+    this.updateWrappedContentLines();
   }
 
   public close(): void {
@@ -120,6 +124,7 @@ export class CloseableWindowEntity extends BaseTappableGameEntity {
     this.contentTextX = this.x + 14;
     this.contentTextY = this.y + this.TITLE_BAR_HEIGHT + 62;
     this.contentTextMaxWidth = this.width - 25;
+    this.updateWrappedContentLines();
   }
 
   private wrapText(
@@ -144,6 +149,14 @@ export class CloseableWindowEntity extends BaseTappableGameEntity {
     lines.push(currentLine);
 
     return lines;
+  }
+
+  private updateWrappedContentLines(): void {
+    this.wrappedContentLines = this.wrapText(
+      this.context,
+      this.content,
+      this.contentTextMaxWidth
+    );
   }
 
   private renderWindow(context: CanvasRenderingContext2D): void {
@@ -181,15 +194,9 @@ export class CloseableWindowEntity extends BaseTappableGameEntity {
     context.font = "16px system-ui";
     context.textAlign = "left";
 
-    const lines = this.wrapText(
-      context,
-      this.content,
-      this.contentTextMaxWidth
-    );
-
-    for (let i = 0; i < lines.length; i++) {
+    for (let i = 0; i < this.wrappedContentLines.length; i++) {
       context.fillText(
-        lines[i],
+        this.wrappedContentLines[i],
         this.contentTextX,
         this.contentTextY + i * this.TEXT_LINE_HEIGHT
       );

--- a/src/game/entities/online-players-entity.ts
+++ b/src/game/entities/online-players-entity.ts
@@ -10,6 +10,9 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
 
   private baseX: number;
   private baseY: number;
+  private context: CanvasRenderingContext2D;
+  private labelWidth = 0;
+  private countWidth = 0;
 
   private shakeDuration = 0;
   private shakeElapsed = 0;
@@ -21,14 +24,20 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     this.baseY = this.canvas.height - 40;
     this.x = this.baseX;
     this.y = this.baseY;
+    this.context = this.canvas.getContext("2d") as CanvasRenderingContext2D;
+    this.context.font = "bold 28px system-ui";
+    this.labelWidth = this.context.measureText(this.getText()).width;
+    this.countWidth = this.context.measureText(this.onlinePlayers.toString()).width;
   }
 
   public setOnlinePlayers(total: number): void {
     if (this.onlinePlayers !== total) {
       this.onlinePlayers = total;
       this.startShake();
+      this.countWidth = this.context.measureText(this.onlinePlayers.toString()).width;
     } else {
       this.onlinePlayers = total;
+      this.countWidth = this.context.measureText(this.onlinePlayers.toString()).width;
     }
   }
 
@@ -66,12 +75,10 @@ export class OnlinePlayersEntity extends BaseAnimatedGameEntity {
     context.textAlign = "left";
 
     const spacing = 10;
-    const labelWidth = context.measureText(labelText).width;
-    const countWidth = context.measureText(countText).width;
-    const totalWidth = countWidth + spacing + labelWidth;
+    const totalWidth = this.countWidth + spacing + this.labelWidth;
 
     const countX = this.x - totalWidth / 2;
-    const labelX = countX + countWidth + spacing;
+    const labelX = countX + this.countWidth + spacing;
 
     context.fillStyle = LIGHT_GREEN_COLOR;
     context.fillText(countText, countX, this.y);


### PR DESCRIPTION
## Summary
- avoid creating gradient every frame for the main background
- cache boost meter gradient
- precompute wrapped text in closeable windows
- cache measured text width in online players display

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873fd39448083279b8149154e0eec36