### PR TITLE
Implement auto scroll in animation inspector

### DIFF
--- a/src/game/debug/animation-inspector-window.ts
+++ b/src/game/debug/animation-inspector-window.ts
@@ -11,6 +11,7 @@ export class AnimationInspectorWindow extends BaseWindow {
   // Use ABGR format for consistency with other debug colors
   private static readonly COLOR_IN_PROGRESS = 0xff00a5ff; // orange
   private readonly animationLogService: AnimationLogService;
+  private previousEntryCount = 0;
 
   constructor() {
     // Slightly increased window height for better readability
@@ -20,6 +21,7 @@ export class AnimationInspectorWindow extends BaseWindow {
 
   protected override renderContent(): void {
     const entries = this.animationLogService.getEntries();
+    const newEntryAdded = entries.length > this.previousEntryCount;
 
     const tableFlags =
       ImGui.TableFlags.Borders |
@@ -34,7 +36,7 @@ export class AnimationInspectorWindow extends BaseWindow {
       ImGui.TableSetupColumn("Progress", ImGui.TableColumnFlags.WidthFixed, 80);
       ImGui.TableHeadersRow();
 
-      entries.forEach((entry) => {
+      entries.forEach((entry, index) => {
         ImGui.TableNextRow();
         ImGui.TableSetColumnIndex(0);
         ImGui.Text(entry.entityName);
@@ -48,13 +50,18 @@ export class AnimationInspectorWindow extends BaseWindow {
         ImGui.PushStyleColor(ImGui.Col.Text, color);
         ImGui.Text(progressText);
         ImGui.PopStyleColor();
+        if (newEntryAdded && index === entries.length - 1) {
+          ImGui.SetScrollHereY(1.0);
+        }
       });
 
       ImGui.EndTable();
+      this.previousEntryCount = entries.length;
     }
 
     if (ImGui.Button("Clear")) {
       this.animationLogService.clear();
+      this.previousEntryCount = 0;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add tracking for number of animation log entries
- automatically scroll to the bottom of the table when a new log entry appears

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687576703414832789113f305e30d1d9