### PR TITLE
Fix stuck game pointer when window loses focus

### DIFF
--- a/src/core/models/game-pointer.ts
+++ b/src/core/models/game-pointer.ts
@@ -196,5 +196,32 @@ export class GamePointer implements IGamePointer {
       },
       { passive: false }
     );
+
+    // Reset pointer state if the window loses focus
+    window.addEventListener("blur", () => {
+      this.reset();
+    });
+
+    // Handle pointer cancel events similarly to pointer up
+    this.canvas.addEventListener(
+      "pointercancel",
+      (event) => {
+        const touch = this.touches.get(event.pointerId);
+        if (touch) {
+          touch.pressing = false;
+          touch.pressed = false;
+        }
+
+        if (this.primaryPointerId === event.pointerId) {
+          const next = Array.from(this.touches.values()).find((t) => t.pressing);
+          this.primaryPointerId = next ? next.pointerId : null;
+          if (next) {
+            next.initialX = next.x;
+            next.initialY = next.y;
+          }
+        }
+      },
+      { passive: false }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- reset `GamePointer` when the window is blurred
- handle `pointercancel` events similarly to pointer up

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876a32719bc8327a23cd46ab94010da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pointer handling by resetting touch states when the window loses focus and handling pointer cancellation events for smoother input management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->