### PR TITLE
Update vite config to migrate to Vercel

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  base: "/hood-ball/",
   server: {
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to default to the root path (/). Asset URLs and client-side routing now resolve relative to the site root, resulting in cleaner, shorter URLs when deployed at the domain root.
  * If the app was previously accessed under a subpath, deployments should be adjusted accordingly, as the application no longer assumes a sub-directory base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->