### PR TITLE
Add report/ban confirmation, ErrorScene for kick, and ball trajectory debug toggle

### DIFF
--- a/src/engine/enums/event-type.ts
+++ b/src/engine/enums/event-type.ts
@@ -19,4 +19,5 @@ export enum EventType {
   SnowWeather,
   PlayerBanned,
   UserBannedByServer,
+  UserKickedByServer,
 }

--- a/src/engine/enums/scene-type.ts
+++ b/src/engine/enums/scene-type.ts
@@ -1,4 +1,5 @@
 export enum SceneType {
   Unknown,
   World,
+  Error,
 }

--- a/src/engine/models/debug-settings.ts
+++ b/src/engine/models/debug-settings.ts
@@ -8,6 +8,7 @@ export class DebugSettings {
   private hitboxVisible: boolean = true;
   private gizmosVisible: boolean = false;
   private menuEnabled: boolean = false;
+  private ballTrajectoryVisible: boolean = false;
 
   constructor(debugging: boolean) {
     this.debugging = debugging;
@@ -85,5 +86,14 @@ export class DebugSettings {
   public setMenuEnabled(value: boolean): void {
     this.menuEnabled = value;
     console.log(`Menu enabled set to: ${value}`);
+  }
+
+  public isBallTrajectoryVisible(): boolean {
+    return this.ballTrajectoryVisible;
+  }
+
+  public setBallTrajectoryVisibility(value: boolean): void {
+    this.ballTrajectoryVisible = value;
+    console.log(`Ball trajectory visibility set to: ${value}`);
   }
 }

--- a/src/game/debug/debug-window.ts
+++ b/src/game/debug/debug-window.ts
@@ -155,6 +155,12 @@ export class DebugWindow extends BaseWindow {
         debugSettings.areGizmosVisible(),
         debugSettings.setGizmosVisibility.bind(debugSettings)
       );
+
+      this.renderCheckbox(
+        "Show ball trajectory",
+        debugSettings.isBallTrajectoryVisible(),
+        debugSettings.setBallTrajectoryVisibility.bind(debugSettings)
+      );
     }
   }
 

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -162,6 +162,10 @@ export class BallEntity
 
     if (this.debugSettings?.isDebugging()) {
       this.renderDebugInformation(context);
+
+      if (this.debugSettings.isBallTrajectoryVisible()) {
+        this.renderTrajectory(context);
+      }
     }
 
     // Hitbox render (from superclass)
@@ -350,6 +354,51 @@ export class BallEntity
       this.vx *= scale;
       this.vy *= scale;
     }
