### PR TITLE
Enhance rainbow effect from chat command

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -196,7 +196,9 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
       this.renderTurboEffect(context);
     }
     if (this.rainbowActive) {
-      context.filter = `hue-rotate(${this.rainbowHue}deg)`;
+      context.filter = `hue-rotate(${this.rainbowHue}deg) saturate(200%) brightness(1.3) contrast(1.2)`;
+    } else {
+      context.filter = "none";
     }
     context.drawImage(
       this.carImage!,
@@ -279,6 +281,7 @@ export class CarEntity extends BaseDynamicCollidingGameEntity {
     this.rainbowActive = true;
     this.rainbowTimer = durationSeconds * 1000;
     this.rainbowHue = 0;
+    console.log("Rainbow effect activated");
   }
 
   public refillBoost(): void {

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -159,6 +159,7 @@ export class ChatService {
     switch (command) {
       case "rainbow":
         if (!senderId || senderId !== this.localPlayerId) {
+          console.log("Rainbow command received - starting effect");
           const event = new LocalEvent<void>(EventType.Rainbow);
           this.eventProcessorService.addLocalEvent(event);
         }


### PR DESCRIPTION
## Summary
- Log when `/rainbow` chat command triggers
- Intensify rainbow effect with multiple canvas filters
- Log activation of the rainbow effect for debug visibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd957a87d883279b6797b96d956db9