### PR TITLE
Remove suggested folder structure guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,29 +213,6 @@ export function buildApp() {
 
 ---
 
-## Suggested Folder Structure
-
-```
-src/
-  domain/
-    entities/
-    services/
-    contracts/
-    events/
-  application/
-    use-cases/
-    subscribers/
-  infrastructure/
-    repositories/
-    gateways/
-    messaging/
-  shared/
-    utils/
-    types/
-```
-
----
-
 ## Anti‑Patterns to Avoid
 
 - ❌ Importing from **Infrastructure** anywhere except the **composition root**.


### PR DESCRIPTION
## Summary
- remove the suggested folder structure section from AGENTS.md to keep the guidelines focused on layering rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c88b3b769483279db97284100aa52a