### PR TITLE
Add Animation inspector window

### DIFF
--- a/src/core/services/gameplay/animation-log-service.ts
+++ b/src/core/services/gameplay/animation-log-service.ts
@@ -1,0 +1,55 @@
+import { injectable } from "@needle-di/core";
+import type { AnimatableEntity } from "../../interfaces/entities/animatable-entity.js";
+import type { EntityAnimationService } from "./entity-animation-service.js";
+import { AnimationType } from "../../../game/enums/animation-type.js";
+
+export type AnimationLogItem = {
+  entityName: string;
+  type: AnimationType;
+  progress: number;
+  finished: boolean;
+};
+
+@injectable()
+export class AnimationLogService {
+  private readonly entries: AnimationLogItem[] = [];
+  private readonly map = new Map<EntityAnimationService, AnimationLogItem>();
+
+  public register(
+    service: EntityAnimationService,
+    entity: AnimatableEntity,
+    type: AnimationType
+  ): void {
+    const entry: AnimationLogItem = {
+      entityName: entity.constructor.name,
+      type,
+      progress: 0,
+      finished: false,
+    };
+    this.entries.push(entry);
+    this.map.set(service, entry);
+  }
+
+  public update(
+    service: EntityAnimationService,
+    progress: number,
+    finished: boolean
+  ): void {
+    const entry = this.map.get(service);
+    if (!entry) return;
+    entry.progress = progress;
+    if (finished) {
+      entry.finished = true;
+      this.map.delete(service);
+    }
+  }
+
+  public getEntries(): AnimationLogItem[] {
+    return this.entries;
+  }
+
+  public clear(): void {
+    this.entries.length = 0;
+    this.map.clear();
+  }
+}

--- a/src/core/services/gameplay/entity-animation-service.ts
+++ b/src/core/services/gameplay/entity-animation-service.ts
@@ -1,8 +1,13 @@
 import { AnimationType } from "../../../game/enums/animation-type.js";
 import type { AnimatableEntity } from "../../interfaces/entities/animatable-entity.js";
