### PR TITLE
docs: reorder matchmaking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ battle.
 - Web Crypto API for server configuration and player scores handling
 - Debug menu to inspect game and network state
 
+## Demo
+
+https://github.com/user-attachments/assets/ae4b8b25-a3d4-4fdd-a5bf-f9d1fcb16f09
+
+### Debug UI
+
+![Sceneshot showing debug menu using Dear imgui](https://github.com/user-attachments/assets/85af22e7-4b85-4d1f-b68c-bc8eb4476b82)
+
 ## Matchmaking Architecture
 
 The matchmaking layer is split into focused services:
@@ -26,14 +34,6 @@ The matchmaking layer is split into focused services:
 
 Services interact through dependency injection and an event bus to avoid
 circular dependencies and lazy initialization.
-
-## Demo
-
-https://github.com/user-attachments/assets/ae4b8b25-a3d4-4fdd-a5bf-f9d1fcb16f09
-
-### Debug UI
-
-![Sceneshot showing debug menu using Dear imgui](https://github.com/user-attachments/assets/85af22e7-4b85-4d1f-b68c-bc8eb4476b82)
 
 ## Contributions
 


### PR DESCRIPTION
## Summary
- Move matchmaking architecture section below debug UI in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6880454088327ae12864001770d88