### PR TITLE
Refactor matchmaking services architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ battle.
 - Web Crypto API for server configuration and player scores handling
 - Debug menu to inspect game and network state
 
+## Matchmaking Architecture
+
+The matchmaking layer is split into focused services:
+
+- `MatchmakingService` discovers or advertises matches.
+- `MatchLifecycleService` handles game-over flow and score saving.
+- `MatchmakingNetworkService` manages network peers and dispatches
+  connection events.
+- `MatchmakingCoordinator` wires WebRTC, the event processor and the
+  networking layer during startup.
+
+Services interact through dependency injection and an event bus to avoid
+circular dependencies and lazy initialization.
+
 ## Demo
 
 https://github.com/user-attachments/assets/ae4b8b25-a3d4-4fdd-a5bf-f9d1fcb16f09

--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -1,6 +1,7 @@
 import { GameState } from "../models/game-state.js";
 import { container } from "./di-container.js";
 import { EventProcessorService } from "./gameplay/event-processor-service.js";
+import { EventConsumerService } from "./gameplay/event-consumer-service.js";
 import { MatchmakingService } from "../../game/services/gameplay/matchmaking-service.js";
 import { EntityOrchestratorService } from "../../game/services/gameplay/entity-orchestrator-service.js";
 import { WebRTCService } from "../../game/services/network/webrtc-service.js";