+  }
+
+  public getTrajectoryPoints(steps = 60): { x: number; y: number }[] {
+    const points: { x: number; y: number }[] = [];
+    const effectiveFriction = this.FRICTION * this.weatherFrictionMultiplier;
+    let px = this.x;
+    let py = this.y;
+    let vx = this.vx;
+    let vy = this.vy;
+
+    for (let i = 0; i < steps; i++) {
+      vx *= 1 - effectiveFriction;
+      vy *= 1 - effectiveFriction;
+
+      if (Math.abs(vx) < this.MIN_VELOCITY) vx = 0;
+      if (Math.abs(vy) < this.MIN_VELOCITY) vy = 0;
+
+      if (vx === 0 && vy === 0) break;
+
+      px -= vx;
+      py -= vy;
+      points.push({ x: px, y: py });
+    }
+
+    return points;
+  }
+
+  private renderTrajectory(context: CanvasRenderingContext2D): void {
+    const points = this.getTrajectoryPoints();
+    if (points.length === 0) return;
+
+    context.save();
+    context.strokeStyle = "rgba(255, 165, 0, 0.7)";
+    context.lineWidth = 1.5;
+    context.setLineDash([4, 4]);
+    context.beginPath();
+    context.moveTo(this.x, this.y);
+
+    for (const point of points) {
+      context.lineTo(point.x, point.y);
+    }
+
+    context.stroke();
+    context.setLineDash([]);
+    context.restore();
   }
 
   private renderDebugInformation(context: CanvasRenderingContext2D): void {

--- a/src/game/entities/common/confirmation-message-entity.ts
+++ b/src/game/entities/common/confirmation-message-entity.ts
@@ -1,0 +1,231 @@
+import { BaseTappableGameEntity } from "../../../engine/entities/base-tappable-game-entity.js";
+import type { GamePointerContract } from "../../../engine/interfaces/input/game-pointer-interface.js";
+
+export class ConfirmationMessageEntity extends BaseTappableGameEntity {
+  private readonly BOX_WIDTH = 340;
+  private readonly BOX_HEIGHT = 140;
+  private readonly CORNER_RADIUS = 6;
+  private readonly BUTTON_WIDTH = 100;
+  private readonly BUTTON_HEIGHT = 36;
+  private readonly BUTTON_GAP = 15;
+
+  private question = "";
+  private isOpened = false;
+
+  private boxX = 0;
+  private boxY = 0;
+  private textX = 0;
+  private textY = 0;
+
+  private confirmBtnX = 0;
+  private confirmBtnY = 0;
+  private cancelBtnX = 0;
+  private cancelBtnY = 0;
+
+  private confirmHovered = false;
+  private cancelHovered = false;
+
+  private confirmed = false;
+  private cancelled = false;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {
+    super(false);
+    this.opacity = 0;
+  }
+
+  public override load(): void {
+    super.load();
+  }
+
+  public isOpen(): boolean {
+    return this.isOpened;
+  }
+
+  public isConfirmed(): boolean {
+    const result = this.confirmed;
+    this.confirmed = false;
+    return result;
+  }
+
+  public isCancelled(): boolean {
+    const result = this.cancelled;
+    this.cancelled = false;
+    return result;
+  }
+
+  public show(question: string): void {
+    this.question = question;
+    this.isOpened = true;
+    this.confirmed = false;
+    this.cancelled = false;
+    this.opacity = 1;
+    this.setActive(true);
+    this.calculateLayout();
+  }
+
+  public close(): void {
+    this.isOpened = false;
+    this.opacity = 0;
+    this.setActive(false);
+  }
+
+  private calculateLayout(): void {
+    this.boxX = this.canvas.width / 2 - this.BOX_WIDTH / 2;
+    this.boxY = this.canvas.height / 2 - this.BOX_HEIGHT / 2;
+    this.textX = this.canvas.width / 2;
+    this.textY = this.boxY + 45;
+
+    const buttonsY = this.boxY + this.BOX_HEIGHT - this.BUTTON_HEIGHT - 15;
+    const totalW = this.BUTTON_WIDTH * 2 + this.BUTTON_GAP;
+    const startX = this.canvas.width / 2 - totalW / 2;
+
+    this.confirmBtnX = startX;
+    this.confirmBtnY = buttonsY;
+    this.cancelBtnX = startX + this.BUTTON_WIDTH + this.BUTTON_GAP;
+    this.cancelBtnY = buttonsY;
+  }
+
+  public override handlePointerEvent(gamePointer: GamePointerContract): void {
+    if (!this.isOpened || this.opacity === 0) return;
+
+    const touches = gamePointer.getTouchPoints();
+
+    this.confirmHovered = false;
+    this.cancelHovered = false;
+    this.pressed = false;
+    this.hovering = false;
+
+    if (touches.length === 0) return;
+
+    for (const touch of touches) {
+      const inConfirm = this.isPointInRect(
+        touch.x, touch.y,
+        this.confirmBtnX, this.confirmBtnY,
+        this.BUTTON_WIDTH, this.BUTTON_HEIGHT
+      );
+      const inCancel = this.isPointInRect(
+        touch.x, touch.y,
+        this.cancelBtnX, this.cancelBtnY,
+        this.BUTTON_WIDTH, this.BUTTON_HEIGHT
+      );
+
+      if (inConfirm || inCancel) {
+        this.hovering = true;
+        if (inConfirm) this.confirmHovered = true;
+        if (inCancel) this.cancelHovered = true;
+
+        if (touch.pressed) {
+          this.pressed = true;
+          this.confirmHovered = inConfirm;
+          this.cancelHovered = inCancel;
+          break;
+        }
+      }
+    }
+  }
+
+  public override update(delta: DOMHighResTimeStamp): void {
+    if (!this.isOpened) return;
+
+    if (this.pressed) {
+      if (this.confirmHovered) {
+        this.confirmed = true;
+      } else if (this.cancelHovered) {
+        this.cancelled = true;
+      }
+    }
+
+    super.update(delta);
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    if (!this.isOpened || this.opacity === 0) return;
+
+    context.save();
+    context.globalAlpha = this.opacity;
+
+    this.renderBox(context);
+    this.renderText(context);
+    this.renderButtons(context);
+
+    context.restore();
+    super.render(context);
+  }
+
+  private renderBox(context: CanvasRenderingContext2D): void {
+    const { boxX: x, boxY: y, BOX_WIDTH: w, BOX_HEIGHT: h, CORNER_RADIUS: r } = this;
+
+    context.fillStyle = "rgba(0, 0, 0, 0.85)";
+    context.beginPath();
+    context.moveTo(x + r, y);
+    context.arcTo(x + w, y, x + w, y + h, r);
+    context.arcTo(x + w, y + h, x, y + h, r);
+    context.arcTo(x, y + h, x, y, r);
+    context.arcTo(x, y, x + w, y, r);
+    context.closePath();
+    context.fill();
+  }
+
+  private renderText(context: CanvasRenderingContext2D): void {
+    context.font = "16px Arial";
+    context.fillStyle = "white";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(this.question, this.textX, this.textY);
+  }
+
+  private renderButtons(context: CanvasRenderingContext2D): void {
+    this.renderButton(
+      context,
+      this.confirmBtnX, this.confirmBtnY,
+      "Yes",
+      this.confirmHovered ? "#27ae60" : "#2ecc71"
+    );
+
+    this.renderButton(
+      context,
+      this.cancelBtnX, this.cancelBtnY,
+      "No",
+      this.cancelHovered ? "#7f8c8d" : "#95a5a6"
+    );
+  }
+
+  private renderButton(
+    context: CanvasRenderingContext2D,
+    x: number, y: number,
+    label: string,
+    color: string
+  ): void {
+    const w = this.BUTTON_WIDTH;
+    const h = this.BUTTON_HEIGHT;
+    const r = 5;
+
+    context.fillStyle = color;
+    context.beginPath();
+    context.moveTo(x + r, y);
+    context.lineTo(x + w - r, y);
+    context.quadraticCurveTo(x + w, y, x + w, y + r);
+    context.lineTo(x + w, y + h - r);
+    context.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    context.lineTo(x + r, y + h);
+    context.quadraticCurveTo(x, y + h, x, y + h - r);
+    context.lineTo(x, y + r);
+    context.quadraticCurveTo(x, y, x + r, y);
+    context.closePath();
+    context.fill();
+
+    context.fillStyle = "white";
+    context.font = "bold 15px Arial";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(label, x + w / 2, y + h / 2);
+  }
+
+  private isPointInRect(
+    px: number, py: number,
+    rx: number, ry: number,
+    rw: number, rh: number
+  ): boolean {
+    return px >= rx && px <= rx + rw && py >= ry && py <= ry + rh;
+  }
+}

--- a/src/game/entities/match-menu-entity.ts
+++ b/src/game/entities/match-menu-entity.ts
@@ -5,6 +5,7 @@ import { SmallButtonEntity } from "./common/small-button-entity.js";
 import { PlayersListEntity } from "./players-list-entity.js";
 import { MatchWindowElement } from "./match-menu/elements/match-window-element.js";
 import { MatchTitleBarElement } from "./match-menu/elements/match-title-bar-element.js";
+import { CloseableMessageEntity } from "./common/closeable-message-entity.js";
 import type { GamePlayer } from "../models/game-player.js";
 import type { PlayerModerationService } from "../services/network/player-moderation-service.js";
 import type { GamePointerContract } from "../../engine/interfaces/input/game-pointer-interface.js";
@@ -21,10 +22,13 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
   private readonly playersListEntity: PlayersListEntity;
   private readonly windowElement: MatchWindowElement;
   private readonly titleBarElement: MatchTitleBarElement;
+  private readonly messageEntity: CloseableMessageEntity;
 
   private windowX = 0;
   private windowY = 0;
   private windowWidth = 0;
+
+  private pendingClose = false;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -54,6 +58,7 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
       this.TITLE_BAR_HEIGHT,
       this.PADDING
     );
