### PR TITLE
Add reconnect logic to main menu

### DIFF
--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -147,16 +147,37 @@ export class GameLoopService {
   }
 
   private handleServerDisconnectedEvent(
-    payload: ServerDisconnectedPayload
+    _payload: ServerDisconnectedPayload
   ): void {
+    const currentScene = this.gameFrame.getCurrentScene();
 
-    if (payload.connectionLost) {
-      alert("Connection to server was lost");
-    } else {
-      alert("Failed to connect to server");
+    if (currentScene instanceof MainScene) {
+      const subScene = currentScene
+        .getSceneManagerService()
+        ?.getCurrentScene();
+
+      if (subScene instanceof MainMenuScene) {
+        subScene.startServerReconnection();
+        return;
+      }
     }
 
-    window.location.reload();
+    const mainScene = new MainScene(
+      this.gameState,
+      container.get(EventConsumerService)
+    );
+    const mainMenuScene = new MainMenuScene(
+      this.gameState,
+      container.get(EventConsumerService),
+      false
+    );
+
+    mainScene.activateScene(mainMenuScene);
+    mainScene.load();
+
+    this.sceneTransitionService.fadeOutAndIn(this.gameFrame, mainScene, 1, 1);
+
+    mainMenuScene.startServerReconnection();
   }
 
   private handleServerNotificationEvent(

--- a/src/game/scenes/main/main-menu/main-menu-entity-factory.ts
+++ b/src/game/scenes/main/main-menu/main-menu-entity-factory.ts
@@ -4,6 +4,7 @@ import { ServerMessageWindowEntity } from "../../../entities/server-message-wind
 import { CloseableMessageEntity } from "../../../entities/common/closeable-message-entity.js";
 import { OnlinePlayersEntity } from "../../../entities/online-players-entity.js";
 import { WelcomeMessageEntity } from "../../../entities/welcome-message-entity.js";
+import { ToastEntity } from "../../../entities/common/toast-entity.js";
 import type { GameState } from "../../../../core/models/game-state.js";
 
 export interface MainMenuEntities {
@@ -13,6 +14,7 @@ export interface MainMenuEntities {
   closeableMessageEntity: CloseableMessageEntity;
   welcomeMessageEntity: WelcomeMessageEntity;
   onlinePlayersEntity: OnlinePlayersEntity;
+  toastEntity: ToastEntity;
 }
 
 export class MainMenuEntityFactory {
@@ -43,6 +45,7 @@ export class MainMenuEntityFactory {
       this.gameState
     );
     const onlinePlayersEntity = new OnlinePlayersEntity(this.canvas);
+    const toastEntity = new ToastEntity(this.canvas);
 
     return {
       titleEntity,
@@ -51,6 +54,7 @@ export class MainMenuEntityFactory {
       closeableMessageEntity,
       welcomeMessageEntity,
       onlinePlayersEntity,
+      toastEntity,
     };
   }
 }

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -32,6 +32,7 @@ export class MainMenuScene extends BaseGameScene {
   private closeableMessageEntity: CloseableMessageEntity | null = null;
   private onlinePlayersEntity: OnlinePlayersEntity | null = null;
   private toastEntity: ToastEntity | null = null;
+  private isReconnecting = false;
 
   constructor(
     gameState: GameState,
@@ -276,6 +277,11 @@ export class MainMenuScene extends BaseGameScene {
   }
 
   public startServerReconnection(): void {
+    if (this.isReconnecting) {
+      return;
+    }
+
+    this.isReconnecting = true;
     this.toastEntity?.show("Reconnecting to game server...");
     this.disableMenuButtons();
     container.get(WebSocketService).connectToServer();
@@ -291,6 +297,7 @@ export class MainMenuScene extends BaseGameScene {
   }
 
   private handleServerConnectedEvent(): void {
+    this.isReconnecting = false;
     this.toastEntity?.hide();
     this.enableMenuButtons();
   }


### PR DESCRIPTION
## Summary
- allow `MainMenuScene` to reconnect when server connection is lost
- show reconnection toast while retrying
- bypass page reload in `GameLoopService` if main menu will reconnect

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876908f1f008327bed7ef2435c8a8f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toast notifications to the main menu for displaying transient messages.
  * Main menu now provides real-time feedback and disables menu buttons when the server connection is lost, showing a "Reconnecting to game server..." message.
  * Menu buttons are re-enabled and the toast is hidden once the connection is restored.

* **Improvements**
  * Enhanced handling of server disconnection and reconnection events for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->