### PR TITLE
Fix chat inspector layout and fade

### DIFF
--- a/src/core/main.css
+++ b/src/core/main.css
@@ -98,7 +98,7 @@ hr {
   outline: none;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.4s ease;
   z-index: 2;
 }
 

--- a/src/game/debug/chat-inspector-window.ts
+++ b/src/game/debug/chat-inspector-window.ts
@@ -16,7 +16,7 @@ export class ChatInspectorWindow extends BaseWindow {
 
   protected override renderContent(): void {
     const messages = this.chatService.getMessages();
-    ImGui.BeginChild("ChatLog", new ImVec2(0, -70), true);
+    ImGui.BeginChild("ChatLog", new ImVec2(0, 150), true);
     messages.forEach((msg) => ImGui.TextWrapped(msg));
     ImGui.EndChild();
 
@@ -25,12 +25,18 @@ export class ChatInspectorWindow extends BaseWindow {
     if (ImGui.InputText("##chatInput", inputRef, 256)) {
       this.inputText = inputRef[0];
     }
-    if (ImGui.Button("Send") && this.inputText.trim() !== "") {
+    const buttonWidth =
+      (ImGui.GetContentRegionAvail().x - ImGui.GetStyle().ItemSpacing.x) / 2;
+
+    if (
+      ImGui.Button("Send", new ImVec2(buttonWidth, 0)) &&
+      this.inputText.trim() !== ""
+    ) {
       this.chatService.sendMessage(this.inputText.trim());
       this.inputText = "";
     }
     ImGui.SameLine();
-    if (ImGui.Button("Clear")) {
+    if (ImGui.Button("Clear", new ImVec2(buttonWidth, 0))) {
       this.chatService.clearMessages();
     }
   }


### PR DESCRIPTION
## Summary
- slow down chat input fade animations
- overhaul chat inspector layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68742300df2883279dbfe33e289a571e