### PR TITLE
Fix TypeScript build errors and verify reconnection behavior

### DIFF
--- a/src/game/scenes/main/main-menu/main-menu-scene.ts
+++ b/src/game/scenes/main/main-menu/main-menu-scene.ts
@@ -21,7 +21,6 @@ import { GameServer } from "../../../models/game-server.js";
 import { ToastEntity } from "../../../entities/common/toast-entity.js";
 import { gameContext } from "../../../context/game-context.js";
 import { WebSocketService } from "../../../services/network/websocket-service.js";
-import { SceneTransitionUtils } from "../../../utils/scene-transition-utils.js";
 import { ErrorScene } from "../../error/error-scene.js";
 import { MainScene } from "../main-scene.js";
 
@@ -307,18 +306,6 @@ export class MainMenuScene extends BaseGameScene {
     this.sceneManagerService
       ?.getTransitionService()
       .crossfade(this.sceneManagerService, settingsScene, 0.2);
-  }
-
-  private transitionToLoginScene(): void {
-    if (!this.sceneManagerService) {
-      console.error("Cannot transition to login scene: sceneManagerService is null");
-      return;
-    }
-
-    SceneTransitionUtils.transitionToLoginScene({
-      sceneManager: this.sceneManagerService,
-      errorMessage: "You have been banned from the server"
-    });
   }
 
   private updateMenuButtonsConnectionState(): void {

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -30,7 +30,6 @@ import { MainMenuScene } from "../main/main-menu/main-menu-scene.js";
 import { ErrorScene } from "../error/error-scene.js";
 import { container } from "../../../engine/services/di-container.js";
 import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
-import { SceneTransitionUtils } from "../../utils/scene-transition-utils.js";
 import { WorldEntityFactory } from "./world-entity-factory.js";
 import { WorldController } from "./world-controller.js";
 import { RemoteCarEntity } from "../../entities/remote-car-entity.js";


### PR DESCRIPTION
1. Removed unused function transitionToLoginScene from main-menu-scene.ts
   - Function was defined but never called anywhere in the codebase

2. Removed unused SceneTransitionUtils imports
   - Removed from main-menu-scene.ts (used by deleted function)
   - Removed from world-scene.ts (never used, uses direct scene transition instead)

Build now compiles cleanly with no TS6133 unused variable errors.

Reconnection behavior verified:
- Exponential backoff already implemented (1s base, 30s max, capped at 50 attempts)
- No forced navigation back to main menu during reconnection
- Settings subscreen remains accessible during reconnection (not in online-required buttons)
- Reconnection runs independently via WebSocketService, not tied to scene transitions

https://claude.ai/code/session_011sUL7kZn7v2RPESSoFGMn4