### PR TITLE
Fix teleport interpolation

### DIFF
--- a/src/core/entities/base-moveable-game-entity.ts
+++ b/src/core/entities/base-moveable-game-entity.ts
@@ -6,6 +6,7 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
   protected width: number = 0;
   protected height: number = 0;
   protected angle: number = 0;
+  protected skipInterpolation = false;
 
   constructor() {
     super();
@@ -49,5 +50,9 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
 
   public setAngle(angle: number): void {
     this.angle = angle;
+  }
+
+  public setSkipInterpolation(): void {
+    this.skipInterpolation = true;
   }
 }

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -52,6 +52,7 @@ export class BallEntity
   public override reset(): void {
     this.resetVelocityAndPosition();
     this.inactive = false;
+    this.setSkipInterpolation();
     super.reset();
   }
 
@@ -59,6 +60,7 @@ export class BallEntity
     // Set position to the center of the canvas accounting for the radius
     this.x = this.canvas.width / 2;
     this.y = this.canvas.height / 2;
+    this.setSkipInterpolation();
   }
 
   public isInactive(): boolean {
@@ -127,8 +129,14 @@ export class BallEntity
 
     const newX = binaryReader.unsignedInt16();
     const newY = binaryReader.unsignedInt16();
-    this.x = MathUtils.lerp(this.x, newX, 0.5);
-    this.y = MathUtils.lerp(this.y, newY, 0.5);
+    if (this.skipInterpolation) {
+      this.x = newX;
+      this.y = newY;
+      this.skipInterpolation = false;
+    } else {
+      this.x = MathUtils.lerp(this.x, newX, 0.5);
+      this.y = MathUtils.lerp(this.y, newY, 0.5);
+    }
 
     this.vx = binaryReader.signedInt16();
     this.vy = binaryReader.signedInt16();

--- a/src/game/entities/remote-car-entity.ts
+++ b/src/game/entities/remote-car-entity.ts
@@ -65,10 +65,17 @@ export class RemoteCarEntity extends CarEntity {
     const newY = scaledY / SCALE_FACTOR_FOR_COORDINATES;
     const newAngle = binaryReader.signedInt16() / SCALE_FACTOR_FOR_ANGLES;
 
-    // Smooth the remote movement to reduce jitter
-    this.x = MathUtils.lerp(this.x, newX, 0.5);
-    this.y = MathUtils.lerp(this.y, newY, 0.5);
-    this.angle = MathUtils.lerp(this.angle, newAngle, 0.5);
+    if (this.skipInterpolation) {
+      this.x = newX;
+      this.y = newY;
+      this.angle = newAngle;
+      this.skipInterpolation = false;
+    } else {
+      // Smooth the remote movement to reduce jitter
+      this.x = MathUtils.lerp(this.x, newX, 0.5);
+      this.y = MathUtils.lerp(this.y, newY, 0.5);
+      this.angle = MathUtils.lerp(this.angle, newAngle, 0.5);
+    }
 
     this.speed = binaryReader.signedInt16() / SCALE_FACTOR_FOR_SPEED;
     this.boosting = binaryReader.unsignedInt8() === 1;


### PR DESCRIPTION
## Summary
- move interpolation skip flag into base moveable entity
- use the flag in ball and remote car without redeclaring it

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d30bb135c8327b7180151ca3c72a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved synchronization for game entities by conditionally bypassing position and angle smoothing after certain actions, resulting in more accurate and responsive updates during resets or repositioning.

* **Bug Fixes**
  * Reduced potential visual jitter or lag when resetting or moving the ball and remote cars, ensuring smoother gameplay transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->