@@ -30,6 +31,10 @@ export class ServiceRegistry {
     container.bind({
       provide: EventProcessorService,
       useClass: EventProcessorService,
+    });
+    container.bind({
+      provide: EventConsumerService,
+      useClass: EventConsumerService,
     });
     container.bind({ provide: CryptoService, useClass: CryptoService });
     container.bind({ provide: CredentialService, useClass: CredentialService });

--- a/src/game/interfaces/services/gameplay/matchmaking-service-interface.ts
+++ b/src/game/interfaces/services/gameplay/matchmaking-service-interface.ts
@@ -5,6 +5,5 @@ export interface IMatchmakingService {
   findOrAdvertiseMatch(): Promise<void>;
   savePlayerScore(): Promise<void>;
   handleGameOver(): Promise<void>;
-  finalizeIfNoPendingDisconnections(): void;
   renderDebugInformation(context: CanvasRenderingContext2D): void;
 }

--- a/src/game/services/gameplay/disconnection-monitor.ts
+++ b/src/game/services/gameplay/disconnection-monitor.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from "@needle-di/core";
+import type { ITimerService } from "../../../core/interfaces/services/gameplay/timer-service-interface.js";
+import { TimerManagerService } from "../../../core/services/gameplay/timer-manager-service.js";
+
+@injectable()
+export class DisconnectionMonitor {
+  private readonly pending = new Set<string>();
+  private timeout: ITimerService | null = null;
+
+  constructor(
+    private readonly timerManager = inject(TimerManagerService)
+  ) {}
+
+  public track(playerIds: string[], onTimeout: () => void): void {
+    this.clear();
+    playerIds.forEach((id) => this.pending.add(id));
+    this.timeout = this.timerManager.createTimer(3, () => {
+      this.clear();
+      onTimeout();
+    });
+  }
+
+  public markDisconnected(playerId: string, onEmpty: () => void): void {
+    this.pending.delete(playerId);
+    if (this.pending.size === 0) {
+      this.timeout?.stop(false);
+      onEmpty();
+    }
+  }
+
+  public clear(): void {
+    this.timeout?.stop(false);
+    this.pending.clear();
+  }
+
+  public isTracking(): boolean {
+    return this.pending.size > 0;
+  }
+}

--- a/src/game/services/gameplay/disconnection-monitor.ts
+++ b/src/game/services/gameplay/disconnection-monitor.ts
@@ -30,6 +30,7 @@ export class DisconnectionMonitor {
 
   public clear(): void {
     this.timeout?.stop(false);
+    this.timeout = null;
     this.pending.clear();
   }
 

--- a/src/game/services/gameplay/match-lifecycle-service.ts
+++ b/src/game/services/gameplay/match-lifecycle-service.ts
@@ -63,8 +63,12 @@ export class MatchLifecycleService {
   }
 
   public async handleGameOver(): Promise<void> {
-    this.gameOverFinalized = false;
+    if (this.gameOverFinalized || this.gameOverInProgress) {
+      return;
+    }
+
     this.gameOverInProgress = true;
+    this.gameOverFinalized = false;
 
     if (this.gameState.getMatch()?.isHost()) {
       const peers = this.webrtcService.getPeers();
@@ -102,6 +106,9 @@ export class MatchLifecycleService {
     }
     this.gameOverFinalized = true;
     this.gameOverInProgress = false;
+    if (this.disconnectionMonitor.isTracking()) {
+      this.disconnectionMonitor.clear();
+    }
     this.gameState.setMatch(null);
     this.pendingIdentities.clear();
     this.receivedIdentities.clear();

--- a/src/game/services/gameplay/match-lifecycle-service.ts
+++ b/src/game/services/gameplay/match-lifecycle-service.ts
@@ -1,0 +1,112 @@
+import { inject, injectable } from "@needle-di/core";
+import { GameState } from "../../../core/models/game-state.js";
+import { APIService } from "../network/api-service.js";
+import { WebRTCService } from "../network/webrtc-service.js";
+import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
+import { EventConsumerService } from "../../../core/services/gameplay/event-consumer-service.js";
+import { LocalEvent } from "../../../core/models/local-event.js";
+import { EventType } from "../../enums/event-type.js";
+import type { SaveUserScoresRequest } from "../../interfaces/requests/save-score-request.js";
+import { GamePlayer } from "../../models/game-player.js";
+import type { IMatchmakingNetworkService } from "../../interfaces/services/network/matchmaking-network-service-interface.js";
+import { MatchmakingNetworkService } from "../network/matchmaking-network-service.js";
+import { DisconnectionMonitor } from "./disconnection-monitor.js";
+import { PendingIdentitiesToken, ReceivedIdentitiesToken } from "./matchmaking-tokens.js";
+import type { PlayerDisconnectedPayload } from "../../interfaces/events/player-disconnected-payload.js";
+import type { WebRTCPeer } from "../../interfaces/services/network/webrtc-peer.js";
+
+@injectable()
+export class MatchLifecycleService {
+  private gameOverFinalized = false;
+  private gameOverInProgress = false;
+
+  constructor(
+    private readonly gameState = inject(GameState),
+    private readonly apiService = inject(APIService),
+    private readonly webrtcService = inject(WebRTCService),
+    private readonly networkService: IMatchmakingNetworkService = inject(
+      MatchmakingNetworkService
+    ),
+    private readonly eventProcessor = inject(EventProcessorService),
+    private readonly eventConsumer = inject(EventConsumerService),
+    private readonly disconnectionMonitor = inject(DisconnectionMonitor),
+    private readonly pendingIdentities = inject(PendingIdentitiesToken),
+    private readonly receivedIdentities = inject(ReceivedIdentitiesToken)
+  ) {
+    this.eventConsumer.subscribeToLocalEvent(
+      EventType.PlayerDisconnected,
+      (data: PlayerDisconnectedPayload) => {
+        if (!this.gameOverInProgress || !data?.player) {
+          return;
+        }
+        const playerId = data.player.getId();
+        this.disconnectionMonitor.markDisconnected(playerId, () =>
+          this.finalizeGameOver()
+        );
+      }
+    );
+  }
+
+  public async savePlayerScore(): Promise<void> {
+    const players = this.gameState.getMatch()?.getPlayers();
+    if (!players || players.length === 0) {
+      console.warn("No players in the match to save score");
+      return;
+    }
+    const savePlayerScoresRequest: SaveUserScoresRequest[] = [];
+    players.forEach((player: GamePlayer) => {
+      const playerId = player.getId();
+      const totalScore = player.getScore();
+      savePlayerScoresRequest.push({ userId: playerId, totalScore });
+    });
+    await this.apiService.saveScore(savePlayerScoresRequest);
+  }
+
+  public async handleGameOver(): Promise<void> {
+    this.gameOverFinalized = false;
+    this.gameOverInProgress = true;
+
+    if (this.gameState.getMatch()?.isHost()) {
+      const peers = this.webrtcService.getPeers();
+      const playerIds: string[] = [];
+      peers.forEach((peer: WebRTCPeer) => {
+        const playerId = peer.getPlayer()?.getId();
+        if (playerId) {
+          playerIds.push(playerId);
+        }
+        peer.disconnectGracefully();
+      });
+
+      this.networkService.removePingCheckInterval();
+      await this.apiService
+        .removeMatch()
+        .catch((error: unknown) => console.error(error));
+
+      this.disconnectionMonitor.track(playerIds, () => {
+        console.warn("Game over timeout reached, forcing finalization");
+        this.finalizeGameOver();
+      });
+
+      if (playerIds.length === 0) {
+        this.finalizeGameOver();
+      }
+    } else {
+      this.finalizeGameOver();
+    }
+  }
+
+  private finalizeGameOver(): void {
+    if (this.gameOverFinalized) {
+      console.log("Game over already finalized, skipping");
+      return;
+    }
+    this.gameOverFinalized = true;
+    this.gameOverInProgress = false;
+    this.gameState.setMatch(null);
+    this.pendingIdentities.clear();
+    this.receivedIdentities.clear();
+    const localEvent = new LocalEvent(EventType.ReturnToMainMenu);
+    this.eventProcessor.addLocalEvent(localEvent);
+    console.log("Game over finalized, returning to main menu");
+  }
+}

--- a/src/game/services/gameplay/matchmaking-controller-service.ts
+++ b/src/game/services/gameplay/matchmaking-controller-service.ts
@@ -1,23 +1,20 @@
+import { inject, injectable } from "@needle-di/core";
 import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
 import { LocalEvent } from "../../../core/models/local-event.js";
 import { EventType } from "../../enums/event-type.js";
 import { MatchmakingService } from "./matchmaking-service.js";
-import { container } from "../../../core/services/di-container.js";
-import { injectable } from "@needle-di/core";
 import type { IMatchmakingService } from "../../interfaces/services/gameplay/matchmaking-service-interface.js";
 
 @injectable()
 export class MatchmakingControllerService {
-  private readonly matchmakingService: IMatchmakingService;
-  private readonly eventProcessor: EventProcessorService;
-
   constructor(
-    matchmakingService: IMatchmakingService = container.get(MatchmakingService),
-    eventProcessor: EventProcessorService = container.get(EventProcessorService)
-  ) {
-    this.matchmakingService = matchmakingService;
-    this.eventProcessor = eventProcessor;
-  }
+    private readonly matchmakingService: IMatchmakingService = inject(
+      MatchmakingService
+    ),
+    private readonly eventProcessor: EventProcessorService = inject(
+      EventProcessorService
+    )
+  ) {}
 
   public async startMatchmaking(): Promise<void> {
     this.eventProcessor.addLocalEvent(

--- a/src/game/services/gameplay/matchmaking-coordinator.ts
+++ b/src/game/services/gameplay/matchmaking-coordinator.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from "@needle-di/core";
+import { WebRTCService } from "../network/webrtc-service.js";
+import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
+import { MatchmakingService } from "./matchmaking-service.js";
+
+@injectable()
+export class MatchmakingCoordinator {
+  constructor(
+    private readonly webrtcService = inject(WebRTCService),
+    private readonly matchmakingService = inject(MatchmakingService),
+    private readonly eventProcessor = inject(EventProcessorService)
+  ) {}
+
+  public initialize(): void {
+    this.eventProcessor.initialize(this.webrtcService);
+    this.webrtcService.initialize(this.matchmakingService.getNetworkService());
+  }
+}

--- a/src/game/services/gameplay/matchmaking-service.ts
+++ b/src/game/services/gameplay/matchmaking-service.ts
@@ -1,63 +1,28 @@
+import { inject, injectable } from "@needle-di/core";
 import { GameState } from "../../../core/models/game-state.js";
 import { MatchStateType } from "../../enums/match-state-type.js";
-import type { SaveUserScoresRequest } from "../../interfaces/requests/save-score-request.js";
 import { DebugUtils } from "../../../core/utils/debug-utils.js";
 import { WebSocketService } from "../network/websocket-service.js";
 import { WebRTCService } from "../network/webrtc-service.js";
-import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
-import { EventConsumerService } from "../../../core/services/gameplay/event-consumer-service.js";
-import { LocalEvent } from "../../../core/models/local-event.js";
-import { EventType } from "../../enums/event-type.js";
-import { APIService } from "../network/api-service.js";
-import { TimerManagerService } from "../../../core/services/gameplay/timer-manager-service.js";
-import { IntervalManagerService } from "../../../core/services/gameplay/interval-manager-service.js";
 import { MatchFinderService } from "./match-finder-service.js";
 import { MatchmakingNetworkService } from "../network/matchmaking-network-service.js";
-import { GamePlayer } from "../../models/game-player.js";
-import {
-  PendingIdentitiesToken,
-  ReceivedIdentitiesToken,
-  PendingDisconnectionsToken,
-} from "./matchmaking-tokens.js";
-import type { IMatchmakingService } from "../../interfaces/services/gameplay/matchmaking-service-interface.js";
 import type { IMatchmakingNetworkService } from "../../interfaces/services/network/matchmaking-network-service-interface.js";
-import { injectable } from "@needle-di/core";
-import { container } from "../../../core/services/di-container.js";
+import type { IMatchmakingService } from "../../interfaces/services/gameplay/matchmaking-service-interface.js";
+import { MatchLifecycleService } from "./match-lifecycle-service.js";
 
 @injectable()
 export class MatchmakingService implements IMatchmakingService {
-  private readonly apiService: APIService;
-  private readonly webSocketService: WebSocketService;
-  private readonly webrtcService: WebRTCService;
-  private readonly matchFinderService: MatchFinderService;
-  private readonly networkService: IMatchmakingNetworkService;
-  private readonly pendingDisconnections: Set<string>;
-  private readonly timerManagerService: TimerManagerService;
-  private gameOverFinalized: boolean = false;
-  private gameOverInProgress: boolean = false;
-  private readonly handlePlayerDisconnected = (): void => {
-    if (this.gameOverInProgress) {
-      this.finalizeIfNoPendingDisconnections();
-    }
-  };
-
-  constructor(private gameState = container.get(GameState)) {
-    this.timerManagerService = container.get(TimerManagerService);
-    container.get(IntervalManagerService);
-    this.apiService = container.get(APIService);
-    this.webSocketService = container.get(WebSocketService);
-    this.webrtcService = container.get(WebRTCService);
-    container.get(EventProcessorService);
-    this.matchFinderService = container.get(MatchFinderService);
-    this.networkService = container.get(MatchmakingNetworkService);
-    this.pendingDisconnections = container.get(PendingDisconnectionsToken);
+  constructor(
+    private readonly gameState = inject(GameState),
+    private readonly webSocketService = inject(WebSocketService),
+    private readonly webrtcService = inject(WebRTCService),
+    private readonly matchFinderService = inject(MatchFinderService),
+    private readonly networkService: IMatchmakingNetworkService = inject(
+      MatchmakingNetworkService
+    ),
+    private readonly lifecycleService = inject(MatchLifecycleService)
+  ) {
     this.registerCommandHandlers();
-
-    const eventConsumerService = container.get(EventConsumerService);
-    eventConsumerService.subscribeToLocalEvent(
-      EventType.PlayerDisconnected,
-      this.handlePlayerDisconnected
-    );
   }
 
   public getNetworkService(): IMatchmakingNetworkService {
@@ -91,103 +56,18 @@ export class MatchmakingService implements IMatchmakingService {
   }
 
   public async savePlayerScore(): Promise<void> {
-    const players = this.gameState.getMatch()?.getPlayers();
-
-    if (players === undefined || players.length === 0) {
-      console.warn("No players in the match to save score");
-      return;
-    }
-
-    const savePlayerScoresRequest: SaveUserScoresRequest[] = [];
-
-    players.forEach((player: GamePlayer) => {
-      const playerId = player.getId();
-      const totalScore = player.getScore();
-
-      savePlayerScoresRequest.push({
-        userId: playerId,
-        totalScore,
-      });
-    });
-
-    await this.apiService.saveScore(savePlayerScoresRequest);
+    await this.lifecycleService.savePlayerScore();
   }
 
   public async handleGameOver(): Promise<void> {
-    this.gameOverFinalized = false; // Reset the flag for new game over
-    this.gameOverInProgress = true;
-
-    if (this.gameState.getMatch()?.isHost()) {
-      const peers = this.webrtcService.getPeers();
-
-      this.pendingDisconnections.clear();
-      peers.forEach((peer) => {
-        const playerId = peer.getPlayer()?.getId();
-        if (playerId) {
-          this.pendingDisconnections.add(playerId);
-        }
-
-        peer.disconnectGracefully();
-      });
-
-      this.networkService.removePingCheckInterval();
-
-      await this.apiService
-        .removeMatch()
-        .catch((error) => console.error(error));
-
-      // Add a timeout to force finalize if disconnections don't complete
-      this.timerManagerService.createTimer(3, () => {
-        console.warn("Game over timeout reached, forcing finalization");
-        this.pendingDisconnections.clear();
-        this.finalizeGameOver();
-      });
-
-      this.finalizeIfNoPendingDisconnections();
-    } else {
-      this.finalizeGameOver();
-    }
-  }
-
-  public finalizeIfNoPendingDisconnections(): void {
-    console.log(
-      `Checking pending disconnections: ${this.pendingDisconnections.size} remaining`
-    );
-
-    if (this.pendingDisconnections.size === 0) {
-      console.log("No pending disconnections, finalizing game over");
-      this.finalizeGameOver();
-    } else {
-      console.log(
-        "Still waiting for pending disconnections:",
-        Array.from(this.pendingDisconnections)
-      );
-    }
-  }
-
-  private finalizeGameOver(): void {
-    if (this.gameOverFinalized) {
-      console.log("Game over already finalized, skipping");
-      return;
-    }
-
-    this.gameOverFinalized = true;
-    this.gameOverInProgress = false;
-    this.gameState.setMatch(null);
-    container.get(PendingIdentitiesToken).clear();
-    container.get(ReceivedIdentitiesToken).clear();
-    const localEvent = new LocalEvent(EventType.ReturnToMainMenu);
-    container.get(EventProcessorService).addLocalEvent(localEvent);
-    console.log("Game over finalized, returning to main menu");
+    await this.lifecycleService.handleGameOver();
   }
 
   public renderDebugInformation(context: CanvasRenderingContext2D): void {
     const match = this.gameState.getMatch();
-
     if (match === null) {
       return;
     }
-
     const state = match.getState();
     DebugUtils.renderText(context, 24, 24, `State: ${MatchStateType[state]}`);
   }

--- a/src/game/services/gameplay/matchmaking-tokens.ts
+++ b/src/game/services/gameplay/matchmaking-tokens.ts
@@ -3,8 +3,3 @@ import { InjectionToken } from "@needle-di/core";
 export const PendingIdentitiesToken = new InjectionToken("PendingIdentities");
 
 export const ReceivedIdentitiesToken = new InjectionToken("ReceivedIdentities");
-
-export const PendingDisconnectionsToken = new InjectionToken(
-  "PendingDisconnections"
-);
-

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -28,7 +28,6 @@ import { injectable, inject } from "@needle-di/core";
 import {
   PendingIdentitiesToken,
   ReceivedIdentitiesToken,
-  PendingDisconnectionsToken,
 } from "../gameplay/matchmaking-tokens.js";
 import { SpawnPointService } from "../gameplay/spawn-point-service.js";
 
@@ -61,8 +60,7 @@ export class MatchmakingNetworkService
       SpawnPointService
     ),
     private readonly pendingIdentities = inject(PendingIdentitiesToken),
-    private readonly receivedIdentities = inject(ReceivedIdentitiesToken),
-    private readonly pendingDisconnections = inject(PendingDisconnectionsToken)
+    private readonly receivedIdentities = inject(ReceivedIdentitiesToken)
   ) {
     this.webSocketService.registerCommandHandlers(this);
     this.webrtcService.registerCommandHandlers(this);
@@ -388,9 +386,6 @@ export class MatchmakingNetworkService
     console.log(`Player ${player.getName()} disconnected`);
     this.gameState.getMatch()?.removePlayer(player);
     this.spawnPointService.releaseSpawnPointIndex(player.getSpawnPointIndex());
-
-    // Remove pending disconnection before notifying others
-    this.pendingDisconnections.delete(player.getId());
 
     // Notify players on match
     this.webrtcService


### PR DESCRIPTION
## Summary
- Extract `MatchLifecycleService` and `DisconnectionMonitor` to manage game-over flow and track disconnects
- Introduce `MatchmakingCoordinator` and explicit dependency injection for matchmaking services
- Update documentation with matchmaking architecture overview

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2f409951c832793508f1affdc4c4a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a “Matchmaking Architecture” section describing the new high-level components and their roles.

- Refactor
  - Centralized startup and networking initialization under a single coordinator.
  - Moved end-of-match responsibilities into a dedicated lifecycle manager for more reliable game-over and disconnection handling.
  - Simplified internal dependency wiring for cleaner services.
  - Removed legacy disconnection-tracking paths to reduce complexity.

- Note
  - No changes to gameplay or UI visible to end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->