### PR TITLE
Fix spawn interpolation

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -136,6 +136,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
         this.x = this.respawnX;
         this.y = this.respawnY;
         this.updateHitbox();
+        this.setSkipInterpolation();
       }
       super.update(deltaTimeStamp);
       return;

--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -35,7 +35,10 @@ export class WorldController {
     private readonly localCarEntity: LocalCarEntity,
     private readonly alertEntity: AlertEntity,
     private readonly boostPadsEntities: BoostPadEntity[],
-    private readonly spawnPointEntities: SpawnPointEntity[]
+    private readonly spawnPointEntities: SpawnPointEntity[],
+    private readonly getEntitiesByOwner: (
+      player: GamePlayer
+    ) => BaseMultiplayerGameEntity[]
   ) {
     this.assignInitialSpawnPoint();
     this.moveCarToSpawnPoint();
@@ -130,6 +133,7 @@ export class WorldController {
     this.ballEntity.reset();
     this.localCarEntity.reset();
     this.moveCarToSpawnPoint();
+    this.markRemoteCarsForSpawn();
     this.localCarEntity.refillBoost();
     this.boostPadsEntities.forEach((pad) => pad.reset());
   }
@@ -141,6 +145,7 @@ export class WorldController {
     this.alertEntity.hide();
     this.localCarEntity.reset();
     this.moveCarToSpawnPoint();
+    this.markRemoteCarsForSpawn();
     this.ballEntity.reset();
     this.scoreboardEntity.startTimer();
   }
@@ -190,7 +195,22 @@ export class WorldController {
         const y = spawnPoint.getY();
         this.localCarEntity.setX(x);
         this.localCarEntity.setY(y);
+        this.localCarEntity.setSkipInterpolation();
       }
+    });
+  }
+
+  private markRemoteCarsForSpawn(): void {
+    const players = this.gameState.getMatch()?.getPlayers() ?? [];
+    players.forEach((player) => {
+      if (player === this.gameState.getGamePlayer()) {
+        return;
+      }
+      this.getEntitiesByOwner(player).forEach((entity) => {
+        if (entity instanceof CarEntity) {
+          entity.setSkipInterpolation();
+        }
+      });
     });
   }
 

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -119,7 +119,8 @@ export class WorldScene extends BaseCollidingGameScene {
       this.localCarEntity,
       this.alertEntity,
       this.boostPadsEntities,
-      this.spawnPointEntities
+      this.spawnPointEntities,
+      this.getEntitiesByOwner.bind(this)
     );
 
     this.scoreManagerService = new ScoreManagerService(


### PR DESCRIPTION
## Summary
- prevent interpolation when cars respawn
- mark remote cars to skip interpolation when moving to spawn
- wire WorldController to getEntitiesByOwner so remote cars can be updated

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d34ef3f3883279afa499161ff0a2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of car respawns and resets to ensure smoother transitions for both local and remote players during countdowns and respawn events.

* **Bug Fixes**
  * Reduced visual glitches when cars are repositioned by skipping interpolation after respawn or reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->