### PR TITLE
Notify main menu on lost connection

### DIFF
--- a/src/core/services/gameplay/game-loop-service.ts
+++ b/src/core/services/gameplay/game-loop-service.ts
@@ -147,7 +147,7 @@ export class GameLoopService {
   }
 
   private handleServerDisconnectedEvent(
-    _payload: ServerDisconnectedPayload
+    payload: ServerDisconnectedPayload
   ): void {
     const currentScene = this.gameFrame.getCurrentScene();
 
@@ -160,11 +160,17 @@ export class GameLoopService {
         this.gameState.setMatch(null);
         this.gameState.getGamePlayer().reset();
         subScene.startServerReconnection();
+        if (payload.connectionLost) {
+          subScene.setPendingMessage("Connection to server was lost");
+        }
         return;
       }
     }
 
-    this.returnToMainMenuScene(true);
+    const message = payload.connectionLost
+      ? "Connection to server was lost"
+      : undefined;
+    this.returnToMainMenuScene(true, message);
   }
 
   private handleServerNotificationEvent(
@@ -174,12 +180,14 @@ export class GameLoopService {
   }
 
   private handleHostDisconnectedEvent(): void {
-    alert("Host has disconnected");
-
-    this.returnToMainMenuScene(false);
+    const message = "Host has disconnected";
+    this.returnToMainMenuScene(false, message);
   }
 
-  private returnToMainMenuScene(reconnect: boolean): void {
+  private returnToMainMenuScene(
+    reconnect: boolean,
+    message?: string
+  ): void {
     this.gameState.setMatch(null);
     this.gameState.getGamePlayer().reset();
 
@@ -195,6 +203,10 @@ export class GameLoopService {
 
     mainScene.activateScene(mainMenuScene);
     mainScene.load();
+
+    if (message) {
+      mainMenuScene.setPendingMessage(message);
+    }
 
     this.sceneTransitionService.fadeOutAndIn(
       this.gameFrame,

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -33,6 +33,7 @@ export class MainMenuScene extends BaseGameScene {
   private onlinePlayersEntity: OnlinePlayersEntity | null = null;
   private toastEntity: ToastEntity | null = null;
   private isReconnecting = false;
+  private pendingMessage: string | null = null;
 
   constructor(
     gameState: GameState,
@@ -91,6 +92,11 @@ export class MainMenuScene extends BaseGameScene {
 
     if (this.showNews) {
       this.downloadServerMessages();
+    }
+
+    if (this.pendingMessage) {
+      this.closeableMessageEntity?.show(this.pendingMessage);
+      this.pendingMessage = null;
     }
   }
 
@@ -274,6 +280,10 @@ export class MainMenuScene extends BaseGameScene {
 
   public override resubscribeEvents(): void {
     this.subscribeToEvents();
+  }
+
+  public setPendingMessage(message: string): void {
+    this.pendingMessage = message;
   }
 
   public startServerReconnection(): void {


### PR DESCRIPTION
## Summary
- show a message on the main menu when returning after losing connection
- support passing connection notice when returning to the menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876a4d1af788327a976444c4f2fd3ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disconnection and host disconnect messages are now displayed directly within the main menu scene, replacing previous alert dialogs.
  * Added support for deferred display of important messages when returning to the main menu.

* **Improvements**
  * Enhanced consistency in how disconnection-related notifications are shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->