### PR TITLE
Fix match advertising after game over

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,5 +1,7 @@
 declare module '@needle-di/core';
 
+declare module '*.css';
+
 // Minimal declarations for jsimgui used in debug windows
 declare module '@mori2003/jsimgui' {
   export const ImGui: any;

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -2,6 +2,7 @@ import type { ITimerService } from "../../../core/interfaces/services/gameplay/t
 import { Match } from "../../models/match.js";
 import { GamePlayer } from "../../models/game-player.js";
 import { GameState } from "../../../core/models/game-state.js";
+import { MatchStateType } from "../../enums/match-state-type.js";
 import { MATCH_ATTRIBUTES } from "../../constants/matchmaking-constants.js";
 import type { WebRTCPeer } from "../../interfaces/services/network/webrtc-peer.js";
 import { EventType } from "../../enums/event-type.js";
@@ -330,7 +331,10 @@ export class MatchmakingNetworkService
       this.notifyMatchPlayerToServer(true, player.getId());
     }
 
-    void this.matchFinderService.advertiseMatch();
+    const match = this.gameState.getMatch();
+    if (match !== null && match.getState() !== MatchStateType.GameOver) {
+      void this.matchFinderService.advertiseMatch();
+    }
   }
 
   @PeerCommandHandler(WebRTCType.PlayerPing)
@@ -408,7 +412,10 @@ export class MatchmakingNetworkService
       this.notifyMatchPlayerToServer(false, player.getId());
     }
 
-    void this.matchFinderService.advertiseMatch();
+    const match = this.gameState.getMatch();
+    if (match !== null && match.getState() !== MatchStateType.GameOver) {
+      void this.matchFinderService.advertiseMatch();
+    }
 
     if (this.pendingDisconnections.delete(player.getId())) {
       this.getMatchmakingService().finalizeIfNoPendingDisconnections();


### PR DESCRIPTION
## Summary
- add ambient declaration for CSS imports
- avoid re-advertising matches after the game has ended

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874481d21348327a5b3e54a0c72d296