### PR TITLE
Fix match menu UI, confirmation overlay, button styling, and ban/disconnect handling

### DIFF
--- a/src/game/entities/ban-menu-entity.ts
+++ b/src/game/entities/ban-menu-entity.ts
@@ -312,7 +312,6 @@ export class BanMenuEntity extends BaseTappableGameEntity implements ActionMenuC
     context.save();
     context.globalAlpha = this.opacity;
 
-    this.renderBackdrop(context);
     this.renderWindow(context);
     this.renderTitleBar(context);
     this.renderBanOptions(context);
@@ -321,11 +320,6 @@ export class BanMenuEntity extends BaseTappableGameEntity implements ActionMenuC
 
     context.restore();
     super.render(context);
-  }
-
-  private renderBackdrop(context: CanvasRenderingContext2D): void {
-    context.fillStyle = "rgba(0, 0, 0, 0.7)";
-    context.fillRect(0, 0, context.canvas.width, context.canvas.height);
   }
 
   private renderWindow(context: CanvasRenderingContext2D): void {
@@ -467,7 +461,7 @@ export class BanMenuEntity extends BaseTappableGameEntity implements ActionMenuC
 
   private renderButtons(context: CanvasRenderingContext2D): void {
     // Cancel
-    context.fillStyle = this.cancelButtonHovered ? "#95a5a6" : "#bdc3c7";
+    context.fillStyle = this.cancelButtonHovered ? "#7ed321" : "#4a90e2";
     this.drawRoundedRect(context, this.cancelButtonX, this.cancelButtonY, this.cancelButtonWidth, this.cancelButtonHeight, 5);
     context.fill();
     context.fillStyle = "#ffffff";

--- a/src/game/entities/common/confirmation-message-entity.ts
+++ b/src/game/entities/common/confirmation-message-entity.ts
@@ -2,12 +2,13 @@ import { BaseTappableGameEntity } from "../../../engine/entities/base-tappable-g
 import type { GamePointerContract } from "../../../engine/interfaces/input/game-pointer-interface.js";
 
 export class ConfirmationMessageEntity extends BaseTappableGameEntity {
-  private readonly BOX_WIDTH = 340;
-  private readonly BOX_HEIGHT = 140;
-  private readonly CORNER_RADIUS = 6;
-  private readonly BUTTON_WIDTH = 100;
-  private readonly BUTTON_HEIGHT = 36;
-  private readonly BUTTON_GAP = 15;
+  private readonly BOX_WIDTH = 400;
+  private readonly BOX_HEIGHT = 150;
+  private readonly CORNER_RADIUS = 8;
+  private readonly BUTTON_WIDTH = 110;
+  private readonly BUTTON_HEIGHT = 38;
+  private readonly BUTTON_GAP = 16;
+  private readonly H_PADDING = 28;
 
   private question = "";
   private isOpened = false;
@@ -73,9 +74,9 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
     this.boxX = this.canvas.width / 2 - this.BOX_WIDTH / 2;
     this.boxY = this.canvas.height / 2 - this.BOX_HEIGHT / 2;
     this.textX = this.canvas.width / 2;
-    this.textY = this.boxY + 45;
+    this.textY = this.boxY + 48;
 
-    const buttonsY = this.boxY + this.BOX_HEIGHT - this.BUTTON_HEIGHT - 15;
+    const buttonsY = this.boxY + this.BOX_HEIGHT - this.BUTTON_HEIGHT - 18;
     const totalW = this.BUTTON_WIDTH * 2 + this.BUTTON_GAP;
     const startX = this.canvas.width / 2 - totalW / 2;
 
@@ -167,11 +168,13 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
   }
 
   private renderText(context: CanvasRenderingContext2D): void {
-    context.font = "16px Arial";
+    context.font = "bold 15px system-ui";
     context.fillStyle = "white";
     context.textAlign = "center";
     context.textBaseline = "middle";
-    context.fillText(this.question, this.textX, this.textY);
+
+    const maxWidth = this.BOX_WIDTH - this.H_PADDING * 2;
+    context.fillText(this.question, this.textX, this.textY, maxWidth);
   }
 
   private renderButtons(context: CanvasRenderingContext2D): void {
@@ -179,14 +182,14 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
       context,
       this.confirmBtnX, this.confirmBtnY,
       "Yes",
-      this.confirmHovered ? "#27ae60" : "#2ecc71"
+      this.confirmHovered ? "#7ed321" : "#4a90e2"
     );
 
     this.renderButton(
       context,
       this.cancelBtnX, this.cancelBtnY,
       "No",
-      this.cancelHovered ? "#7f8c8d" : "#95a5a6"
+      this.cancelHovered ? "#7ed321" : "#4a90e2"
     );
   }
 
@@ -215,7 +218,7 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
     context.fill();
 
     context.fillStyle = "white";
-    context.font = "bold 15px Arial";
+    context.font = "bold 15px system-ui";
     context.textAlign = "center";
     context.textBaseline = "middle";
     context.fillText(label, x + w / 2, y + h / 2);

--- a/src/game/entities/match-menu-entity.ts
+++ b/src/game/entities/match-menu-entity.ts
@@ -226,11 +226,13 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
 
       if (this.confirmationEntity.isConfirmed()) {
         this.confirmationEntity.close();
+        this.playersListEntity.closeActiveActionMenu();
         this.pendingAction?.();
         this.pendingAction = null;
       } else if (this.confirmationEntity.isCancelled()) {
         this.confirmationEntity.close();
         this.pendingAction = null;
+        // Submenu stays open so user can pick a different reason
       }
 
       super.update(delta);
@@ -269,16 +271,7 @@ export class MatchMenuEntity extends BaseTappableGameEntity {
     context.save();
     context.globalAlpha = this.opacity;
 
-    // Skip the match-menu backdrop when a sub-menu (report/ban reason picker
-    // or confirmation dialog) is layering its own dark overlay on top.
-    const subMenuOpen =
-      this.playersListEntity.isActionMenuOpen() ||
-      this.confirmationEntity.isOpen();
-
-    if (!subMenuOpen) {
-      this.backdropEntity.render(context);
-    }
-
+    this.backdropEntity.render(context);
     this.windowElement.render(context);
     this.titleBarElement.render(context);
     this.closeButtonEntity.render(context);

--- a/src/game/entities/players-list-entity.ts
+++ b/src/game/entities/players-list-entity.ts
@@ -152,6 +152,15 @@ export class PlayersListEntity extends BaseGameEntity {
     super.update(delta);
   }
 
+  public closeActiveActionMenu(): void {
+    if (this.reportMenuEntity?.isOpen()) {
+      this.reportMenuEntity.close();
+    }
+    if (this.banMenuEntity?.isOpen()) {
+      this.banMenuEntity.close();
+    }
+  }
+
   private processActionMenu(
     menu: ActionMenuContract,
     delta: DOMHighResTimeStamp,
@@ -160,7 +169,7 @@ export class PlayersListEntity extends BaseGameEntity {
     menu.update(delta);
 
     if (onConfirm()) {
-      menu.close();
+      // Keep menu open — parent (MatchMenuEntity) will close it after confirmation resolves
       this.gamePointer?.clearPressed();
     } else if (menu.isCancelled()) {
       menu.close();

--- a/src/game/entities/report-menu-entity.ts
+++ b/src/game/entities/report-menu-entity.ts
@@ -248,9 +248,6 @@ export class ReportMenuEntity extends BaseTappableGameEntity implements ActionMe
     context.save();
     context.globalAlpha = this.opacity;
 
-    // Render backdrop
-    this.renderBackdrop(context);
-
     // Render window
     this.renderWindow(context);
 
@@ -265,12 +262,6 @@ export class ReportMenuEntity extends BaseTappableGameEntity implements ActionMe
 
     context.restore();
     super.render(context);
-  }
-
-  private renderBackdrop(context: CanvasRenderingContext2D): void {
-    // Simple dark backdrop
-    context.fillStyle = "rgba(0, 0, 0, 0.7)";
-    context.fillRect(0, 0, context.canvas.width, context.canvas.height);
   }
 
   private renderWindow(context: CanvasRenderingContext2D): void {
@@ -422,7 +413,7 @@ export class ReportMenuEntity extends BaseTappableGameEntity implements ActionMe
 
   private renderButtons(context: CanvasRenderingContext2D): void {
     // Cancel button
-    const cancelColor = this.cancelButtonHovered ? "#95a5a6" : "#bdc3c7";
+    const cancelColor = this.cancelButtonHovered ? "#7ed321" : "#4a90e2";
     context.fillStyle = cancelColor;
     this.drawRoundedRect(
       context,

--- a/src/game/scenes/world/world-controller.ts
+++ b/src/game/scenes/world/world-controller.ts
@@ -1,6 +1,7 @@
 import { BinaryReader } from "../../../engine/utils/binary-reader-utils.js";
 import { BinaryWriter } from "../../../engine/utils/binary-writer-utils.js";
 import { RemoteEvent } from "../../../engine/models/remote-event.js";
+import { LocalEvent } from "../../../engine/models/local-event.js";
 import { EventType } from "../../../engine/enums/event-type.js";
 import { MatchStateType } from "../../enums/match-state-type.js";
 import { TimerManagerService } from "../../../engine/services/gameplay/timer-manager-service.js";
@@ -459,6 +460,13 @@ export class WorldController {
     });
 
     this.matchActionsLogService.addAction(action);
+
+    // If the local player is the banned player, navigate to login as a terminal state
+    if (playerId === this.gamePlayer.getNetworkId()) {
+      console.log("Local player has been banned from this match");
+      const localEvent = new LocalEvent(EventType.UserBannedByServer);
+      this.eventProcessorService.addLocalEvent(localEvent);
+    }
   }
 
   public handleCarDemolitions(

--- a/src/game/services/network/matchmaking-network-service.ts
+++ b/src/game/services/network/matchmaking-network-service.ts
@@ -6,15 +6,18 @@ import { MATCH_ATTRIBUTES } from "../../constants/matchmaking-constants.js";
 import type { WebRTCPeer } from "../../../engine/interfaces/network/webrtc-peer-interface.js";
 import { EventType } from "../../../engine/enums/event-type.js";
 import { LocalEvent } from "../../../engine/models/local-event.js";
+import { RemoteEvent } from "../../../engine/models/remote-event.js";
 import type { PlayerConnectedPayload } from "../../interfaces/events/player-connected-payload-interface.js";
 import type { PlayerDisconnectedPayload } from "../../interfaces/events/player-disconnected-payload-interface.js";
 import type { HostDisconnectedPayload } from "../../interfaces/events/host-disconnected-payload-interface.js";
 
 import { WebRTCType } from "../../../engine/enums/webrtc-type.js";
+import { WebSocketType } from "../../enums/websocket-type.js";
 import type { IntervalServiceContract } from "../../../engine/interfaces/services/gameplay/interval-service-interface.js";
 import { BinaryWriter } from "../../../engine/utils/binary-writer-utils.js";
 import { BinaryReader } from "../../../engine/utils/binary-reader-utils.js";
 import { PeerCommandHandler } from "../../../engine/decorators/peer-command-handler-decorator.js";
+import { ServerCommandHandler } from "../../decorators/server-command-handler.js";
 import { WebSocketService } from "./websocket-service.js";
 import { SignatureService } from "../security/signature-service.js";
 import { WebRTCService } from "./webrtc-service.js";
@@ -24,6 +27,8 @@ import { EventProcessorService } from "../../../engine/services/gameplay/event-p
 import { TimerManagerService } from "../../../engine/services/gameplay/timer-manager-service.js";
 import { IntervalManagerService } from "../../../engine/services/gameplay/interval-manager-service.js";
 import { MatchSessionService } from "../session/match-session-service.js";
+import { MatchActionsLogService } from "../gameplay/match-actions-log-service.js";
+import { MatchAction } from "../../models/match-action.js";
 import { injectable, inject } from "@needle-di/core";
 import { SpawnPointService } from "../gameplay/spawn-point-service.js";
 
@@ -56,9 +61,11 @@ export class MatchmakingNetworkService
     private readonly spawnPointService: SpawnPointService = inject(
       SpawnPointService,
     ),
-
     private readonly signatureService: SignatureService = inject(
       SignatureService,
+    ),
+    private readonly matchActionsLogService: MatchActionsLogService = inject(
+      MatchActionsLogService,
     ),
   ) {
     this.webSocketService.registerCommandHandlers(this);
@@ -698,6 +705,47 @@ export class MatchmakingNetworkService
       .toArrayBuffer();
 
     peer.sendUnreliableUnorderedMessage(payload);
+  }
+
+  @ServerCommandHandler(WebSocketType.PlayerKicked)
+  public handlePlayerKicked(binaryReader: BinaryReader): void {
+    const userId = binaryReader.fixedLengthString(32);
+
+    const match = this.matchSessionService.getMatch();
+    if (match === null) {
+      console.debug("Received PlayerKicked but no active match");
+      return;
+    }
+    if (!match.isHost()) {
+      console.debug("Received PlayerKicked but not host, ignoring");
+      return;
+    }
+
+    const player = match.getPlayerByNetworkId(userId);
+    const playerName = player?.getName() ?? userId;
+
+    console.log(`Kicking banned player from match: ${playerName} (${userId})`);
+
+    const action = MatchAction.playerBanned(userId, { playerName });
+    this.matchActionsLogService.addAction(action);
+
+    // Disconnect the banned player from the P2P game immediately
+    const bannedPeer = this.webrtcService
+      .getPeers()
+      .find((p: WebRTCPeer) => p.getPlayer()?.getNetworkId() === userId);
+
+    if (bannedPeer) {
+      bannedPeer.disconnect(true);
+    }
+
+    // Broadcast to remaining peers so they log the ban in their match history
+    const payload = BinaryWriter.build()
+      .fixedLengthString(userId, 32)
+      .toArrayBuffer();
+
+    const banEvent = new RemoteEvent(EventType.PlayerBanned);
+    banEvent.setData(payload);
+    this.eventProcessorService.sendEvent(banEvent);
   }
 
   private removeNpcPlayerAndReleaseSpawnPoint(match: MatchSession): void {

--- a/src/game/services/network/websocket-service.ts
+++ b/src/game/services/network/websocket-service.ts
@@ -17,10 +17,6 @@ import { ServerCommandHandler } from "../../decorators/server-command-handler.js
 import { injectable, inject } from "@needle-di/core";
 import { GameState } from "../../../engine/models/game-state.js";
 import type { WebSocketServiceContract } from "../../interfaces/services/network/websocket-service-interface.js";
-import { MatchSessionService } from "../session/match-session-service.js";
-import { MatchActionsLogService } from "../gameplay/match-actions-log-service.js";
-import { MatchAction } from "../../models/match-action.js";
-import { RemoteEvent } from "../../../engine/models/remote-event.js";
 
 @injectable()
 export class WebSocketService implements WebSocketServiceContract {
@@ -35,6 +31,8 @@ export class WebSocketService implements WebSocketServiceContract {
   private maxReconnectAttempts = 50; // Maximum number of reconnection attempts (0 = unlimited)
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private sessionClearedListenerAttached = false;
+  // Set when the server closes the connection due to ban or kick; prevents reconnect
+  private isTerminalDisconnect = false;
 
   private dispatcherService: WebSocketDispatcherService;
 
@@ -57,12 +55,6 @@ export class WebSocketService implements WebSocketServiceContract {
     private readonly eventProcessorService: EventProcessorServiceContract = inject(
       EventProcessorService,
     ),
-    private readonly matchSessionService: MatchSessionService = inject(
-      MatchSessionService,
-    ),
-    private readonly matchActionsLogService: MatchActionsLogService = inject(
-      MatchActionsLogService,
-    ),
   ) {
     this.baseURL = APIUtils.getWSBaseURL();
     this.dispatcherService = new WebSocketDispatcherService();
@@ -84,6 +76,7 @@ export class WebSocketService implements WebSocketServiceContract {
   }
 
   public connectToServer(): void {
+    this.isTerminalDisconnect = false;
     this.attachSessionClearedListener();
     this.attemptConnection();
   }
@@ -291,12 +284,6 @@ export class WebSocketService implements WebSocketServiceContract {
     this.eventProcessorService.addLocalEvent(localEvent);
   }
 
-  @ServerCommandHandler(WebSocketType.PlayerKicked)
-  public handleUserBan(binaryReader: BinaryReader) {
-    const userId = binaryReader.fixedLengthString(32);
-
-    this.processUserBan(userId);
-  }
 
   private addEventListeners(webSocket: WebSocket): void {
     webSocket.addEventListener("open", this.boundHandleOpenEvent);
@@ -350,6 +337,7 @@ export class WebSocketService implements WebSocketServiceContract {
     if (event.code === 1000 && event.reason === "User has been banned") {
       console.log("User has been banned from the server");
 
+      this.isTerminalDisconnect = true;
       this.stopReconnection();
       this.webSocket = null;
 
@@ -363,6 +351,7 @@ export class WebSocketService implements WebSocketServiceContract {
     if (event.code === 1000 && event.reason === "User has been kicked") {
       console.log("User has been kicked from the server");
 
+      this.isTerminalDisconnect = true;
       this.stopReconnection();
       this.webSocket = null;
 
@@ -401,6 +390,10 @@ export class WebSocketService implements WebSocketServiceContract {
 
   private handleErrorEvent(event: Event): void {
     console.error("WebSocket error", event);
+
+    if (this.isTerminalDisconnect) {
+      return;
+    }
 
     // If we're connected and get an error, treat it like a disconnection
     if (this.gameServer.isConnected()) {
@@ -450,41 +443,6 @@ export class WebSocketService implements WebSocketServiceContract {
     }
   }
 
-  private processUserBan(userId: string): void {
-    const match = this.matchSessionService.getMatch();
-
-    if (match === null) {
-      console.debug("Received UserBan message but no active match");
-      return;
-    }
-
-    if (!match.isHost()) {
-      console.debug("Received UserBan message but not host, ignoring");
-      return;
-    }
-
-    const player = match.getPlayerByNetworkId(userId);
-    const playerName = player?.getName() ?? userId;
-
-    console.log(`User banned: ${playerName} (${userId})`);
-
-    // Add to local match log
-    const action = MatchAction.playerBanned(userId, {
-      playerName,
-    });
-
-    this.matchActionsLogService.addAction(action);
-
-    // Broadcast the ban event to all peers
-    const payload = BinaryWriter.build()
-      .fixedLengthString(userId, 32)
-      .toArrayBuffer();
-
-    const banEvent = new RemoteEvent(EventType.PlayerBanned);
-    banEvent.setData(payload);
-
-    this.eventProcessorService.sendEvent(banEvent);
-  }
 
   private isLoggingEnabled(): boolean {
     return this.gameState.getDebugSettings().isWebSocketLoggingEnabled();


### PR DESCRIPTION
- Unify backdrop: remove per-submenu dark overlays; MatchMenuEntity's single
  backdrop now persists across all submenu states (report, ban, confirmation)
- Preserve submenu on confirm: confirmation dialog now renders on top of the
  active report/ban submenu instead of closing it; submenu closes only after
  the user confirms or cancels via MatchMenuEntity
- Confirmation dialog UI: widen box (340→400px), increase padding, use
  system-ui font; Yes/No buttons now use blue (#4a90e2) default with green
  (#7ed321) hover, matching the global button style
- Cancel button styling: report and ban menu Cancel buttons now use the same
  blue/green scheme as all other action buttons
- Ban/disconnect fix: move PlayerKicked WebSocket handler into
  MatchmakingNetworkService so the host immediately disconnects the banned
  peer from WebRTC after broadcasting the ban; WorldController now emits
  UserBannedByServer when the local player is the banned party, routing them
  to the login screen instead of leaving them in-game; add isTerminalDisconnect
  flag in WebSocketService to prevent the error-event race from restarting the
  reconnect loop after a ban or kick close

https://claude.ai/code/session_01AiqPZT7nrGgTD5Ep1gLoYh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-game notification when the local player is banned by the server.

* **Bug Fixes**
  * Fixed menu backdrop rendering behavior.
  * Improved confirmation dialog layout and positioning.

* **UI/Visual**
  * Updated button hover colors in menus.
  * Adjusted dialog spacing and dimensions.
  * Changed text font styling for improved legibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->