### PR TITLE
Fix chat input hide logic

### DIFF
--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -60,11 +60,6 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
   }
 
   private hideInput(): void {
-    if (!this.inputVisible) {
-      return;
-    }
-
-    this.inputVisible = false;
     this.inputElement.blur();
     this.inputElement.classList.remove("show");
     const onTransitionEnd = () => {
@@ -75,6 +70,7 @@ export class ChatButtonEntity extends BaseTappableGameEntity {
       once: true,
     });
     this.gamePointer.setPreventDefault(true);
+    this.inputVisible = false;
     this.setActive(true);
   }
 


### PR DESCRIPTION
## Summary
- revert guard clause in chat button hideInput method
- set `inputVisible` after hiding the DOM element

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875613c43e483279a978167425f6e5d