### PR TITLE
feat: add rainbow chat command

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -77,6 +77,10 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
   private carImage: HTMLImageElement | null = null;
   private imagePath = this.IMAGE_BLUE_PATH;
 
+  private rainbowActive = false;
+  private rainbowTimer = 0;
+  private rainbowHue = 0;
+
   constructor(x: number, y: number, angle: number, private remote = false) {
     super();
     this.remote = remote;
@@ -144,6 +148,15 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
 
     this.handleBoostPads();
 
+    if (this.rainbowActive) {
+      this.rainbowTimer -= deltaTimeStamp;
+      this.rainbowHue = (this.rainbowHue + deltaTimeStamp * 0.36) % 360;
+      if (this.rainbowTimer <= 0) {
+        this.rainbowActive = false;
+        this.rainbowHue = 0;
+      }
+    }
+
     if (this.boosting) {
       this.smokeSpawnElapsed += deltaTimeStamp;
       if (this.smokeSpawnElapsed >= this.SMOKE_SPAWN_INTERVAL) {
@@ -181,6 +194,9 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     context.rotate(this.angle);
     if (this.boosting) {
       this.renderTurboEffect(context);
+    }
+    if (this.rainbowActive) {
+      context.filter = `hue-rotate(${this.rainbowHue}deg)`;
     }
     context.drawImage(
       this.carImage!,
@@ -257,6 +273,12 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
 
   public deactivateBoost(): void {
     this.boosting = false;
+  }
+
+  public activateRainbow(durationSeconds = 15): void {
+    this.rainbowActive = true;
+    this.rainbowTimer = durationSeconds * 1000;
+    this.rainbowHue = 0;
   }
 
   public refillBoost(): void {

--- a/src/game/enums/event-type.ts
+++ b/src/game/enums/event-type.ts
@@ -16,5 +16,5 @@ export enum EventType {
   OnlinePlayers,
   CarDemolished,
   ReturnToMainMenu,
-  Fireball,
+  Rainbow,
 }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -1,6 +1,7 @@
 import { LocalCarEntity } from "../../entities/local-car-entity.js";
 import { GoalEntity } from "../../entities/goal-entity.js";
 import { BallEntity } from "../../entities/ball-entity.js";
+import { CarEntity } from "../../entities/car-entity.js";
 import { ScoreboardEntity } from "../../entities/scoreboard-entity.js";
 import { AlertEntity } from "../../entities/alert-entity.js";
 import { ToastEntity } from "../../entities/common/toast-entity.js";
@@ -267,8 +268,12 @@ export class WorldScene extends BaseCollidingGameScene {
       () => void this.returnToMainMenuScene()
     );
 
-    this.subscribeToLocalEvent(EventType.Fireball, () => {
-      this.ballEntity?.activateFireball();
+    this.subscribeToLocalEvent(EventType.Rainbow, () => {
+      this.worldEntities.forEach((entity) => {
+        if (entity instanceof CarEntity) {
+          entity.activateRainbow();
+        }
+      });
     });
   }
 

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -157,9 +157,9 @@ export class ChatService {
     const command = text.slice(1).toLowerCase();
 
     switch (command) {
-      case "fireball":
+      case "rainbow":
         if (!senderId || senderId !== this.localPlayerId) {
-          const event = new LocalEvent<void>(EventType.Fireball);
+          const event = new LocalEvent<void>(EventType.Rainbow);
           this.eventProcessorService.addLocalEvent(event);
         }
         return true;


### PR DESCRIPTION
## Summary
- replace `/fireball` with `/rainbow` command
- cycle car colors through rainbow hues for 15 seconds when command used
## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c079d4483278358a9cd2755bc25