### PR TITLE
Fix boosting serialization format

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -108,7 +108,6 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     const angle = Math.round(this.angle * SCALE_FACTOR_FOR_ANGLES);
     const speed = Math.round(this.speed * SCALE_FACTOR_FOR_SPEED);
     const boost = Math.round(this.boost);
-    const boosting = this.boosting ? 1 : 0;
 
     const scaledX = Math.round(this.x * SCALE_FACTOR_FOR_COORDINATES);
     const scaledY = Math.round(this.y * SCALE_FACTOR_FOR_COORDINATES);
@@ -118,7 +117,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
       .unsignedInt16(scaledY)
       .signedInt16(angle)
       .signedInt16(speed)
-      .unsignedInt8(boosting)
+      .boolean(this.boosting)
       .unsignedInt8(boost)
       .toArrayBuffer();
 

--- a/src/game/entities/remote-car-entity.ts
+++ b/src/game/entities/remote-car-entity.ts
@@ -42,7 +42,7 @@ export class RemoteCarEntity extends CarEntity {
     const y = scaledY / SCALE_FACTOR_FOR_COORDINATES;
     const angle = binaryReader.signedInt16() / SCALE_FACTOR_FOR_ANGLES;
     const speed = binaryReader.signedInt16() / SCALE_FACTOR_FOR_SPEED;
-    const boosting = binaryReader.unsignedInt8() === 1;
+    const boosting = binaryReader.boolean();
     const boost = binaryReader.unsignedInt8();
 
     return new RemoteCarEntity(
@@ -78,7 +78,7 @@ export class RemoteCarEntity extends CarEntity {
     }
 
     this.speed = binaryReader.signedInt16() / SCALE_FACTOR_FOR_SPEED;
-    this.boosting = binaryReader.unsignedInt8() === 1;
+    this.boosting = binaryReader.boolean();
     this.boost = binaryReader.unsignedInt8();
 
     this.updateHitbox();


### PR DESCRIPTION
## Summary
- serialize `boosting` as a boolean when sending car data
- read `boosting` using `BinaryReader.boolean()` when creating or updating remote cars

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d3aa787348327979812f154f92267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how the boosting state is handled during game data serialization and synchronization, using a more efficient boolean format instead of a numeric value. No changes to gameplay or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->