### PR TITLE
Fix color for animation progress in inspector

### DIFF
--- a/src/game/debug/animation-inspector-window.ts
+++ b/src/game/debug/animation-inspector-window.ts
@@ -8,7 +8,8 @@ import { injectable } from "@needle-di/core";
 @injectable()
 export class AnimationInspectorWindow extends BaseWindow {
   private static readonly COLOR_FINISHED = 0xff00ff00;
-  private static readonly COLOR_IN_PROGRESS = 0xffffa500;
+  // Use ABGR format for consistency with other debug colors
+  private static readonly COLOR_IN_PROGRESS = 0xff00a5ff; // orange
   private readonly animationLogService: AnimationLogService;
 
   constructor() {


### PR DESCRIPTION
## Summary
- correct the color constant in the Animation Inspector so that in-progress animations show orange rather than blue

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875750ad138832799440b2aa7ce142b