### PR TITLE
Add match actions log overlay

### DIFF
--- a/src/core/services/service-registry.ts
+++ b/src/core/services/service-registry.ts
@@ -22,6 +22,7 @@ import { CameraService } from "./gameplay/camera-service.js";
 import { SpawnPointService } from "../../game/services/gameplay/spawn-point-service.js";
 import { ChatService } from "../../game/services/network/chat-service.js";
 import { AnimationLogService } from "./gameplay/animation-log-service.js";
+import { MatchActionsLogService } from "../../game/services/gameplay/match-actions-log-service.js";
 
 export class ServiceRegistry {
   public static register(canvas: HTMLCanvasElement, debugging: boolean): void {
@@ -75,6 +76,10 @@ export class ServiceRegistry {
     container.bind({ provide: AnimationLogService, useClass: AnimationLogService });
     container.bind({ provide: CameraService, useClass: CameraService });
     container.bind({ provide: SpawnPointService, useClass: SpawnPointService });
+    container.bind({
+      provide: MatchActionsLogService,
+      useClass: MatchActionsLogService,
+    });
     container.bind({
       provide: PendingIdentitiesToken,
       useValue: new Map<string, boolean>(),

--- a/src/game/entities/match-actions-history-entity.ts
+++ b/src/game/entities/match-actions-history-entity.ts
@@ -1,0 +1,205 @@
+import { BaseAnimatedGameEntity } from "../../core/entities/base-animated-entity.js";
+import { GameState } from "../../core/models/game-state.js";
+import { MatchAction } from "../models/match-action.js";
+import { MatchActionType } from "../enums/match-action-type.js";
+
+interface TextPart {
+  text: string;
+  color: string;
+}
+
+export class MatchActionsHistoryEntity extends BaseAnimatedGameEntity {
+  private readonly padding = 10;
+  private readonly cornerRadius = 8;
+  private readonly fontSize = 16;
+  private readonly lineHeight = 16;
+  private readonly actionMargin = 4;
+  private readonly maxActions = 5;
+
+  private actions: MatchAction[] = [];
+  private context: CanvasRenderingContext2D;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly gameState: GameState
+  ) {
+    super();
+    const context = this.canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Canvas context not available");
+    }
+    this.context = context;
+    this.opacity = 0;
+  }
+
+  public show(actions: MatchAction[]): void {
+    this.actions = actions.slice(-this.maxActions);
+
+    if (this.actions.length === 0) {
+      this.width = 0;
+      this.height = 0;
+      if (this.opacity > 0) {
+        this.fadeOut(0.2);
+      }
+      return;
+    }
+
+    this.measure();
+    this.setPosition();
+
+    if (this.opacity === 0) {
+      this.fadeIn(0.2);
+    }
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    if (this.opacity === 0 || this.actions.length === 0) {
+      return;
+    }
+
+    context.save();
+    this.applyOpacity(context);
+    this.drawBackground(context);
+    this.drawText(context);
+    context.restore();
+  }
+
+  private measure(): void {
+    if (this.actions.length === 0) {
+      this.width = 0;
+      this.height = 0;
+      return;
+    }
+
+    this.context.font = `${this.fontSize}px system-ui`;
+
+    const maxWidth = this.actions.reduce((acc, action) => {
+      const text = this.getTextParts(action)
+        .map((part) => part.text)
+        .join("");
+      return Math.max(acc, this.context.measureText(text).width);
+    }, 0);
+
+    this.width = maxWidth + this.padding * 2;
+    this.height =
+      this.actions.length * this.lineHeight +
+      (this.actions.length - 1) * this.actionMargin +
+      this.padding * 2;
+  }
+
+  private setPosition(): void {
+    this.x = 20;
+    this.y = 20;
+  }
+
+  private drawBackground(ctx: CanvasRenderingContext2D): void {
+    ctx.fillStyle = "rgba(0,0,0,0.6)";
+    ctx.beginPath();
+    ctx.moveTo(this.x + this.cornerRadius, this.y);
+    ctx.lineTo(this.x + this.width - this.cornerRadius, this.y);
+    ctx.quadraticCurveTo(
+      this.x + this.width,
+      this.y,
+      this.x + this.width,
+      this.y + this.cornerRadius
+    );
+    ctx.lineTo(this.x + this.width, this.y + this.height - this.cornerRadius);
+    ctx.quadraticCurveTo(
+      this.x + this.width,
+      this.y + this.height,
+      this.x + this.width - this.cornerRadius,
+      this.y + this.height
+    );
+    ctx.lineTo(this.x + this.cornerRadius, this.y + this.height);
+    ctx.quadraticCurveTo(
+      this.x,
+      this.y + this.height,
+      this.x,
+      this.y + this.height - this.cornerRadius
+    );
+    ctx.lineTo(this.x, this.y + this.cornerRadius);
+    ctx.quadraticCurveTo(this.x, this.y, this.x + this.cornerRadius, this.y);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  private drawText(ctx: CanvasRenderingContext2D): void {
+    ctx.font = `${this.fontSize}px system-ui`;
+    ctx.textBaseline = "middle";
+    let y = this.y + this.padding + this.lineHeight / 2;
+    const baseX = this.x + this.padding;
+
+    for (let i = 0; i < this.actions.length; i++) {
+      const action = this.actions[i];
+      const parts = this.getTextParts(action);
+      let x = baseX;
+
+      for (const part of parts) {
+        ctx.fillStyle = part.color;
+        ctx.fillText(part.text, x, y);
+        x += ctx.measureText(part.text).width;
+      }
+
+      y += this.lineHeight;
+      if (i < this.actions.length - 1) {
+        y += this.actionMargin;
+      }
+    }
+  }
+
+  private getTextParts(action: MatchAction): TextPart[] {
+    if (action.getType() === MatchActionType.Goal) {
+      const scorerId = action.getScorerId();
+      const playerName = this.getPlayerName(scorerId);
+      const playerColor = this.getPlayerColor(scorerId);
+
+      return [
+        { text: "⚽️ ", color: "white" },
+        { text: playerName, color: playerColor },
+        { text: " scored!", color: "white" },
+      ];
+    }
+
+    const attackerId = action.getAttackerId();
+    const victimId = action.getVictimId();
+    const attackerName = this.getPlayerName(attackerId);
+    const victimName = this.getPlayerName(victimId);
+    const attackerColor = this.getPlayerColor(attackerId);
+    const victimColor = this.getPlayerColor(victimId);
+
+    return [
+      { text: attackerName, color: attackerColor },
+      { text: " 💣 ", color: "white" },
+      { text: victimName, color: victimColor },
+    ];
+  }
+
+  private getPlayerName(playerId: string | null): string {
+    if (!playerId) {
+      return "Unknown";
+    }
+
+    const match = this.gameState.getMatch();
+    const player = match?.getPlayerByNetworkId(playerId) ?? null;
+
+    if (player) {
+      return player.getName();
+    }
+
+    const localPlayer = this.gameState.getGamePlayer();
+    if (playerId === localPlayer.getNetworkId()) {
+      return localPlayer.getName();
+    }
+
+    return playerId;
+  }
+
+  private getPlayerColor(playerId: string | null): string {
+    if (!playerId) {
+      return "white";
+    }
+
+    const localPlayerId = this.gameState.getGamePlayer().getNetworkId();
+    return playerId === localPlayerId ? "#2196f3" : "#ff4d4d";
+  }
+}

--- a/src/game/enums/match-action-type.ts
+++ b/src/game/enums/match-action-type.ts
@@ -1,0 +1,4 @@
+export enum MatchActionType {
+  Goal = "goal",
+  Demolition = "demolition",
+}

--- a/src/game/models/match-action.ts
+++ b/src/game/models/match-action.ts
@@ -31,6 +31,14 @@ export class MatchAction {
     return this.type;
   }
 
+  public isGoal(): boolean {
+    return this.type === MatchActionType.Goal;
+  }
+
+  public isDemolition(): boolean {
+    return this.type === MatchActionType.Demolition;
+  }
+
   public getTimestamp(): number {
     return this.timestamp;
   }

--- a/src/game/models/match-action.ts
+++ b/src/game/models/match-action.ts
@@ -1,0 +1,49 @@
+import { MatchActionType } from "../enums/match-action-type.js";
+
+export class MatchAction {
+  private constructor(
+    private readonly type: MatchActionType,
+    private readonly timestamp: number,
+    private readonly scorerId: string | null,
+    private readonly attackerId: string | null,
+    private readonly victimId: string | null
+  ) {}
+
+  public static goal(playerId: string, timestamp: number = Date.now()): MatchAction {
+    return new MatchAction(MatchActionType.Goal, timestamp, playerId, null, null);
+  }
+
+  public static demolition(
+    attackerId: string,
+    victimId: string,
+    timestamp: number = Date.now()
+  ): MatchAction {
+    return new MatchAction(
+      MatchActionType.Demolition,
+      timestamp,
+      null,
+      attackerId,
+      victimId
+    );
+  }
+
+  public getType(): MatchActionType {
+    return this.type;
+  }
+
+  public getTimestamp(): number {
+    return this.timestamp;
+  }
+
+  public getScorerId(): string | null {
+    return this.scorerId;
+  }
+
+  public getAttackerId(): string | null {
+    return this.attackerId;
+  }
+
+  public getVictimId(): string | null {
+    return this.victimId;
+  }
+}

--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -270,9 +270,7 @@ export class WorldController {
     }
     triggerCarExplosion(victimCar.getX(), victimCar.getY());
 
-    this.matchActionsLogService.addAction(
-      MatchAction.demolition(payload.attackerId, payload.victimId)
-    );
+    this.logDemolition(payload.attackerId, payload.victimId);
 
     const attackerName = attacker?.getName() ?? "Unknown";
     const victimName = victim.getName();
@@ -384,11 +382,9 @@ export class WorldController {
 
             this.eventProcessorService.sendEvent(event);
 
-            this.matchActionsLogService.addAction(
-              MatchAction.demolition(
-                attackerPlayer.getNetworkId(),
-                victimPlayer.getNetworkId()
-              )
+            this.logDemolition(
+              attackerPlayer.getNetworkId(),
+              victimPlayer.getNetworkId()
             );
           }
         }
@@ -417,5 +413,11 @@ export class WorldController {
     }
 
     return player === this.gameState.getGamePlayer() ? "blue" : "red";
+  }
+
+  private logDemolition(attackerId: string, victimId: string): void {
+    this.matchActionsLogService.addAction(
+      MatchAction.demolition(attackerId, victimId)
+    );
   }
 }

--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -244,10 +244,6 @@ export class WorldController {
       victimId: binaryReader.fixedLengthString(32),
     };
 
-    this.matchActionsLogService.addAction(
-      MatchAction.demolition(payload.attackerId, payload.victimId)
-    );
-
     const attacker =
       this.gameState.getMatch()?.getPlayerByNetworkId(payload.attackerId) ??
       null;
@@ -273,6 +269,10 @@ export class WorldController {
       victimCar.demolish(spawn.x, spawn.y, 3000);
     }
     triggerCarExplosion(victimCar.getX(), victimCar.getY());
+
+    this.matchActionsLogService.addAction(
+      MatchAction.demolition(payload.attackerId, payload.victimId)
+    );
 
     const attackerName = attacker?.getName() ?? "Unknown";
     const victimName = victim.getName();

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -66,8 +66,9 @@ export class WorldScene extends BaseCollidingGameScene {
   private chatHistoryEntity: ChatHistoryEntity | null = null;
   private matchActionsHistoryEntity: MatchActionsHistoryEntity | null = null;
 
-  private readonly matchActionsLogService = new MatchActionsLogService();
+  private readonly matchActionsLogService: MatchActionsLogService;
   private matchActionsLogUnsubscribe: (() => void) | null = null;
+  private chatMessageUnsubscribe: (() => void) | null = null;
 
   private scoreManagerService: ScoreManagerService | null = null;
   private worldController: WorldController | null = null;
@@ -87,6 +88,8 @@ export class WorldScene extends BaseCollidingGameScene {
     this.eventProcessorService = container.get(EventProcessorService);
     this.spawnPointService = container.get(SpawnPointService);
     this.chatService = container.get(ChatService);
+    this.matchActionsLogService = container.get(MatchActionsLogService);
+    this.matchActionsLogService.clear();
     this.addSyncableEntities();
     this.subscribeToEvents();
   }
@@ -364,7 +367,8 @@ export class WorldScene extends BaseCollidingGameScene {
       this.helpEntity as HelpEntity
     );
     this.uiEntities.push(this.chatButtonEntity, this.chatHistoryEntity);
-    this.chatService.onMessage((msgs) =>
+    this.chatMessageUnsubscribe?.();
+    this.chatMessageUnsubscribe = this.chatService.onMessage((msgs) =>
       this.chatHistoryEntity?.show(
         msgs,
         this.gameState.getGamePlayer().getName()
@@ -373,6 +377,9 @@ export class WorldScene extends BaseCollidingGameScene {
   }
 
   private setupMatchActionsHistory(): void {
+    if (this.matchActionsHistoryEntity) {
+      return;
+    }
     this.matchActionsHistoryEntity = new MatchActionsHistoryEntity(
       this.canvas,
       this.gameState
@@ -466,6 +473,9 @@ export class WorldScene extends BaseCollidingGameScene {
 
     this.matchActionsLogUnsubscribe?.();
     this.matchActionsLogUnsubscribe = null;
+    this.matchActionsLogService.clear();
+    this.chatMessageUnsubscribe?.();
+    this.chatMessageUnsubscribe = null;
 
     super.dispose();
   }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -357,6 +357,14 @@ export class WorldScene extends BaseCollidingGameScene {
     }
 
     this.chatHistoryEntity = new ChatHistoryEntity(this.canvas, this.gameState);
+    // If there are existing messages, render them immediately
+    const initialMsgs = this.chatService.getMessages();
+    if (initialMsgs.length > 0) {
+      this.chatHistoryEntity.show(
+        initialMsgs,
+        this.gameState.getGamePlayer().getName()
+      );
+    }
 
     this.chatButtonEntity = new ChatButtonEntity(
       boostMeterEntity,

--- a/src/game/services/gameplay/match-actions-log-service.ts
+++ b/src/game/services/gameplay/match-actions-log-service.ts
@@ -1,0 +1,38 @@
+import { MatchAction } from "../../models/match-action.js";
+
+type MatchActionListener = (actions: MatchAction[]) => void;
+
+export class MatchActionsLogService {
+  private readonly maxActions = 5;
+  private actions: MatchAction[] = [];
+  private listeners: MatchActionListener[] = [];
+
+  public addAction(action: MatchAction): void {
+    this.actions.push(action);
+    if (this.actions.length > this.maxActions) {
+      this.actions = this.actions.slice(-this.maxActions);
+    }
+    this.notifyListeners();
+  }
+
+  public getActions(): MatchAction[] {
+    return [...this.actions];
+  }
+
+  public onChange(listener: MatchActionListener): () => void {
+    this.listeners.push(listener);
+    listener(this.getActions());
+
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  private notifyListeners(): void {
+    const snapshot = this.getActions();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+}

--- a/src/game/services/gameplay/match-actions-log-service.ts
+++ b/src/game/services/gameplay/match-actions-log-service.ts
@@ -1,7 +1,9 @@
+import { injectable } from "@needle-di/core";
 import { MatchAction } from "../../models/match-action.js";
 
 type MatchActionListener = (actions: MatchAction[]) => void;
 
+@injectable()
 export class MatchActionsLogService {
   private readonly maxActions = 5;
   private actions: MatchAction[] = [];
@@ -10,13 +12,22 @@ export class MatchActionsLogService {
   public addAction(action: MatchAction): void {
     this.actions.push(action);
     if (this.actions.length > this.maxActions) {
-      this.actions = this.actions.slice(-this.maxActions);
+      this.actions.splice(0, this.actions.length - this.maxActions);
     }
     this.notifyListeners();
   }
 
   public getActions(): MatchAction[] {
     return [...this.actions];
+  }
+
+  public clear(): void {
+    if (this.actions.length === 0) {
+      return;
+    }
+
+    this.actions.length = 0;
+    this.notifyListeners();
   }
 
   public onChange(listener: MatchActionListener): () => void {
@@ -33,6 +44,6 @@ export class MatchActionsLogService {
 
   private notifyListeners(): void {
     const snapshot = this.getActions();
-    this.listeners.forEach((listener) => listener(snapshot));
+    [...this.listeners].forEach((listener) => listener(snapshot));
   }
 }

--- a/src/game/services/gameplay/score-manager-service.ts
+++ b/src/game/services/gameplay/score-manager-service.ts
@@ -5,6 +5,7 @@ import { TeamType } from "../../enums/team-type.js";
 import { RemoteEvent } from "../../../core/models/remote-event.js";
 import { GameState } from "../../../core/models/game-state.js";
 import { GamePlayer } from "../../models/game-player.js";
+import { MatchAction } from "../../models/match-action.js";
 
 import { BinaryWriter } from "../../../core/utils/binary-writer-utils.js";
 import { BinaryReader } from "../../../core/utils/binary-reader-utils.js";
@@ -17,6 +18,7 @@ import { AlertEntity } from "../../entities/alert-entity.js";
 import { TimerManagerService } from "../../../core/services/gameplay/timer-manager-service.js";
 import { EventProcessorService } from "../../../core/services/gameplay/event-processor-service.js";
 import type { IMatchmakingService } from "../../interfaces/services/gameplay/matchmaking-service-interface.js";
+import { MatchActionsLogService } from "./match-actions-log-service.js";
 
 export class ScoreManagerService {
   constructor(
@@ -25,6 +27,7 @@ export class ScoreManagerService {
     private readonly goalEntity: GoalEntity,
     private readonly scoreboardUI: ScoreboardUI,
     private readonly alertEntity: AlertEntity,
+    private readonly matchActionsLogService: MatchActionsLogService,
     private readonly timerManagerService: TimerManagerService,
     private readonly eventProcessorService: EventProcessorService,
     private readonly matchmakingService: IMatchmakingService,
@@ -89,6 +92,8 @@ export class ScoreManagerService {
 
     player?.setScore(playerScore);
     this.updateScoreboard();
+
+    this.matchActionsLogService.addAction(MatchAction.goal(playerId));
 
     let team: TeamType = TeamType.Red;
 
@@ -162,6 +167,10 @@ export class ScoreManagerService {
     } else {
       this.scoreboardUI.incrementRedScore();
     }
+
+    this.matchActionsLogService.addAction(
+      MatchAction.goal(player.getNetworkId())
+    );
 
     this.showGoalAlert(player, goalTeam);
     this.explosionCallback(

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -43,8 +43,15 @@ export class ChatService {
     return this.messages;
   }
 
-  public onMessage(listener: (messages: ChatMessage[]) => void): void {
+  public onMessage(listener: (messages: ChatMessage[]) => void): () => void {
     this.listeners.push(listener);
+
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
   }
 
   public clearMessages(): void {

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -45,6 +45,10 @@ export class ChatService {
 
   public onMessage(listener: (messages: ChatMessage[]) => void): () => void {
     this.listeners.push(listener);
+    // Deliver current snapshot if available (prevents blank UI on first subscribe)
+    if (this.messages.length > 0) {
+      listener([...this.messages]);
+    }
 
     return () => {
       const index = this.listeners.indexOf(listener);
@@ -56,6 +60,9 @@ export class ChatService {
 
   public clearMessages(): void {
     this.messages.length = 0;
+    this.listeners.forEach((listener) => {
+      listener([]);
+    });
   }
 
   public sendMessage(text: string): void {


### PR DESCRIPTION
## Summary
- add a match actions log UI entity that renders goal and demolition events with team colors beneath the chat overlay
- introduce a match actions log service and model to collect the latest actions and wire it into score and demolition handling
- update the world scene to register the new log entity, keep chat history rendered last, and push actions from goal and demolition events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83fec89c083279eafe40b3a0a7cd9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live match actions history HUD showing up to 5 recent actions (goals, demolitions) with translucent rounded background, fade animations, color-coded names, and fixed top-left placement; updates from local and remote events.
  * Centralized match actions log service collecting and publishing recent actions.

* **Chores**
  * Chat service onMessage now returns an unsubscribe function.
  * MatchActionsLogService registered in DI container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->