### PR TITLE
Reduce opacity for inactive tappables

### DIFF
--- a/src/core/entities/base-tappable-game-entity.ts
+++ b/src/core/entities/base-tappable-game-entity.ts
@@ -73,6 +73,7 @@ export class BaseTappableGameEntity extends BaseAnimatedGameEntity {
       this.active
     ) {
       context.save();
+      this.applyOpacity(context);
 
       if (this.stealFocus) {
         this.drawFullSceneRectangle(context);
@@ -110,5 +111,14 @@ export class BaseTappableGameEntity extends BaseAnimatedGameEntity {
     context.rect(-this.width / 2, -this.height / 2, this.width, this.height);
     context.stroke();
     context.closePath();
+  }
+
+  protected override applyOpacity(context: CanvasRenderingContext2D): void {
+    super.applyOpacity(context);
+
+    // Reduce opacity slightly when the entity is inactive
+    if (!this.active) {
+      context.globalAlpha *= 0.5;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- make inactive tappable objects semi-transparent
- render debug outlines using the same opacity

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d3d61a818832791b6501d74203d29