+    this.messageEntity = new CloseableMessageEntity(canvas);
 
     this.calculateLayout();
   }
@@ -65,6 +70,7 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     this.playersListEntity.load();
     this.windowElement.load();
     this.titleBarElement.load();
+    this.messageEntity.load();
     super.load();
   }
 
@@ -86,13 +92,14 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
       this.windowY + this.TITLE_BAR_HEIGHT + 45,
       this.windowWidth - this.PADDING * 2,
       this.gamePointer,
-      (playerId: string, reason: string) =>
-        this.handlePlayerReport(playerId, reason),
+      (playerId: string, reason: string, playerName: string) =>
+        this.handlePlayerReport(playerId, reason, playerName),
       (
         playerId: string,
         reason: string,
+        playerName: string,
         duration?: { value: number; unit: string }
-      ) => this.handlePlayerBan(playerId, reason, duration),
+      ) => this.handlePlayerBan(playerId, reason, playerName, duration),
       this.canvas
     );
   }
@@ -119,32 +126,54 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     );
   }
 
-  private handlePlayerReport(playerId: string, reason: string): void {
+  private handlePlayerReport(playerId: string, reason: string, playerName: string): void {
+    if (!window.confirm(`Are you sure you want to report ${playerName}?`)) {
+      return;
+    }
+
     this.moderationService
       .reportUser(playerId, reason, false)
+      .then(() => {
+        this.messageEntity.show("Report sent");
+        this.pendingClose = true;
+      })
       .catch((error) => {
         console.error("Failed to report user:", error);
+        this.messageEntity.show("Failed to report player");
+        this.pendingClose = true;
       });
-
-    this.onClose();
   }
 
   private handlePlayerBan(
     playerId: string,
     reason: string,
+    playerName: string,
     duration?: { value: number; unit: string }
   ): void {
+    if (!window.confirm(`Are you sure you want to ban ${playerName}?`)) {
+      return;
+    }
+
     this.moderationService
       .banUser(playerId, reason, duration)
+      .then(() => {
+        this.messageEntity.show("User banned");
+        this.pendingClose = true;
+      })
       .catch((error) => {
         console.error("Failed to ban user:", error);
+        this.messageEntity.show("Failed to ban player");
+        this.pendingClose = true;
       });
-
-    this.onClose();
   }
 
   public override handlePointerEvent(gamePointer: GamePointerContract): void {
     if (!this.active || this.opacity === 0) {
+      return;
+    }
+
+    if (this.pendingClose && this.messageEntity.isActive()) {
+      this.messageEntity.handlePointerEvent(gamePointer);
       return;
     }
 
@@ -170,6 +199,16 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
   }
 
   public override update(delta: DOMHighResTimeStamp): void {
+    if (this.pendingClose) {
+      this.messageEntity.update(delta);
+      if (!this.messageEntity.isActive()) {
+        this.pendingClose = false;
+        this.onClose();
+      }
+      super.update(delta);
+      return;
+    }
+
     if (this.playersListEntity.isActionMenuOpen()) {
       this.playersListEntity.update(delta);
       super.update(delta);
@@ -202,12 +241,18 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     context.save();
     context.globalAlpha = this.opacity;
 
-    this.backdropEntity.render(context);
+    if (!this.playersListEntity.isActionMenuOpen()) {
+      this.backdropEntity.render(context);
+    }
     this.windowElement.render(context);
     this.titleBarElement.render(context);
     this.closeButtonEntity.render(context);
     this.leaveMatchButton.render(context);
     this.playersListEntity.render(context);
+
+    if (this.pendingClose) {
+      this.messageEntity.render(context);
+    }
 
     context.restore();
     super.render(context);

--- a/src/game/entities/match-menu-entity.ts
+++ b/src/game/entities/match-menu-entity.ts
@@ -6,6 +6,7 @@ import { PlayersListEntity } from "./players-list-entity.js";
 import { MatchWindowElement } from "./match-menu/elements/match-window-element.js";
 import { MatchTitleBarElement } from "./match-menu/elements/match-title-bar-element.js";
 import { CloseableMessageEntity } from "./common/closeable-message-entity.js";
+import { ConfirmationMessageEntity } from "./common/confirmation-message-entity.js";
 import type { GamePlayer } from "../models/game-player.js";
 import type { PlayerModerationService } from "../services/network/player-moderation-service.js";
 import type { GamePointerContract } from "../../engine/interfaces/input/game-pointer-interface.js";
@@ -22,12 +23,16 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
   private readonly playersListEntity: PlayersListEntity;
   private readonly windowElement: MatchWindowElement;
   private readonly titleBarElement: MatchTitleBarElement;
+  private readonly confirmationEntity: ConfirmationMessageEntity;
   private readonly messageEntity: CloseableMessageEntity;
 
   private windowX = 0;
   private windowY = 0;
   private windowWidth = 0;
 
+  // Stores the API call to execute if the user confirms
+  private pendingAction: (() => void) | null = null;
+  // True while waiting for the user to dismiss the result message
   private pendingClose = false;
 
   constructor(
@@ -58,6 +63,7 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
       this.TITLE_BAR_HEIGHT,
       this.PADDING
     );
+    this.confirmationEntity = new ConfirmationMessageEntity(canvas);
     this.messageEntity = new CloseableMessageEntity(canvas);
 
     this.calculateLayout();
@@ -70,6 +76,7 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     this.playersListEntity.load();
     this.windowElement.load();
     this.titleBarElement.load();
+    this.confirmationEntity.load();
     this.messageEntity.load();
     super.load();
   }
@@ -127,21 +134,21 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
   }
 
   private handlePlayerReport(playerId: string, reason: string, playerName: string): void {
-    if (!window.confirm(`Are you sure you want to report ${playerName}?`)) {
-      return;
-    }
+    this.pendingAction = () => {
+      this.moderationService
+        .reportUser(playerId, reason, false)
+        .then(() => {
+          this.messageEntity.show("Report sent");
+          this.pendingClose = true;
+        })
+        .catch((error) => {
+          console.error("Failed to report user:", error);
+          this.messageEntity.show("Failed to report player");
+          this.pendingClose = true;
+        });
+    };
 
-    this.moderationService
-      .reportUser(playerId, reason, false)
-      .then(() => {
-        this.messageEntity.show("Report sent");
-        this.pendingClose = true;
-      })
-      .catch((error) => {
-        console.error("Failed to report user:", error);
-        this.messageEntity.show("Failed to report player");
-        this.pendingClose = true;
-      });
+    this.confirmationEntity.show(`Are you sure you want to report ${playerName}?`);
   }
 
   private handlePlayerBan(
@@ -150,21 +157,21 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     playerName: string,
     duration?: { value: number; unit: string }
   ): void {
-    if (!window.confirm(`Are you sure you want to ban ${playerName}?`)) {
-      return;
-    }
+    this.pendingAction = () => {
+      this.moderationService
+        .banUser(playerId, reason, duration)
+        .then(() => {
+          this.messageEntity.show("User banned");
+          this.pendingClose = true;
+        })
+        .catch((error) => {
+          console.error("Failed to ban user:", error);
+          this.messageEntity.show("Failed to ban player");
+          this.pendingClose = true;
+        });
+    };
 
-    this.moderationService
-      .banUser(playerId, reason, duration)
-      .then(() => {
-        this.messageEntity.show("User banned");
-        this.pendingClose = true;
-      })
-      .catch((error) => {
-        console.error("Failed to ban user:", error);
-        this.messageEntity.show("Failed to ban player");
-        this.pendingClose = true;
-      });
+    this.confirmationEntity.show(`Are you sure you want to ban ${playerName}?`);
   }
 
   public override handlePointerEvent(gamePointer: GamePointerContract): void {
@@ -174,6 +181,11 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
 
     if (this.pendingClose && this.messageEntity.isActive()) {
       this.messageEntity.handlePointerEvent(gamePointer);
+      return;
+    }
+
+    if (this.confirmationEntity.isOpen()) {
+      this.confirmationEntity.handlePointerEvent(gamePointer);
       return;
     }
 
@@ -205,6 +217,22 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
         this.pendingClose = false;
         this.onClose();
       }
+      super.update(delta);
+      return;
+    }
+
+    if (this.confirmationEntity.isOpen()) {
+      this.confirmationEntity.update(delta);
+
+      if (this.confirmationEntity.isConfirmed()) {
+        this.confirmationEntity.close();
+        this.pendingAction?.();
+        this.pendingAction = null;
+      } else if (this.confirmationEntity.isCancelled()) {
+        this.confirmationEntity.close();
+        this.pendingAction = null;
+      }
+
       super.update(delta);
       return;
     }
