### PR TITLE
Fix missing DebugService registration

### DIFF
--- a/src/game/bootstrap/register-game-services.ts
+++ b/src/game/bootstrap/register-game-services.ts
@@ -26,6 +26,7 @@ import {
   type PendingIdentityMap,
   type ReceivedIdentityMap,
 } from "../services/gameplay/matchmaking-tokens.js";
+import { DebugService } from "../services/debug/debug-service.js";
 
 type ValueProvider = {
   provide: unknown;
@@ -65,6 +66,7 @@ export function registerGameServices(container: BindableContainer): void {
   container.bind({ provide: SpawnPointService, useClass: SpawnPointService });
   container.bind({ provide: MatchActionsLogService, useClass: MatchActionsLogService });
   container.bind({ provide: GameLoopFacade, useClass: GameLoopFacade });
+  container.bind({ provide: DebugService, useClass: DebugService });
   container.bind({
     provide: EVENT_IDENTIFIER_RESOLVER_TOKEN,
     useValue: {


### PR DESCRIPTION
## Summary
- bind DebugService during the game bootstrap to satisfy GameLoopFacade dependencies

## Testing
- npm run lint
- npm run verify:di
- npm run verify:deps
- npm run smoke:engine
- npm run smoke:engine-package

------
https://chatgpt.com/codex/tasks/task_e_68d03b4b676883279f1d3a2d534c94a5