### PR TITLE
Add return to main menu event

### DIFF
--- a/src/game/enums/event-type.ts
+++ b/src/game/enums/event-type.ts
@@ -15,4 +15,5 @@ export enum EventType {
   MatchmakingStarted,
   OnlinePlayers,
   CarDemolished,
+  ReturnToMainMenu,
 }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -136,7 +136,6 @@ export class WorldScene extends BaseCollidingGameScene {
       this.worldController.handleGoalTimeEnd.bind(this.worldController),
       () => {
         this.worldController?.handleGameOverEnd();
-        void this.returnToMainMenuScene();
       },
       (x: number, y: number, team: TeamType) =>
         this.triggerGoalExplosion(x, y, team),
@@ -261,6 +260,11 @@ export class WorldScene extends BaseCollidingGameScene {
     this.subscribeToLocalEvent<PlayerDisconnectedPayload>(
       EventType.PlayerDisconnected,
       this.handlePlayerDisconnection.bind(this)
+    );
+
+    this.subscribeToLocalEvent(
+      EventType.ReturnToMainMenu,
+      () => void this.returnToMainMenuScene()
     );
   }
 

--- a/src/game/services/gameplay/matchmaking-service.ts
+++ b/src/game/services/gameplay/matchmaking-service.ts
@@ -5,6 +5,8 @@ import { DebugUtils } from "../../../core/utils/debug-utils.js";
 import { WebSocketService } from "../network/websocket-service.js";
 import { WebRTCService } from "../network/webrtc-service.js";
 import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
+import { LocalEvent } from "../../../core/models/local-event.js";
+import { EventType } from "../../enums/event-type.js";
 import { APIService } from "../network/api-service.js";
 import { TimerManagerService } from "../../../core/services/gameplay/timer-manager-service.js";
 import { IntervalManagerService } from "../../../core/services/gameplay/interval-manager-service.js";
@@ -133,6 +135,8 @@ export class MatchmakingService implements IMatchmakingService {
     this.gameState.setMatch(null);
     container.get(PendingIdentitiesToken).clear();
     container.get(ReceivedIdentitiesToken).clear();
+    const localEvent = new LocalEvent(EventType.ReturnToMainMenu);
+    container.get(EventProcessorService).addLocalEvent(localEvent);
   }
 
   public renderDebugInformation(context: CanvasRenderingContext2D): void {


### PR DESCRIPTION
## Summary
- add new `EventType.ReturnToMainMenu`
- emit local event from `MatchmakingService.finalizeGameOver`
- remove direct menu transition after game over
- handle the new event in `WorldScene`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68741fa4fbc0832792c51fe4f7d3b1ed