@@ -241,14 +269,25 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     context.save();
     context.globalAlpha = this.opacity;
 
-    if (!this.playersListEntity.isActionMenuOpen()) {
+    // Skip the match-menu backdrop when a sub-menu (report/ban reason picker
+    // or confirmation dialog) is layering its own dark overlay on top.
+    const subMenuOpen =
+      this.playersListEntity.isActionMenuOpen() ||
+      this.confirmationEntity.isOpen();
+
+    if (!subMenuOpen) {
       this.backdropEntity.render(context);
     }
+
     this.windowElement.render(context);
     this.titleBarElement.render(context);
     this.closeButtonEntity.render(context);
     this.leaveMatchButton.render(context);
     this.playersListEntity.render(context);
+
+    if (this.confirmationEntity.isOpen()) {
+      this.confirmationEntity.render(context);
+    }
 
     if (this.pendingClose) {
       this.messageEntity.render(context);

--- a/src/game/entities/players-list-entity.ts
+++ b/src/game/entities/players-list-entity.ts
@@ -15,8 +15,8 @@ export class PlayersListEntity extends BaseGameEntity {
   private containerX = 0;
   private containerY = 0;
   private gamePointer: GamePointerContract | null = null;
-  private onReport: ((playerId: string, reason: string) => void) | null = null;
-  private onBan: ((playerId: string, reason: string, duration?: {value: number, unit: string}) => void) | null = null;
+  private onReport: ((playerId: string, reason: string, playerName: string) => void) | null = null;
+  private onBan: ((playerId: string, reason: string, playerName: string, duration?: {value: number, unit: string}) => void) | null = null;
   private canvas: HTMLCanvasElement | null = null;
   private apiService: APIService;
 
@@ -32,8 +32,8 @@ export class PlayersListEntity extends BaseGameEntity {
     y: number,
     width: number,
     gamePointer: GamePointerContract,
-    onReport: (playerId: string, reason: string) => void,
-    onBan: (playerId: string, reason: string, duration?: {value: number, unit: string}) => void,
+    onReport: (playerId: string, reason: string, playerName: string) => void,
+    onBan: (playerId: string, reason: string, playerName: string, duration?: {value: number, unit: string}) => void,
     canvas: HTMLCanvasElement
   ): void {
     this.containerX = x;
@@ -108,7 +108,7 @@ export class PlayersListEntity extends BaseGameEntity {
           const selectedReason = this.reportMenuEntity!.getConfirmedReason();
           const reportedPlayer = this.reportMenuEntity!.getReportedPlayer();
           if (selectedReason && reportedPlayer && this.onReport) {
-            this.onReport(reportedPlayer.getId(), selectedReason);
+            this.onReport(reportedPlayer.getId(), selectedReason, reportedPlayer.getName());
             return true;
           }
           return false;
@@ -126,7 +126,7 @@ export class PlayersListEntity extends BaseGameEntity {
           const confirmedData = this.banMenuEntity!.getConfirmedData();
           const bannedPlayer = this.banMenuEntity!.getBannedPlayer();
           if (confirmedData && bannedPlayer && this.onBan) {
-            this.onBan(bannedPlayer.getId(), confirmedData.reason, confirmedData.duration);
+            this.onBan(bannedPlayer.getId(), confirmedData.reason, bannedPlayer.getName(), confirmedData.duration);
             return true;
           }
           return false;

--- a/src/game/scenes/error/error-scene.ts
+++ b/src/game/scenes/error/error-scene.ts
@@ -1,0 +1,86 @@
+import { BaseGameScene } from "../../../engine/scenes/base-game-scene.js";
+import { GameState } from "../../../engine/models/game-state.js";
+import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
+import { SceneType } from "../../../engine/enums/scene-type.js";
+import { container } from "../../../engine/services/di-container.js";
+
+export class ErrorScene extends BaseGameScene {
+  private readonly MESSAGE_WIDTH = 340;
+  private readonly MESSAGE_HEIGHT = 100;
+  private readonly CORNER_RADIUS = 6;
+
+  private errorMessage: string;
+  private messageX = 0;
+  private messageY = 0;
+  private messageTextX = 0;
+  private messageTextY = 0;
+
+  constructor(errorMessage: string) {
+    const gameState = container.get(GameState);
+    const eventConsumerService = container.get(EventConsumerService);
+    super(gameState, eventConsumerService);
+    this.errorMessage = errorMessage;
+  }
+
+  public override getTypeId(): SceneType {
+    return SceneType.Error;
+  }
+
+  public override load(): void {
+    this.calculateLayout();
+    this.loaded = true;
+  }
+
+  public override update(_deltaTimeStamp: DOMHighResTimeStamp): void {
+    // All user interactions are disabled — do not process pointer events or entities
+  }
+
+  public override render(context: CanvasRenderingContext2D): void {
+    context.save();
+    context.globalAlpha = this.opacity;
+
+    this.renderBackground(context);
+    this.renderMessage(context);
+
+    context.restore();
+  }
+
+  private calculateLayout(): void {
+    this.messageX = this.canvas.width / 2 - this.MESSAGE_WIDTH / 2;
+    this.messageY = this.canvas.height / 2 - this.MESSAGE_HEIGHT / 2;
+    this.messageTextX = this.canvas.width / 2;
+    this.messageTextY = this.messageY + this.MESSAGE_HEIGHT / 2 + 5;
+  }
+
+  private renderBackground(context: CanvasRenderingContext2D): void {
+    const gradient = context.createLinearGradient(0, 0, 0, this.canvas.height);
+    gradient.addColorStop(0, "#c0392b");
+    gradient.addColorStop(1, "#7b241c");
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  private renderMessage(context: CanvasRenderingContext2D): void {
+    const r = this.CORNER_RADIUS;
+    const x = this.messageX;
+    const y = this.messageY;
+    const w = this.MESSAGE_WIDTH;
+    const h = this.MESSAGE_HEIGHT;
+
+    context.fillStyle = "rgba(0, 0, 0, 0.8)";
+    context.beginPath();
+    context.moveTo(x + r, y);
+    context.arcTo(x + w, y, x + w, y + h, r);
+    context.arcTo(x + w, y + h, x, y + h, r);
+    context.arcTo(x, y + h, x, y, r);
+    context.arcTo(x, y, x + w, y, r);
+    context.closePath();
+    context.fill();
+
+    context.font = "16px Arial";
+    context.fillStyle = "white";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(this.errorMessage, this.messageTextX, this.messageTextY - 5);
+  }
+}

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -22,6 +22,8 @@ import { ToastEntity } from "../../../entities/common/toast-entity.js";
 import { gameContext } from "../../../context/game-context.js";
 import { WebSocketService } from "../../../services/network/websocket-service.js";
 import { SceneTransitionUtils } from "../../../utils/scene-transition-utils.js";
+import { ErrorScene } from "../../error/error-scene.js";
+import { MainScene } from "../main-scene.js";
 
 export class MainMenuScene extends BaseGameScene {
   private MENU_OPTIONS_TEXT: string[] = ["Join game", "Scoreboard", "Settings"];
@@ -143,6 +145,11 @@ export class MainMenuScene extends BaseGameScene {
     this.subscribeToLocalEvent(
       EventType.UserBannedByServer,
       this.handleUserBannedByServerEvent.bind(this)
+    );
+
+    this.subscribeToLocalEvent(
+      EventType.UserKickedByServer,
+      this.handleUserKickedByServerEvent.bind(this)
     );
   }
 
@@ -373,6 +380,21 @@ export class MainMenuScene extends BaseGameScene {
   private handleUserBannedByServerEvent(): void {
     console.log("User banned by server, transitioning to login scene");
     this.transitionToLoginScene();
+  }
+
+  private handleUserKickedByServerEvent(): void {
+    console.log("User kicked by server, navigating to error scene");
+
+    const mainScene = new MainScene();
+    const errorScene = new ErrorScene("You have been kicked from the server");
+    mainScene.activateScene(errorScene);
+    mainScene.load();
+
+    if (this.sceneManagerService) {
+      this.sceneManagerService
+        .getTransitionService()
+        .fadeOutAndIn(this.sceneManagerService, mainScene, 1, 1);
+    }
   }
 
   private handleOnlinePlayersEvent(payload: OnlinePlayersPayload): void {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -316,10 +316,11 @@ export class WorldScene extends BaseCollidingGameScene {
 
   private handleMatchmakingError(error: Error) {
     console.error("Matchmaking error", error);
-    alert("Could not find or advertise match, returning to main scene menu...");
 
     this.matchSessionService.setMatch(null);
-    void this.returnToMainMenuScene();
+    void this.returnToMainMenuScene(
+      "Could not find or advertise match, returning to main menu..."
+    );
   }
 
   private addSyncableEntities(): void {
@@ -724,13 +725,17 @@ export class WorldScene extends BaseCollidingGameScene {
     this.subscribeToEvents();
   }
 
-  private async returnToMainMenuScene(): Promise<void> {
+  private async returnToMainMenuScene(errorMessage?: string): Promise<void> {
     const mainScene = new MainScene();
     const mainMenuScene = new MainMenuScene(
       this.gameState,
       container.get(EventConsumerService),
       false
     );
+
+    if (errorMessage) {
+      mainMenuScene.setPendingMessage(errorMessage);
+    }
 
     if (!this.gameServer.isConnected()) {
       try {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -27,6 +27,7 @@ import { SceneTransitionService } from "../../../engine/services/gameplay/scene-
 import { TimerManagerService } from "../../../engine/services/gameplay/timer-manager-service.js";
 import { MainScene } from "../main/main-scene.js";
 import { MainMenuScene } from "../main/main-menu/main-menu-scene.js";
+import { ErrorScene } from "../error/error-scene.js";
 import { container } from "../../../engine/services/di-container.js";
 import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
 import { SceneTransitionUtils } from "../../utils/scene-transition-utils.js";
@@ -476,6 +477,11 @@ export class WorldScene extends BaseCollidingGameScene {
       () => void this.returnToLoginScene()
     );
 
+    this.subscribeToLocalEvent(
+      EventType.UserKickedByServer,
+      () => this.navigateToErrorScene("You have been kicked from the server")
+    );
+
     this.subscribeToLocalEvent(EventType.SnowWeather, () => {
       this.activateSnowWeather();
     });
@@ -759,6 +765,30 @@ export class WorldScene extends BaseCollidingGameScene {
       gameFrame: this.gameState.getGameFrame(),
       errorMessage: "You have been banned from the server",
     });
+  }
+
+  private navigateToErrorScene(errorMessage: string): void {
+    console.log("Navigating to error scene:", errorMessage);
+
+    if (this.matchmakingService) {
+      this.matchmakingService.leaveMatch().catch((error) => {
+        console.error("Error leaving match during kick:", error);
+      });
+    }
+
+    this.dispose();
+
+    const mainScene = new MainScene();
+    const errorScene = new ErrorScene(errorMessage);
+    mainScene.activateScene(errorScene);
+    mainScene.load();
+
+    this.sceneTransitionService.fadeOutAndIn(
+      this.gameState.getGameFrame(),
+      mainScene,
+      1,
+      1
+    );
   }
 
   private activateSnowWeather(): void {

--- a/src/game/services/network/websocket-service.ts
+++ b/src/game/services/network/websocket-service.ts
@@ -350,14 +350,23 @@ export class WebSocketService implements WebSocketServiceContract {
     if (event.code === 1000 && event.reason === "User has been banned") {
       console.log("User has been banned from the server");
 
-      // Stop any reconnection attempts
       this.stopReconnection();
-
-      // Clean up the WebSocket connection reference
       this.webSocket = null;
 
-      // Emit user banned event
       const localEvent = new LocalEvent(EventType.UserBannedByServer);
+      this.eventProcessorService.addLocalEvent(localEvent);
+
+      return;
+    }
+
+    // Check if the user has been kicked
+    if (event.code === 1000 && event.reason === "User has been kicked") {
+      console.log("User has been kicked from the server");
+
+      this.stopReconnection();
+      this.webSocket = null;
+
+      const localEvent = new LocalEvent(EventType.UserKickedByServer);
       this.eventProcessorService.addLocalEvent(localEvent);
 
       return;


### PR DESCRIPTION
- Report/Ban: show window.confirm() before submitting, then display
  tappable success/error message via CloseableMessageEntity; close menu
  only after user dismisses the message
- Match menu: skip rendering backdrop when a sub-menu (report/ban
  reason picker) is open to prevent double-darkening
- Add ErrorScene with red gradient background and non-dismissible
  message; navigate there when the server kicks a user (new
  UserKickedByServer event + WebSocket close-reason handling); existing
  UserBannedByServer flow to LoginScene is unchanged
- DebugSettings: add isBallTrajectoryVisible / setBallTrajectoryVisibility
- BallEntity: add getTrajectoryPoints() getter and renderTrajectory()
  which draws the predicted path as a dashed orange line when enabled
- DebugWindow UI section: add "Show ball trajectory" checkbox backed by
  the new DebugSettings getter/setter

https://claude.ai/code/session_013WGmS2W1ebKNoqSDfr4DsS