### PR TITLE
Harden BinaryReader against out-of-bounds payload reads

### DIFF
--- a/src/engine/utils/binary-reader-utils.ts
+++ b/src/engine/utils/binary-reader-utils.ts
@@ -34,6 +34,7 @@ export class BinaryReader {
   }
 
   public byte(): number {
+    this.ensureAvailable(1);
     return this.uint8[this.position++];
   }
 
@@ -57,44 +58,52 @@ export class BinaryReader {
   }
 
   public signedInt8(): number {
+    this.ensureAvailable(1);
     return this.dataView.getInt8(this.position++);
   }
 
   public unsignedInt8(): number {
+    this.ensureAvailable(1);
     return this.dataView.getUint8(this.position++);
   }
 
   public signedInt16(): number {
+    this.ensureAvailable(2);
     const val = this.dataView.getInt16(this.position, this.littleEndian);
     this.position += 2;
     return val;
   }
 
   public unsignedInt16(): number {
+    this.ensureAvailable(2);
     const val = this.dataView.getUint16(this.position, this.littleEndian);
     this.position += 2;
     return val;
   }
 
   public signedInt32(): number {
+    this.ensureAvailable(4);
     const val = this.dataView.getInt32(this.position, this.littleEndian);
     this.position += 4;
     return val;
   }
 
   public unsignedInt32(): number {
+    this.ensureAvailable(4);
     const val = this.dataView.getUint32(this.position, this.littleEndian);
     this.position += 4;
     return val;
   }
 
   public float32(): number {
+    this.ensureAvailable(4);
     const val = this.dataView.getFloat32(this.position, this.littleEndian);
     this.position += 4;
     return val;
   }
 
   public float64(): number {
+    this.ensureAvailable(8);
     const val = this.dataView.getFloat64(this.position, this.littleEndian);
     this.position += 8;
     return val;
@@ -105,6 +114,7 @@ export class BinaryReader {
   }
 
   public fixedLengthString(length: number): string {
+    this.ensureAvailable(length);
     const bytes = this.uint8.subarray(this.position, this.position + length);
     this.position += length;
     const end = bytes.indexOf(0);
@@ -113,6 +123,7 @@ export class BinaryReader {
 
   public variableLengthString(): string {
     const length = this.unsignedInt32();
+    this.ensureAvailable(length);
     const bytes = this.uint8.subarray(this.position, this.position + length);
     this.position += length;
     return this.decoder.decode(bytes);
@@ -135,6 +146,12 @@ export class BinaryReader {
       throw new Error("No mark set");
     }
     return this.buffer.slice(this.markPosition, this.position);
+  }
+
+  private ensureAvailable(length: number): void {
+    if (length < 0 || this.position + length > this.bufferLength) {
+      throw new RangeError("Attempt to read beyond buffer bounds");
+    }
   }
 
   public preview(bytesPerLine: number = 24): string {


### PR DESCRIPTION
### Motivation

- Network-facing parsers rely on `BinaryReader` and malformed/truncated packets could trigger uncontrolled `DataView` range errors and crash message handling paths.
- Introduce defensive checks so adversarial or buggy payloads fail fast with a clear `RangeError` instead of causing instability or potential DoS.

### Description

- Added a private helper `ensureAvailable(length)` to centralize bounds validation for read operations in `BinaryReader`.
- Added pre-read checks to primitive readers (`byte`, `signedInt8`, `unsignedInt8`, `signedInt16`, `unsignedInt16`, `signedInt32`, `unsignedInt32`, `float32`, `float64`) to prevent reads past buffer end.
- Added bounds validation to `fixedLengthString` and `variableLengthString` so length fields cannot advance the read pointer beyond available bytes.
- Changes are contained in `src/engine/utils/binary-reader-utils.ts` and preserve existing API semantics while failing fast on invalid inputs.

### Testing

- Ran the production build with `npm run build` and the build completed successfully (no TypeScript or bundling errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48e5c74048327a4ad1628026bbe56)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation for binary data reading operations to improve system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->