### PR TITLE
Fix scene events not re-subscribed on returning

### DIFF
--- a/src/core/interfaces/scenes/game-scene.ts
+++ b/src/core/interfaces/scenes/game-scene.ts
@@ -30,4 +30,9 @@ export interface GameScene {
    * Cleanup resources when the scene is removed from the stack.
    */
   dispose(): void;
+
+  /**
+   * Re-subscribe events when returning to a previously disposed scene.
+   */
+  resubscribeEvents(): void;
 }

--- a/src/core/scenes/base-game-scene.ts
+++ b/src/core/scenes/base-game-scene.ts
@@ -280,6 +280,8 @@ export class BaseGameScene implements GameScene {
       return;
     }
 
+    previousScene.resubscribeEvents();
+
     console.log("Returning to", previousScene.constructor.name);
 
     this.sceneManagerService
@@ -289,6 +291,11 @@ export class BaseGameScene implements GameScene {
         previousScene,
         crossfadeDurationSeconds
       );
+  }
+
+  public resubscribeEvents(): void {
+    // Scenes can override this if they need to bind events again after
+    // being disposed when returning from the stack.
   }
 
   public dispose(): void {

--- a/src/game/scenes/main/login/login-scene.ts
+++ b/src/game/scenes/main/login/login-scene.ts
@@ -222,6 +222,10 @@ export class LoginScene extends BaseGameScene {
     this.controller.connectToServer();
   }
 
+  public override resubscribeEvents(): void {
+    this.subscribeToEvents();
+  }
+
   private transitionToMainMenuScene(): void {
     const mainMenuScene = new MainMenuScene(
       this.gameState,

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -255,6 +255,10 @@ export class MainMenuScene extends BaseGameScene {
     });
   }
 
+  public override resubscribeEvents(): void {
+    this.subscribeToEvents();
+  }
+
 
   private handleOnlinePlayersEvent(payload: OnlinePlayersPayload): void {
     this.onlinePlayersEntity?.setOnlinePlayers(payload.total);

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -420,6 +420,10 @@ export class WorldScene extends BaseCollidingGameScene {
     return "ontouchstart" in window || navigator.maxTouchPoints > 0;
   }
 
+  public override resubscribeEvents(): void {
+    this.subscribeToEvents();
+  }
+
   private async returnToMainMenuScene(): Promise<void> {
     const mainScene = new MainScene(
       this.gameState,


### PR DESCRIPTION
## Summary
- allow scenes to resubscribe to events after being disposed
- hook up event re-subscribing when returning to a previous scene
- implement resubscribe logic for `WorldScene`, `LoginScene`, and `MainMenuScene`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875811e9a408327b4665c937c628d25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scene management to automatically re-subscribe to events when returning to previously used scenes, ensuring smoother transitions and consistent functionality in the login, main menu, and world scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->