### PR TITLE
Fix countdown timer when making new matches

### DIFF
--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -61,6 +61,7 @@ export class WorldController {
   public handleWaitingForPlayers(): void {
     this.gameState.setMatchState(MatchStateType.WaitingPlayers);
     this.scoreboardEntity.stopTimer();
+    this.countdownCurrentNumber = this.COUNTDOWN_START_NUMBER;
   }
 
   public showCountdown(): void {
@@ -68,6 +69,10 @@ export class WorldController {
     const isHost = match?.isHost();
 
     this.gameState.setMatchState(MatchStateType.Countdown);
+
+    if (this.countdownCurrentNumber <= 0) {
+      this.countdownCurrentNumber = this.COUNTDOWN_START_NUMBER;
+    }
 
     this.resetForCountdown();
 


### PR DESCRIPTION
## Summary
- reset countdown when host waits for players
- ensure countdown restarts if the previous one finished before a new match begins

## Testing
- `npm install`
- `npm run build` *(fails: TS2571 object type unknown etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68743c7989d483279068af658a55d9a4