### PR TITLE
Handle graceful peer disconnect

### DIFF
--- a/src/game/interfaces/services/network/matchmaking-network-service-interface.ts
+++ b/src/game/interfaces/services/network/matchmaking-network-service-interface.ts
@@ -8,7 +8,7 @@ export interface IMatchmakingNetworkService {
   removePingCheckInterval(): void;
   handlePlayerIdentity(binaryReader: BinaryReader): void;
   onPeerConnected(peer: WebRTCPeer): void;
-  onPeerDisconnected(peer: WebRTCPeer): void;
+  onPeerDisconnected(peer: WebRTCPeer, graceful: boolean): void;
   handleJoinRequest(peer: WebRTCPeer): void;
   handleJoinResponse(peer: WebRTCPeer, binaryReader: BinaryReader): void;
   handlePlayerConnection(peer: WebRTCPeer, binaryReader: BinaryReader): void;

--- a/src/game/interfaces/services/network/peer-connection-listener.ts
+++ b/src/game/interfaces/services/network/peer-connection-listener.ts
@@ -2,5 +2,5 @@ import type { WebRTCPeer } from "./webrtc-peer.js";
 
 export interface PeerConnectionListener {
   onPeerConnected(peer: WebRTCPeer): void;
-  onPeerDisconnected(peer: WebRTCPeer): void;
+  onPeerDisconnected(peer: WebRTCPeer, graceful: boolean): void;
 }

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -131,7 +131,7 @@ export class MatchmakingNetworkService
     this.sendJoinRequest(peer);
   }
 
-  public onPeerDisconnected(peer: WebRTCPeer): void {
+  public onPeerDisconnected(peer: WebRTCPeer, graceful: boolean): void {
     if (peer.hasJoined() === false) {
       console.warn("Ignoring disconnection from non-joined peer", peer);
       return;
@@ -146,7 +146,7 @@ export class MatchmakingNetworkService
 
     if (this.gameState.getMatch()?.isHost()) {
       this.handlePlayerDisconnection(peer);
-    } else {
+    } else if (!graceful) {
       this.handleHostDisconnected(peer);
     }
   }


### PR DESCRIPTION
## Summary
- add `graceful` flag to `onPeerDisconnected` hooks
- track when `WebRTCPeerService` disconnects gracefully
- ignore host disconnects after game over

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68741523299c832781d36b242fc45ab6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved peer disconnection handling by distinguishing between graceful and abrupt disconnects in multiplayer sessions.

* **Bug Fixes**
  * Enhanced notification system to accurately inform users when a peer disconnects gracefully versus unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->