### PR TITLE
Fade chat input in and out

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
       type="text"
       placeholder="Type a message..."
       maxlength="35"
-      style="display: none"
     />
     <canvas id="debug" tabindex="1"></canvas>
     <canvas id="game" tabindex="-1"></canvas>

--- a/src/core/main.css
+++ b/src/core/main.css
@@ -96,7 +96,14 @@ hr {
   font-size: 18px;
   color: #fff;
   outline: none;
-  display: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
   z-index: 2;
+}
+
+#chat-input.show {
+  opacity: 1;
+  pointer-events: auto;
 }
 

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -47,6 +47,10 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
     }
 
     this.inputElement.style.display = "block";
+    // Trigger reflow to ensure the transition runs
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    this.inputElement.offsetWidth;
+    this.inputElement.classList.add("show");
     this.inputElement.value = "";
     this.inputElement.focus();
     this.gamePointer.setPreventDefault(false);
@@ -56,7 +60,14 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
 
   private hideInput(): void {
     this.inputElement.blur();
-    this.inputElement.style.display = "none";
+    this.inputElement.classList.remove("show");
+    const onTransitionEnd = () => {
+      this.inputElement.style.display = "none";
+      this.inputElement.removeEventListener("transitionend", onTransitionEnd);
+    };
+    this.inputElement.addEventListener("transitionend", onTransitionEnd, {
+      once: true,
+    });
     this.gamePointer.setPreventDefault(true);
     this.inputVisible = false;
     this.setActive(true);


### PR DESCRIPTION
## Summary
- remove inline "display: none" on chat input element
- animate chat input visibility with CSS
- toggle `.show` class to fade chat input

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687417be5c888327b00606b3ad2a1b57