### PR TITLE
Fix new match state reset

### DIFF
--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -192,7 +192,6 @@ export class WorldScene extends BaseCollidingGameScene {
   private handleMatchAdvertised(): void {
     if (this.gameState.getMatch()?.getPlayers().length === 1) {
       this.worldController?.handleWaitingForPlayers();
-      this.toastEntity?.show("Waiting for players...");
     }
   }
 
@@ -306,6 +305,7 @@ export class WorldScene extends BaseCollidingGameScene {
 
   private handleWaitingForPlayers(): void {
     this.worldController?.handleWaitingForPlayers();
+    this.toastEntity?.show("Waiting for players...");
   }
   private handleRemoteBoostPadConsumed(data: ArrayBuffer | null): void {
     if (data === null) {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -191,6 +191,7 @@ export class WorldScene extends BaseCollidingGameScene {
 
   private handleMatchAdvertised(): void {
     if (this.gameState.getMatch()?.getPlayers().length === 1) {
+      this.worldController?.handleWaitingForPlayers();
       this.toastEntity?.show("Waiting for players...");
     }
   }


### PR DESCRIPTION
## Summary
- ensure new match resets waiting state by invoking `handleWaitingForPlayers` when advertising a match

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874fd3fedd08327afdacd921fdb2db6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the "Waiting for players..." state when a match has exactly one player, ensuring the correct behavior and messaging are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->