### PR TITLE
fix: eliminate split-brain pattern in BaseMoveableGameEntity

### DIFF
--- a/src/engine/entities/base-moveable-game-entity.ts
+++ b/src/engine/entities/base-moveable-game-entity.ts
@@ -4,17 +4,9 @@ import { AnimationType } from "../enums/animation-type.js";
 import { EntityAnimationService } from "../services/gameplay/entity-animation-service.js";
 
 export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
-  protected x: number = 0;
-  protected y: number = 0;
-  protected width: number = 0;
-  protected height: number = 0;
-  protected angle: number = 0;
-  protected skipInterpolation = false;
-  protected scale: number = 1;
-
   protected animationTasks: EntityAnimationService[] = [];
 
-  /** Backing TransformComponent – use getComponent(TransformComponent) for new code. */
+  /** Backing TransformComponent — all position/size/angle getters delegate here. */
   protected readonly transform: TransformComponent;
 
   constructor() {
@@ -22,66 +14,112 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
     this.transform = this.addComponent(new TransformComponent());
   }
 
-  // ── Transform ──────────────────────────────────────────────────
+  // ── Transform getters/setters (single source of truth) ─────────
+
+  protected get x(): number {
+    return this.transform.x;
+  }
+
+  protected set x(value: number) {
+    this.transform.x = value;
+  }
+
+  protected get y(): number {
+    return this.transform.y;
+  }
+
+  protected set y(value: number) {
+    this.transform.y = value;
+  }
+
+  protected get width(): number {
+    return this.transform.width;
+  }
+
+  protected set width(value: number) {
+    this.transform.width = value;
+  }
+
+  protected get height(): number {
+    return this.transform.height;
+  }
+
+  protected set height(value: number) {
+    this.transform.height = value;
+  }
+
+  protected get angle(): number {
+    return this.transform.angle;
+  }
+
+  protected set angle(value: number) {
+    this.transform.angle = value;
+  }
+
+  protected get scale(): number {
+    return this.transform.scale;
+  }
+
+  protected set scale(value: number) {
+    this.transform.scale = value;
+  }
+
+  protected get skipInterpolation(): boolean {
+    return this.transform.skipInterpolation;
+  }
+
+  protected set skipInterpolation(value: boolean) {
+    this.transform.skipInterpolation = value;
+  }
+
+  // ── Public Transform API ───────────────────────────────────────
 
   public getX(): number {
-    return this.x;
+    return this.transform.x;
   }
 
   public setX(x: number): void {
-    this.x = x;
     this.transform.x = x;
   }
 
   public getY(): number {
-    return this.y;
+    return this.transform.y;
   }
 
   public setY(y: number): void {
-    this.y = y;
     this.transform.y = y;
   }
 
   public getWidth(): number {
-    return this.width;
+    return this.transform.width;
   }
 
   public setWidth(width: number): void {
-    this.width = width;
     this.transform.width = width;
   }
 
   public getHeight(): number {
-    return this.height;
+    return this.transform.height;
   }
 
   public setHeight(height: number): void {
-    this.height = height;
     this.transform.height = height;
   }
 
   public getAngle(): number {
-    return this.angle;
+    return this.transform.angle;
   }
 
   public setAngle(angle: number): void {
-    this.angle = angle;
     this.transform.angle = angle;
   }
 
   public setSkipInterpolation(): void {
-    this.skipInterpolation = true;
     this.transform.skipInterpolation = true;
   }
 
   public teleport(x: number, y: number, angle?: number): void {
     this.transform.teleport(x, y, angle);
-    this.x = x;
-    this.y = y;
-    if (angle !== undefined) {
-      this.angle = angle;
-    }
-    this.skipInterpolation = this.transform.skipInterpolation;
   }
 
   // ── Scale ──────────────────────────────────────────────────────
@@ -92,7 +130,6 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
 
   public setScale(scale: number): void {
     this.scale = scale;
-    this.transform.scale = scale;
   }
 
   // ── Animations ─────────────────────────────────────────────────

