### PR TITLE
Advertise matches periodically with ping median

### DIFF
--- a/src/game/interfaces/requests/advertise-match-request.ts
+++ b/src/game/interfaces/requests/advertise-match-request.ts
@@ -5,4 +5,5 @@ export interface AdvertiseMatchRequest {
   totalSlots: number;
   availableSlots: number;
   attributes: MatchAttributes;
+  ping_median_milliseconds?: number;
 }

--- a/src/game/interfaces/services/network/matchmaking-network-service-interface.ts
+++ b/src/game/interfaces/services/network/matchmaking-network-service-interface.ts
@@ -6,6 +6,8 @@ export interface IMatchmakingNetworkService {
   stopFindMatchesTimer(): void;
   startPingCheckInterval(): void;
   removePingCheckInterval(): void;
+  startAdvertiseMatchInterval(): void;
+  removeAdvertiseMatchInterval(): void;
   handlePlayerIdentity(binaryReader: BinaryReader): void;
   onPeerConnected(peer: WebRTCPeer): void;
   onPeerDisconnected(peer: WebRTCPeer, graceful: boolean): void;

--- a/src/game/services/gameplay/match-finder-service.ts
+++ b/src/game/services/gameplay/match-finder-service.ts
@@ -20,6 +20,7 @@ import { GameState } from "../../../core/models/game-state.js";
 import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
 import { injectable, inject } from "@needle-di/core";
 import { PendingIdentitiesToken } from "./matchmaking-tokens.js";
+import type { GamePlayer } from "../../models/game-player.js";
 
 @injectable()
 export class MatchFinderService {
@@ -84,9 +85,42 @@ export class MatchFinderService {
       attributes: match.getAttributes(),
     };
 
+    const pingMedian = this.calculatePlayersPingMedian();
+
+    if (pingMedian !== null) {
+      body.ping_median_milliseconds = pingMedian;
+    }
+
     await this.apiService.advertiseMatch(body);
     const localEvent = new LocalEvent(EventType.MatchAdvertised);
     this.eventProcessorService.addLocalEvent(localEvent);
+  }
+
+  private calculatePlayersPingMedian(): number | null {
+    const match = this.gameState.getMatch();
+
+    if (match === null) {
+      console.warn("Game match is null");
+      return null;
+    }
+
+    const pings = match
+      .getPlayers()
+      .map((player: GamePlayer) => player.getPingTime())
+      .filter((ping: number | null): ping is number => ping !== null);
+
+    if (pings.length === 0) {
+      return null;
+    }
+
+    pings.sort((a: number, b: number) => a - b);
+    const middle = Math.floor(pings.length / 2);
+
+    if (pings.length % 2 === 0) {
+      return Math.round((pings[middle - 1] + pings[middle]) / 2);
+    }
+
+    return Math.round(pings[middle]);
   }
 
   private async joinMatch(match: MatchData): Promise<void> {

--- a/src/game/services/gameplay/match-lifecycle-service.ts
+++ b/src/game/services/gameplay/match-lifecycle-service.ts
@@ -82,6 +82,7 @@ export class MatchLifecycleService {
       });
 
       this.networkService.removePingCheckInterval();
+      this.networkService.removeAdvertiseMatchInterval();
       await this.apiService
         .removeMatch()
         .catch((error: unknown) => console.error(error));

--- a/src/game/services/gameplay/matchmaking-service.ts
+++ b/src/game/services/gameplay/matchmaking-service.ts
@@ -42,6 +42,7 @@ export class MatchmakingService implements IMatchmakingService {
       console.log("No matches found");
       await this.matchFinderService.createAndAdvertiseMatch();
       this.networkService.startPingCheckInterval();
+      this.networkService.startAdvertiseMatchInterval();
       return;
     }
 
@@ -53,6 +54,7 @@ export class MatchmakingService implements IMatchmakingService {
 
     await this.matchFinderService.createAndAdvertiseMatch();
     this.networkService.startPingCheckInterval();
+    this.networkService.startAdvertiseMatchInterval();
   }
 
   public async savePlayerScore(): Promise<void> {

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -37,6 +37,7 @@ export class MatchmakingNetworkService
 {
   private findMatchesTimerService: ITimerService | null = null;
   private pingCheckInterval: IIntervalService | null = null;
+  private advertiseMatchInterval: IIntervalService | null = null;
 
   constructor(
     private readonly gameState: GameState = inject(GameState),
@@ -87,6 +88,23 @@ export class MatchmakingNetworkService
   public removePingCheckInterval(): void {
     if (this.pingCheckInterval !== null) {
       this.intervalManagerService.removeInterval(this.pingCheckInterval);
+    }
+  }
+
+  public startAdvertiseMatchInterval(): void {
+    this.advertiseMatchInterval = this.intervalManagerService.createInterval(
+      60,
+      () => {
+        this.matchFinderService
+          .advertiseMatch()
+          .catch((error: unknown) => console.error(error));
+      }
+    );
+  }
+
+  public removeAdvertiseMatchInterval(): void {
+    if (this.advertiseMatchInterval !== null) {
+      this.intervalManagerService.removeInterval(this.advertiseMatchInterval);
     }
   }
 


### PR DESCRIPTION
## Summary
- add `ping_median_milliseconds` to match advertisement request
- include median player ping when advertising match and support periodic ads every minute
- expose interval controls for match ads and clean up on game over
- simplify ping median inclusion by always attaching the value when available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c80b95256c8327a309590ee7f50446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic periodic match advertising keeps hosted games visible in matchmaking.
  * Match listings now include median connection latency to improve match quality.

* **Improvements**
  * More reliable lobby visibility whether creating or joining a match.
  * Cleaner shutdown: advertising stops automatically when a game ends, reducing stale listings.
  * Overall matchmaking stability and discoverability enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->