### PR TITLE
Fix car collision after explosion

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -130,6 +130,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
       this.respawnTimer -= deltaTimeStamp;
       if (this.respawnTimer <= 0) {
         this.demolished = false;
+        this.rigidBody = true;
         this.opacity = 1;
         this.angle = 1.5708;
         this.speed = 0;
@@ -242,6 +243,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     this.vy = 0;
     this.boosting = false;
     this.opacity = 0;
+    this.rigidBody = false;
   }
 
   public isDemolished(): boolean {


### PR DESCRIPTION
## Summary
- disable car hitbox and rigid body while demolished
- re-enable collision on respawn

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d381e203883278ac6ee756b439abc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved car behavior by ensuring its physical interactions are correctly updated when demolished or respawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->