--- a/src/engine/entities/base-tappable-game-entity.ts
+++ b/src/engine/entities/base-tappable-game-entity.ts
@@ -4,9 +4,6 @@ import { InteractionComponent } from "../components/interaction-component.js";
 import { EngineLogger } from "../services/engine-logger.js";
 
 export class BaseTappableGameEntity extends BaseMoveableGameEntity {
-  protected width = 0;
-  protected height = 0;
-
   protected active = true;
 
   protected hovering = false;

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -25,8 +25,6 @@ export class BallEntity
   private readonly MAX_VELOCITY: number = 10;
 
   private radius: number = this.RADIUS;
-  protected width = this.RADIUS * 2;
-  protected height = this.RADIUS * 2;
 
   private inactive: boolean = false;
   private lastPlayer: GamePlayer | null = null;
@@ -42,6 +40,8 @@ export class BallEntity
     super();
     this.x = x;
     this.y = y;
+    this.width = this.RADIUS * 2;
+    this.height = this.RADIUS * 2;
     this.physics.mass = this.MASS;
     this.physics.bounciness = 0.8;
     this.setSyncableValues();

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -44,8 +44,6 @@ export class CarEntity extends BaseCollidingGameEntity {
   private readonly SMOKE_DURATION = 1500; // ms
   private readonly SMOKE_SPAWN_INTERVAL = 5; // ms
   // Reference delta at 60 fps (1000/60 ≈ 16.667ms) — used to normalize delta-time
-  private readonly REFERENCE_DELTA = 1000 / 60;
-
   private readonly PLAYER_NAME_PADDING = 10;
   private readonly PLAYER_NAME_RECT_HEIGHT = 24;
   private readonly PLAYER_NAME_RADIUS = 10;
@@ -55,8 +53,6 @@ export class CarEntity extends BaseCollidingGameEntity {
   private readonly PING_ACTIVE_COLOR = "#C6FF00";
   private readonly PING_INACTIVE_COLOR = "#FF0000";
 
-  protected width: number = 50;
-  protected height: number = 50;
   protected canvas: HTMLCanvasElement | null = null;
   protected speed: number = 0;
 
@@ -89,9 +85,8 @@ export class CarEntity extends BaseCollidingGameEntity {
     this.x = x;
     this.y = y;
     this.angle = angle;
-    this.transform.x = x;
-    this.transform.y = y;
-    this.transform.angle = angle;
+    this.width = 50;
+    this.height = 50;
     this.physics.mass = this.MASS;
     this.setBounciness(0.5);
 
@@ -106,7 +101,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   }
 
   public override reset(): void {
-    this.transform.angle = 1.5708;
+    this.angle = 1.5708;
     this.speed = 0;
     this.boost = this.MAX_BOOST;
     this.boosting = false;
@@ -198,9 +193,9 @@ export class CarEntity extends BaseCollidingGameEntity {
 
     const newDemolished = binaryReader.boolean();
 
-    this.transform.x = newX;
-    this.transform.y = newY;
-    this.transform.angle = newAngle;
+    this.x = newX;
+    this.y = newY;
+    this.angle = newAngle;
     this.speed = newSpeed;
     this.boosting = newBoosting;
     this.boost = newBoost;
@@ -618,9 +613,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   }
 
   private updateSmokeParticles(delta: DOMHighResTimeStamp): void {
-    // Scale particle movement by delta so behaviour is frame-rate independent.
-    // Velocities are calibrated for 60 fps; divide by the reference delta.
-    const scale = delta / this.REFERENCE_DELTA;
+    const scale = delta / 16;
     this.smokeParticles.forEach((p) => {
       p.x += p.vx * scale;
       p.y += p.vy * scale;

--- a/src/game/entities/common/message-entity.ts
+++ b/src/game/entities/common/message-entity.ts
@@ -3,11 +3,6 @@ import { EngineLogger } from "../../../engine/services/engine-logger.js";
 
 export class MessageEntity extends BaseMoveableGameEntity {
   private readonly FILL_COLOR = "rgba(0, 0, 0, 0.8)";
-  private readonly DEFAULT_HEIGHT = 100;
-  private readonly DEFAULT_WIDTH = 340;
-
-  protected width = this.DEFAULT_WIDTH;
-  protected height = this.DEFAULT_HEIGHT;
 
   private textX = 0;
   private textY = 0;

--- a/src/game/entities/common/toast-entity.ts
+++ b/src/game/entities/common/toast-entity.ts
@@ -2,9 +2,6 @@ import { TimerService } from "../../../engine/services/gameplay/timer-service.js
 import { BaseMoveableGameEntity } from "../../../engine/entities/base-moveable-game-entity.js";
 
 export class ToastEntity extends BaseMoveableGameEntity {
-  protected width: number = 0;
-  protected height: number = 0;
-
   private text: string = "Unknown";
   private readonly padding: number = 10;
   private readonly topMargin: number = 160; // Top margin

--- a/src/game/entities/common/toggle-button.ts
+++ b/src/game/entities/common/toggle-button.ts
@@ -1,12 +1,12 @@
 import { BaseMoveableGameEntity } from "../../../engine/entities/base-moveable-game-entity.js";
 
 export class ToggleEntity extends BaseMoveableGameEntity {
-  protected width: number = 55; // Incremented width to 55
-  protected height: number = 30;
   private radius: number = 15; // Adjusted radius for rounded corners based on height
 
   constructor(private toggleState = false) {
     super();
+    this.width = 55;
+    this.height = 30;
   }
 
   public setToggleState(toggleState: boolean): void {


### PR DESCRIPTION
Revert remaining perf PR artifact: smoke delta scaling (delta/REFERENCE_DELTA -> delta/16).

Convert BaseMoveableGameEntity x/y/width/height/angle/scale/skipInterpolation from direct properties into getters/setters that delegate to TransformComponent. This eliminates the split-brain where both this.x and this.transform.x exist independently, requiring manual sync in every constructor and setter.

Removed class field declarations shadowing the new getters/setters from:
- CarEntity (width, height -> moved to constructor)
- BallEntity (width, height -> moved to constructor)
- BaseTappableGameEntity (width, height -> removed, defaults from base)
- MessageEntity (width, height -> removed, unused)
- ToastEntity (width, height -> removed, set in measureDimensions)
- ToggleEntity (width, height -> moved to constructor)