### PR TITLE
Add fireball chat command with animated effect

### DIFF
--- a/src/game/enums/event-type.ts
+++ b/src/game/enums/event-type.ts
@@ -16,4 +16,5 @@ export enum EventType {
   OnlinePlayers,
   CarDemolished,
   ReturnToMainMenu,
+  Fireball,
 }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -266,6 +266,10 @@ export class WorldScene extends BaseCollidingGameScene {
       EventType.ReturnToMainMenu,
       () => void this.returnToMainMenuScene()
     );
+
+    this.subscribeToLocalEvent(EventType.Fireball, () => {
+      this.ballEntity?.activateFireball();
+    });
   }
 
   private subscribeToRemoteEvents(): void {


### PR DESCRIPTION
## Summary
- Support slash commands in `ChatService` and add `/fireball` command
- Trigger fireball effect via event and subscribe in `WorldScene`
- Add animated fireball rendering and timer to `BallEntity`

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b33d6a0094832788fcf815db3cda3b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a fireball power-up for the ball with dynamic flame visuals and a timed duration.
  - Added a /fireball chat command to activate the effect; works for both local and peer messages.
  - Fireball rendering features a directional flame tail and fiery body while preserving standard visuals when inactive.
  - Command messages that trigger actions are handled immediately and omitted from chat display to reduce clutter.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->