### PR TITLE
Fix ban/report modals and ban flow

### DIFF
--- a/src/game/entities/ban-menu-entity.ts
+++ b/src/game/entities/ban-menu-entity.ts
@@ -37,7 +37,7 @@ export class BanMenuEntity extends BaseTappableGameEntity implements ActionMenuC
   
   // Duration state
   private durationValue: number = 1;
-  private durationUnitIndex: number = 1; // Default to Hours
+  private durationUnitIndex: number = 0; // Default to Minutes
   private isPermanent: boolean = false;
   
   // Confirmed result
@@ -128,7 +128,7 @@ export class BanMenuEntity extends BaseTappableGameEntity implements ActionMenuC
     
     // Reset duration defaults
     this.durationValue = 1;
-    this.durationUnitIndex = 1; // Hours
+    this.durationUnitIndex = 0; // Minutes
     this.isPermanent = false;
 
     this.calculateLayout();

--- a/src/game/entities/common/confirmation-message-entity.ts
+++ b/src/game/entities/common/confirmation-message-entity.ts
@@ -2,13 +2,14 @@ import { BaseTappableGameEntity } from "../../../engine/entities/base-tappable-g
 import type { GamePointerContract } from "../../../engine/interfaces/input/game-pointer-interface.js";
 
 export class ConfirmationMessageEntity extends BaseTappableGameEntity {
-  private readonly BOX_WIDTH = 400;
-  private readonly BOX_HEIGHT = 150;
+  private readonly BOX_WIDTH = 300;
+  private readonly BOX_HEIGHT = 160;
   private readonly CORNER_RADIUS = 8;
-  private readonly BUTTON_WIDTH = 110;
-  private readonly BUTTON_HEIGHT = 38;
-  private readonly BUTTON_GAP = 16;
-  private readonly H_PADDING = 28;
+  private readonly BUTTON_WIDTH = 90;
+  private readonly BUTTON_HEIGHT = 36;
+  private readonly BUTTON_GAP = 12;
+  private readonly H_PADDING = 20;
+  private readonly LINE_HEIGHT = 24;
 
   private question = "";
   private isOpened = false;
@@ -74,9 +75,9 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
     this.boxX = this.canvas.width / 2 - this.BOX_WIDTH / 2;
     this.boxY = this.canvas.height / 2 - this.BOX_HEIGHT / 2;
     this.textX = this.canvas.width / 2;
-    this.textY = this.boxY + 48;
+    this.textY = this.boxY + 40;
 
-    const buttonsY = this.boxY + this.BOX_HEIGHT - this.BUTTON_HEIGHT - 18;
+    const buttonsY = this.boxY + this.BOX_HEIGHT - this.BUTTON_HEIGHT - 14;
     const totalW = this.BUTTON_WIDTH * 2 + this.BUTTON_GAP;
     const startX = this.canvas.width / 2 - totalW / 2;
 
@@ -168,13 +169,45 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
   }
 
   private renderText(context: CanvasRenderingContext2D): void {
-    context.font = "bold 15px system-ui";
+    context.font = "14px system-ui";
     context.fillStyle = "white";
     context.textAlign = "center";
     context.textBaseline = "middle";
 
     const maxWidth = this.BOX_WIDTH - this.H_PADDING * 2;
-    context.fillText(this.question, this.textX, this.textY, maxWidth);
+    const lines = this.wrapText(context, this.question, maxWidth);
+
+    const totalHeight = lines.length * this.LINE_HEIGHT;
+    let startY = this.textY - (totalHeight / 2) + (this.LINE_HEIGHT / 2);
+
+    for (const line of lines) {
+      context.fillText(line, this.textX, startY, maxWidth);
+      startY += this.LINE_HEIGHT;
+    }
+  }
+
+  private wrapText(context: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+    const words = text.split(" ");
+    const lines: string[] = [];
+    let currentLine = "";
+
+    for (const word of words) {
+      const testLine = currentLine ? currentLine + " " + word : word;
+      const metrics = context.measureText(testLine);
+
+      if (metrics.width > maxWidth && currentLine) {
+        lines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    return lines;
   }
 
   private renderButtons(context: CanvasRenderingContext2D): void {
@@ -182,14 +215,14 @@ export class ConfirmationMessageEntity extends BaseTappableGameEntity {
       context,
       this.confirmBtnX, this.confirmBtnY,
       "Yes",
-      this.confirmHovered ? "#7ed321" : "#4a90e2"
+      this.confirmHovered ? "#22C55E" : "#3B82F6"
     );
 
     this.renderButton(
       context,
       this.cancelBtnX, this.cancelBtnY,
       "No",
-      this.cancelHovered ? "#7ed321" : "#4a90e2"
+      this.cancelHovered ? "#22C55E" : "#3B82F6"
     );
   }
 

--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -378,8 +378,18 @@ export class MainMenuScene extends BaseGameScene {
   }
 
   private handleUserBannedByServerEvent(): void {
-    console.log("User banned by server, transitioning to login scene");
-    this.transitionToLoginScene();
+    console.log("User banned by server, navigating to error scene");
+
+    const mainScene = new MainScene();
+    const errorScene = new ErrorScene("You have been banned from the server");
+    mainScene.activateScene(errorScene);
+    mainScene.load();
+
+    if (this.sceneManagerService) {
+      this.sceneManagerService
+        .getTransitionService()
+        .fadeOutAndIn(this.sceneManagerService, mainScene, 1, 1);
+    }
   }
 
   private handleUserKickedByServerEvent(): void {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -475,7 +475,7 @@ export class WorldScene extends BaseCollidingGameScene {
 
     this.subscribeToLocalEvent(
       EventType.UserBannedByServer,
-      () => void this.returnToLoginScene()
+      () => this.navigateToErrorScene("You have been banned from the server")
     );
 
     this.subscribeToLocalEvent(
@@ -754,22 +754,6 @@ export class WorldScene extends BaseCollidingGameScene {
       1,
       1
     );
-  }
-
-  private returnToLoginScene(): void {
-    console.log("Returning to login scene due to user ban");
-
-    if (this.matchmakingService) {
-      this.matchmakingService.leaveMatch().catch((error) => {
-        console.error("Error leaving match during server kick:", error);
-      });
-    }
-
-    SceneTransitionUtils.transitionToLoginScene({
-      transitionService: this.sceneTransitionService,
-      gameFrame: this.gameState.getGameFrame(),
-      errorMessage: "You have been banned from the server",
-    });
   }
 
   private navigateToErrorScene(errorMessage: string): void {


### PR DESCRIPTION
## Confirmation Modal Improvements
- Reduce modal width from 400px to 300px for a more compact layout
- Support two-line text wrapping for clearer messages
- Standardize button colors: blue (#3B82F6) default, green (#22C55E) on hover
- Improve text rendering with proper line height spacing

## Ban Menu Updates
- Change default duration unit from hours to minutes
- Allows users to more quickly set shorter ban durations

## Ban Flow Fix
- Show clear ban-specific error screen instead of redirecting to login
- Both bans and kicks now display error screens with appropriate messages
- Prevents reconnection attempts by leveraging existing terminal disconnect flag
- Improved UX: users see "You have been banned from the server" message

## Implementation Details
- Modal box: 300x160px with compact spacing
- Text wrapping algorithm for multi-line display
- Color scheme: blue (default), green (hover/active states)
- Ban duration defaults to minutes instead of hours
- Error scene displayed for both ban and kick scenarios

https://claude.ai/code/session_01Tb8aFJ1vBWNB7C9kQaGosP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ban menu default duration unit to minutes.
  * Improved server ban notifications with dedicated error messaging.

* **UI Improvements**
  * Enhanced confirmation dialog layout with word-wrapping text display.
  * Adjusted confirmation button sizing and styling for better usability.
  * Updated button colors for improved visual feedback states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->