### PR TITLE
Fix host disconnect bug

### DIFF
--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -12,6 +12,8 @@ import { MatchmakingNetworkService } from "../../game/services/network/matchmaki
 import {
   PendingIdentitiesToken,
   ReceivedIdentitiesToken,
+  PendingDisconnectionsToken,
+  MatchmakingServiceToken,
 } from "../../game/services/gameplay/matchmaking-tokens.js";
 import { CredentialService } from "../../game/services/security/credential-service.js";
 import { CameraService } from "./gameplay/camera-service.js";
@@ -46,6 +48,10 @@ export class ServiceRegistry {
       useClass: MatchmakingService,
     });
     container.bind({
+      provide: MatchmakingServiceToken,
+      useExisting: MatchmakingService,
+    });
+    container.bind({
       provide: EntityOrchestratorService,
       useClass: EntityOrchestratorService,
     });
@@ -60,6 +66,10 @@ export class ServiceRegistry {
     container.bind({
       provide: ReceivedIdentitiesToken,
       useValue: new Map<string, { playerId: string; playerName: string }>(),
+    });
+    container.bind({
+      provide: PendingDisconnectionsToken,
+      useValue: new Set<string>(),
     });
     ServiceRegistry.initializeServices();
   }

--- a/src/game/interfaces/services/gameplay/matchmaking-service-interface.ts
+++ b/src/game/interfaces/services/gameplay/matchmaking-service-interface.ts
@@ -5,5 +5,6 @@ export interface IMatchmakingService {
   findOrAdvertiseMatch(): Promise<void>;
   savePlayerScore(): Promise<void>;
   handleGameOver(): Promise<void>;
+  finalizeIfNoPendingDisconnections(): void;
   renderDebugInformation(context: CanvasRenderingContext2D): void;
 }

--- a/src/game/services/gameplay/matchmaking-tokens.ts
+++ b/src/game/services/gameplay/matchmaking-tokens.ts
@@ -3,3 +3,9 @@ import { InjectionToken } from "@needle-di/core";
 export const PendingIdentitiesToken = new InjectionToken("PendingIdentities");
 
 export const ReceivedIdentitiesToken = new InjectionToken("ReceivedIdentities");
+
+export const PendingDisconnectionsToken = new InjectionToken(
+  "PendingDisconnections"
+);
+
+export const MatchmakingServiceToken = new InjectionToken("MatchmakingService");


### PR DESCRIPTION
## Summary
- add `PendingDisconnectionsToken`
- register pending disconnection state
- defer setting `match` to null until peers disconnect
- clear disconnection counter as players leave

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873fd149ad48327928ac468e91a4b7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved game session handling to ensure the game over state is finalized only after all pending player disconnections are resolved.

* **Bug Fixes**
  * Enhanced reliability when finalizing game sessions by tracking and managing pending disconnections during player exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->