+import { AnimationLogService } from "./animation-log-service.js";
+import { container } from "../di-container.js";
 
 export class EntityAnimationService {
   private readonly entity: AnimatableEntity;
+
+  private readonly animationLogService: AnimationLogService =
+    container.get(AnimationLogService);
 
   private completed: boolean = false;
 
@@ -26,6 +31,8 @@ export class EntityAnimationService {
     this.endValue = endValue;
     this.durationMilliseconds = durationSeconds * 1000;
     this.animationType = animationType;
+
+    this.animationLogService.register(this, entity, animationType);
 
     console.log(
       `${this.constructor.name} [${AnimationType[animationType]}] created for ${entity.constructor.name}`
@@ -67,6 +74,12 @@ export class EntityAnimationService {
     }
 
     this.completed = progress >= 1;
+
+    this.animationLogService.update(this, progress, this.completed);
+  }
+
+  public getProgress(): number {
+    return Math.min(this.elapsedMilliseconds / this.durationMilliseconds, 1);
   }
 
   public isCompleted(): boolean {

--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -19,6 +19,7 @@ import { CredentialService } from "../../game/services/security/credential-servi
 import { CameraService } from "./gameplay/camera-service.js";
 import { SpawnPointService } from "../../game/services/gameplay/spawn-point-service.js";
 import { ChatService } from "../../game/services/network/chat-service.js";
+import { AnimationLogService } from "./gameplay/animation-log-service.js";
 
 export class ServiceRegistry {
   public static register(canvas: HTMLCanvasElement, debugging: boolean): void {
@@ -57,6 +58,7 @@ export class ServiceRegistry {
     });
     container.bind({ provide: WebRTCService, useClass: WebRTCService });
     container.bind({ provide: ChatService, useClass: ChatService });
+    container.bind({ provide: AnimationLogService, useClass: AnimationLogService });
     container.bind({ provide: CameraService, useClass: CameraService });
     container.bind({ provide: SpawnPointService, useClass: SpawnPointService });
     container.bind({

--- a/src/game/debug/animation-inspector-window.ts
+++ b/src/game/debug/animation-inspector-window.ts
@@ -1,0 +1,57 @@
+import { ImGui, ImVec2 } from "@mori2003/jsimgui";
+import { BaseWindow } from "../../core/debug/base-window.js";
+import { AnimationType } from "../enums/animation-type.js";
+import { AnimationLogService } from "../../core/services/gameplay/animation-log-service.js";
+import { container } from "../../core/services/di-container.js";
+import { injectable } from "@needle-di/core";
+
+@injectable()
+export class AnimationInspectorWindow extends BaseWindow {
+  private readonly animationLogService: AnimationLogService;
+
+  constructor() {
+    super("Animation inspector", new ImVec2(350, 250));
+    this.animationLogService = container.get(AnimationLogService);
+  }
+
+  protected override renderContent(): void {
+    const entries = this.animationLogService.getEntries();
+
+    const tableFlags =
+      ImGui.TableFlags.Borders |
+      ImGui.TableFlags.RowBg |
+      ImGui.TableFlags.Resizable |
+      ImGui.TableFlags.ScrollY |
+      ImGui.TableFlags.SizingStretchProp;
+
+    if (ImGui.BeginTable("AnimationsTable", 3, tableFlags, new ImVec2(0, 200))) {
+      ImGui.TableSetupColumn("Entity", ImGui.TableColumnFlags.WidthStretch);
+      ImGui.TableSetupColumn("Type", ImGui.TableColumnFlags.WidthFixed, 90);
+      ImGui.TableSetupColumn("Progress", ImGui.TableColumnFlags.WidthFixed, 80);
+      ImGui.TableHeadersRow();
+
+      entries.forEach((entry) => {
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+        ImGui.Text(entry.entityName);
+        ImGui.TableSetColumnIndex(1);
+        ImGui.Text(AnimationType[entry.type]);
+        ImGui.TableSetColumnIndex(2);
+        const progressText = `${(entry.progress * 100).toFixed(0)}%`;
+        if (entry.finished) {
+          ImGui.PushStyleColor(ImGui.Col.Text, 0xff00ff00);
+          ImGui.Text(progressText);
+          ImGui.PopStyleColor();
+        } else {
+          ImGui.Text(progressText);
+        }
+      });
+
+      ImGui.EndTable();
+    }
+
+    if (ImGui.Button("Clear")) {
+      this.animationLogService.clear();
+    }
+  }
+}

--- a/src/game/debug/debug-window.ts
+++ b/src/game/debug/debug-window.ts
@@ -5,6 +5,7 @@ import { MatchInspectorWindow } from "./match-inspector-window.js";
 import { BaseWindow } from "../../core/debug/base-window.js";
 import { PeerInspectorWindow } from "./peer-inspector-window.js";
 import { ChatInspectorWindow } from "./chat-inspector-window.js";
+import { AnimationInspectorWindow } from "./animation-inspector-window.js";
 import type { GameState } from "../../core/models/game-state.js";
 
 export class DebugWindow extends BaseWindow {
@@ -12,6 +13,7 @@ export class DebugWindow extends BaseWindow {
   private sceneInspectorWindow: SceneInspectorWindow;
   private matchInspectorWindow: MatchInspectorWindow;
   private peerInspectorWindow: PeerInspectorWindow;
+  private animationInspectorWindow: AnimationInspectorWindow;
   private chatInspectorWindow: ChatInspectorWindow;
 
   constructor(private gameState: GameState) {
@@ -20,6 +22,7 @@ export class DebugWindow extends BaseWindow {
     this.sceneInspectorWindow = new SceneInspectorWindow(gameState);
     this.matchInspectorWindow = new MatchInspectorWindow(gameState);
     this.peerInspectorWindow = new PeerInspectorWindow();
+    this.animationInspectorWindow = new AnimationInspectorWindow();
     this.chatInspectorWindow = new ChatInspectorWindow();
     this.open();
   }
@@ -47,6 +50,10 @@ export class DebugWindow extends BaseWindow {
 
     if (this.peerInspectorWindow.isOpen()) {
       this.peerInspectorWindow.render();
+    }
+
+    if (this.animationInspectorWindow.isOpen()) {
+      this.animationInspectorWindow.render();
     }
 
     if (this.chatInspectorWindow.isOpen()) {
@@ -77,6 +84,10 @@ export class DebugWindow extends BaseWindow {
 
         if (ImGui.MenuItem("Peers", "P")) {
           this.peerInspectorWindow.toggle();
+        }
+
+        if (ImGui.MenuItem("Animation", "A")) {
+          this.animationInspectorWindow.toggle();
         }
 
         if (ImGui.MenuItem("Chat", "C")) {


### PR DESCRIPTION
## Summary
- track animations in a new AnimationLogService
- expose progress in EntityAnimationService
- add Animation inspector window to debug menu
- register the new service

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68752ed437d8832787b49e9c3a3e4f8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Animation Inspector window to the debug menu, allowing users to view real-time animation progress for entities in a detailed table.
  * Users can clear the animation log entries directly from the inspector window.
  * Animation progress is now tracked and can be inspected visually, with completed animations highlighted for clarity.

* **Improvements**
  * Debug menu now includes a shortcut ("A") to quickly access the Animation Inspector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->