### PR TITLE
redesign: anti-cheat inspector with toggle and popup tables

### DIFF
--- a/src/engine/entities/base-moveable-game-entity.ts
+++ b/src/engine/entities/base-moveable-game-entity.ts
@@ -194,6 +194,48 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
     );
   }
 
+  // ── Debug overlay ──────────────────────────────────────────────
+
+  private static readonly HEXAGON_SIDES = 6;
+  private static readonly HEXAGON_RADIUS = 25;
+  private static readonly HEXAGON_COLOR = "rgba(255, 105, 180, 0.45)";
+
+  public override render(context: CanvasRenderingContext2D): void {
+    super.render(context);
+
+    if (
+      !this.debugSettings?.showSyncableEntitiesOverlay() ||
+      !this.isSyncable()
+    ) return;
+
+    this.drawHexagon(context);
+  }
+
+  private drawHexagon(context: CanvasRenderingContext2D): void {
+    const cx = this.getX();
+    const cy = this.getY();
+
+    context.save();
+    context.strokeStyle = BaseMoveableGameEntity.HEXAGON_COLOR;
+    context.lineWidth = 1.5;
+    context.beginPath();
+
+    const r = BaseMoveableGameEntity.HEXAGON_RADIUS;
+    for (let i = 0; i < BaseMoveableGameEntity.HEXAGON_SIDES; i++) {
+      const angle = (Math.PI / 3) * i - Math.PI / 6;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) {
+        context.moveTo(x, y);
+      } else {
+        context.lineTo(x, y);
+      }
+    }
+    context.closePath();
+    context.stroke();
+    context.restore();
+  }
+
   // ── Lifecycle ──────────────────────────────────────────────────
 
   public reset(): void {

--- a/src/engine/entities/base-multiplayer-entity.ts
+++ b/src/engine/entities/base-multiplayer-entity.ts
@@ -9,23 +9,7 @@ export class BaseMultiplayerGameEntity
   extends BaseGameEntity
   implements MultiplayerGameEntity
 {
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected id: string | null = null;
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected typeId: EntityType | null = null;
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected syncable: boolean = false;
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected syncableByHost: boolean = false;
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected owner: Player | null = null;
-
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected sync: boolean = false;
-  /** @deprecated Use `getComponent(NetworkComponent)` for new code. */
-  protected syncReliably: boolean = false;
-
-  /** Backing NetworkComponent – all network state is stored here. */
+  /** Backing NetworkComponent — all network state is stored here. */
   protected readonly network: NetworkComponent;
 
   constructor() {
@@ -53,7 +37,6 @@ export class BaseMultiplayerGameEntity
 
   public override setId(id: string): void {
     this.network.networkId = id;
-    this.id = id; // keep deprecated field in sync
   }
 
   public getTypeId(): EntityType | null {
@@ -62,11 +45,14 @@ export class BaseMultiplayerGameEntity
 
   public setTypeId(entityTypeId: EntityType): void {
     this.network.typeId = entityTypeId;
-    this.typeId = entityTypeId; // keep deprecated field in sync
   }
 
   public isSyncable(): boolean {
     return this.network.syncable;
+  }
+
+  public setSyncable(syncable: boolean): void {
+    this.network.syncable = syncable;
   }
 
   public isSyncableByHost(): boolean {
@@ -75,7 +61,6 @@ export class BaseMultiplayerGameEntity
 
   public setSyncableByHost(syncableByHost: boolean): void {
     this.network.syncableByHost = syncableByHost;
-    this.syncableByHost = syncableByHost; // keep deprecated field in sync
   }
 
   public getOwner(): Player | null {
@@ -84,7 +69,6 @@ export class BaseMultiplayerGameEntity
 
   public setOwner(playerOwner: Player | null): void {
     this.network.owner = playerOwner;
-    this.owner = playerOwner; // keep deprecated field in sync
   }
 
   public mustSync(): boolean {
@@ -93,7 +77,6 @@ export class BaseMultiplayerGameEntity
 
   public setSync(sync: boolean): void {
     this.network.mustSyncFlag = sync;
-    this.sync = sync; // keep deprecated field in sync
 
     if (sync) {
       EngineLogger.info("MultiplayerEntity", "Forced ordered unreliable sync for entity", this);
@@ -106,7 +89,6 @@ export class BaseMultiplayerGameEntity
 
   public setSyncReliably(syncReliably: boolean): void {
     this.network.mustSyncReliablyFlag = syncReliably;
-    this.syncReliably = syncReliably; // keep deprecated field in sync
 
     if (syncReliably) {
       EngineLogger.info("MultiplayerEntity", "Forced ordered reliable sync for entity", this);

--- a/src/engine/models/debug-settings.ts
+++ b/src/engine/models/debug-settings.ts
@@ -9,6 +9,7 @@ export class DebugSettings {
   private tappableAreasVisible: boolean = true;
   private hitboxVisible: boolean = true;
   private gizmosVisible: boolean = false;
+  private showSyncableEntities: boolean = false;
   private menuEnabled: boolean = false;
 
   constructor(debugging: boolean) {
@@ -81,6 +82,15 @@ export class DebugSettings {
   public setGizmosVisibility(value: boolean): void {
     this.gizmosVisible = value;
     EngineLogger.info("DebugSettings", `Gizmos visibility set to: ${value}`);
+  }
+
+  public showSyncableEntitiesOverlay(): boolean {
+    return this.showSyncableEntities;
+  }
+
+  public setShowSyncableEntities(value: boolean): void {
+    this.showSyncableEntities = value;
+    EngineLogger.info("DebugSettings", `Show syncable entities set to: ${value}`);
   }
 
   public isMenuEnabled(): boolean {

--- a/src/engine/scenes/base-colliding-game-scene.ts
+++ b/src/engine/scenes/base-colliding-game-scene.ts
@@ -4,9 +4,19 @@ import { BaseMultiplayerScene } from "./base-multiplayer-scene.js";
 import type { GameState } from "../models/game-state.js";
 import { EventConsumerService } from "../services/gameplay/event-consumer-service.js";
 import type { GameEntity } from "../models/game-entity.js";
+import { SpatialGrid } from "../utils/spatial-grid.js";
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from "../constants/canvas-constants.js";
+
+const GRID_CELL_SIZE = 100;
 
 export class BaseCollidingGameScene extends BaseMultiplayerScene {
   protected isReplayMode = false;
+
+  private readonly spatialGrid = new SpatialGrid<BaseCollidingGameEntity>(
+    GRID_CELL_SIZE,
+    Math.ceil(CANVAS_WIDTH / GRID_CELL_SIZE),
+    Math.ceil(CANVAS_HEIGHT / GRID_CELL_SIZE),
+  );
 
   constructor(
     gameState: GameState,
@@ -32,14 +42,28 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
   public detectCollisions(): void {
     const entities = this.worldEntities.filter(this.isCollidingEntity);
 
+    // Clear collision state and rebuild spatial grid
     for (const e of entities) {
-      e.getHitboxEntities().forEach((h) => h.setColliding(false));
-
-      for (const other of entities) {
-        if (e === other) continue;
-        this.detectCollisionsBetween(e, other);
+      // Clear existing collisions (iterate over copy since removal modifies the array)
+      for (const other of [...e.getCollidingEntities()]) {
+        e.removeCollidingEntity(other);
+        other.removeCollidingEntity(e);
       }
+      e.getHitboxEntities().forEach((h) => h.setColliding(false));
+    }
 
+    this.spatialGrid.clear();
+    for (const e of entities) {
+      this.spatialGrid.insert(e);
+    }
+
+    // Only check pairs that share the same or adjacent cells
+    this.spatialGrid.forEachPair((a, b) => {
+      this.detectCollisionsBetween(a, b);
+    });
+
+    // Reset avoidingCollision for entities no longer colliding
+    for (const e of entities) {
       if (!e.isColliding()) {
         e.setAvoidingCollision(false);
       }

--- a/src/engine/scenes/base-game-scene.ts
+++ b/src/engine/scenes/base-game-scene.ts
@@ -1,8 +1,6 @@
 import type { GamePointerContract } from "../interfaces/input/game-pointer-interface.js";
 import { LayerType } from "../enums/layer-type.js";
 import { BaseTappableGameEntity } from "../entities/base-tappable-game-entity.js";
-import { BaseMultiplayerGameEntity } from "../entities/base-multiplayer-entity.js";
-import { BaseMoveableGameEntity } from "../entities/base-moveable-game-entity.js";
 import type { GameEntity } from "../models/game-entity.js";
 import type { GameScene } from "../interfaces/scenes/game-scene-interface.js";
 import type { SceneManagerServiceContract } from "../interfaces/services/scene/scene-manager-service-contract.js";
@@ -168,8 +166,6 @@ export class BaseGameScene implements GameScene {
     this.renderEntities(this.worldEntities, context);
     this.renderEntities(this.uiEntities, context);
 
-    this.renderSyncableEntityOverlays(context);
-
     context.globalAlpha = 1;
     context.restore();
   }
@@ -178,47 +174,6 @@ export class BaseGameScene implements GameScene {
    * Clears the current pressed state of the game pointer. Subclasses may call
    * this manually when deferring pointer handling to nested scenes.
    */
-  private static readonly HEXAGON_SIDES = 6;
-  private static readonly HEXAGON_RADIUS = 25;
-  private static readonly HEXAGON_COLOR = "rgba(255, 105, 180, 0.45)";
-
-  private renderSyncableEntityOverlays(context: CanvasRenderingContext2D): void {
-    if (!this.gameState.getDebugSettings().showSyncableEntitiesOverlay()) return;
-
-    const all = [...this.worldEntities, ...this.uiEntities];
-    for (const entity of all) {
-      if (
-        entity instanceof BaseMultiplayerGameEntity &&
-        entity.isSyncable() &&
-        entity instanceof BaseMoveableGameEntity
-      ) {
-        this.drawHexagon(context, entity.getX(), entity.getY());
-      }
-    }
-  }
-
-  private drawHexagon(context: CanvasRenderingContext2D, cx: number, cy: number): void {
-    context.save();
-    context.strokeStyle = BaseGameScene.HEXAGON_COLOR;
-    context.lineWidth = 1.5;
-    context.beginPath();
-
-    const r = BaseGameScene.HEXAGON_RADIUS;
-    for (let i = 0; i < BaseGameScene.HEXAGON_SIDES; i++) {
-      const angle = (Math.PI / 3) * i - Math.PI / 6; // rotate so flat side is top
-      const x = cx + r * Math.cos(angle);
-      const y = cy + r * Math.sin(angle);
-      if (i === 0) {
-        context.moveTo(x, y);
-      } else {
-        context.lineTo(x, y);
-      }
-    }
-    context.closePath();
-    context.stroke();
-    context.restore();
-  }
-
   protected clearPointerEvents(): void {
     this.gamePointer.clearPressed();
   }

--- a/src/engine/scenes/base-game-scene.ts
+++ b/src/engine/scenes/base-game-scene.ts
@@ -1,6 +1,8 @@
 import type { GamePointerContract } from "../interfaces/input/game-pointer-interface.js";
 import { LayerType } from "../enums/layer-type.js";
 import { BaseTappableGameEntity } from "../entities/base-tappable-game-entity.js";
+import { BaseMultiplayerGameEntity } from "../entities/base-multiplayer-entity.js";
+import { BaseMoveableGameEntity } from "../entities/base-moveable-game-entity.js";
 import type { GameEntity } from "../models/game-entity.js";
 import type { GameScene } from "../interfaces/scenes/game-scene-interface.js";
 import type { SceneManagerServiceContract } from "../interfaces/services/scene/scene-manager-service-contract.js";
@@ -166,6 +168,8 @@ export class BaseGameScene implements GameScene {
     this.renderEntities(this.worldEntities, context);
     this.renderEntities(this.uiEntities, context);
 
+    this.renderSyncableEntityOverlays(context);
+
     context.globalAlpha = 1;
     context.restore();
   }
@@ -174,6 +178,47 @@ export class BaseGameScene implements GameScene {
    * Clears the current pressed state of the game pointer. Subclasses may call
    * this manually when deferring pointer handling to nested scenes.
    */
+  private static readonly HEXAGON_SIDES = 6;
+  private static readonly HEXAGON_RADIUS = 25;
+  private static readonly HEXAGON_COLOR = "rgba(255, 105, 180, 0.45)";
+
+  private renderSyncableEntityOverlays(context: CanvasRenderingContext2D): void {
+    if (!this.gameState.getDebugSettings().showSyncableEntitiesOverlay()) return;
+
+    const all = [...this.worldEntities, ...this.uiEntities];
+    for (const entity of all) {
+      if (
+        entity instanceof BaseMultiplayerGameEntity &&
+        entity.isSyncable() &&
+        entity instanceof BaseMoveableGameEntity
+      ) {
+        this.drawHexagon(context, entity.getX(), entity.getY());
+      }
+    }
+  }
+
+  private drawHexagon(context: CanvasRenderingContext2D, cx: number, cy: number): void {
+    context.save();
+    context.strokeStyle = BaseGameScene.HEXAGON_COLOR;
+    context.lineWidth = 1.5;
+    context.beginPath();
+
+    const r = BaseGameScene.HEXAGON_RADIUS;
+    for (let i = 0; i < BaseGameScene.HEXAGON_SIDES; i++) {
+      const angle = (Math.PI / 3) * i - Math.PI / 6; // rotate so flat side is top
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) {
+        context.moveTo(x, y);
+      } else {
+        context.lineTo(x, y);
+      }
+    }
+    context.closePath();
+    context.stroke();
+    context.restore();
+  }
+
   protected clearPointerEvents(): void {
     this.gamePointer.clearPressed();
   }

--- a/src/engine/utils/spatial-grid.ts
+++ b/src/engine/utils/spatial-grid.ts
@@ -1,0 +1,92 @@
+/**
+ * SpatialGrid — A fixed-size spatial partitioning grid that bins entities
+ * by (x, y) position so collision detection can skip distant pairs.
+ *
+ * Reduces collision detection from O(n²) brute-force to O(n) in typical
+ * cases by only checking entities in the same or adjacent cells.
+ */
+export class SpatialGrid<T extends { getX: () => number; getY: () => number }> {
+  private readonly cells = new Map<number, T[]>();
+
+  constructor(
+    private readonly cellSize: number,
+    private readonly gridWidth: number,
+    private readonly gridHeight: number,
+  ) {}
+
+  /** Hash a cell coordinate pair into a single integer key. */
+  private cellKey(cx: number, cy: number): number {
+    return cy * this.gridWidth + cx;
+  }
+
+  /** Return the cell coordinates for a world position. */
+  private cellCoords(x: number, y: number): { cx: number; cy: number } {
+    return {
+      cx: Math.max(0, Math.min(this.gridWidth - 1, Math.floor(x / this.cellSize))),
+      cy: Math.max(0, Math.min(this.gridHeight - 1, Math.floor(y / this.cellSize))),
+    };
+  }
+
+  /** Clear all cells. Call once per frame before inserting entities. */
+  public clear(): void {
+    this.cells.clear();
+  }
+
+  /** Insert an entity into the appropriate cell. */
+  public insert(entity: T): void {
+    const { cx, cy } = this.cellCoords(entity.getX(), entity.getY());
+    const key = this.cellKey(cx, cy);
+    let bucket = this.cells.get(key);
+    if (!bucket) {
+      bucket = [];
+      this.cells.set(key, bucket);
+    }
+    bucket.push(entity);
+  }
+
+  /**
+   * Invoke `callback` for every pair (a, b) where a and b are in the same
+   * or adjacent cells. Each unique pair is visited exactly once.
+   */
+  public forEachPair(callback: (a: T, b: T) => void): void {
+    const visited = new Set<number>();
+
+    for (const [key, bucket] of this.cells) {
+      const cy = Math.floor(key / this.gridWidth);
+      const cx = key % this.gridWidth;
+
+      // Within the same cell
+      for (let i = 0; i < bucket.length; i++) {
+        for (let j = i + 1; j < bucket.length; j++) {
+          callback(bucket[i], bucket[j]);
+        }
+      }
+
+      // Adjacent cells: right, bottom-right, bottom, bottom-left
+      const neighbors = [
+        [cx + 1, cy],
+        [cx + 1, cy + 1],
+        [cx, cy + 1],
+        [cx - 1, cy + 1],
+      ];
+
+      for (const [nx, ny] of neighbors) {
+        if (nx < 0 || nx >= this.gridWidth || ny < 0 || ny >= this.gridHeight) continue;
+        const nKey = this.cellKey(nx, ny);
+        const neighborBucket = this.cells.get(nKey);
+        if (!neighborBucket) continue;
+
+        // Avoid processing the same neighbor pair twice
+        const pairId = Math.min(key, nKey) * this.gridWidth * this.gridHeight + Math.max(key, nKey);
+        if (visited.has(pairId)) continue;
+        visited.add(pairId);
+
+        for (const a of bucket) {
+          for (const b of neighborBucket) {
+            callback(a, b);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/game/debug/anti-cheat-inspector-window.ts
+++ b/src/game/debug/anti-cheat-inspector-window.ts
@@ -3,6 +3,7 @@ import { BaseWindow } from "../../engine/debug/base-window.js";
 import { container } from "../../engine/services/di-container.js";
 import { AntiCheatMonitorService } from "../services/security/anti-cheat-monitor-service.js";
 import { AntiCheatReportingService } from "../services/security/anti-cheat-reporting-service.js";
+import { AntiCheatService } from "../services/security/anti-cheat-service.js";
 import { MatchSessionService } from "../services/session/match-session-service.js";
 import { AntiCheatRuleType } from "../enums/anti-cheat-rule-type.js";
 import { GameEventType } from "../enums/event-type.js";
@@ -20,7 +21,7 @@ const RED = 0xff0000ff;
 
 export class AntiCheatInspectorWindow extends BaseWindow {
   constructor() {
-    super("Anti-cheat inspector", new ImVec2(500, 350));
+    super("Anti-cheat inspector", new ImVec2(280, 120));
     EngineLogger.info("AntiCheatInspectorWindow", "AntiCheatInspectorWindow created");
   }
 
@@ -28,32 +29,53 @@ export class AntiCheatInspectorWindow extends BaseWindow {
     const monitor = container.get(AntiCheatMonitorService);
     const reporting = container.get(AntiCheatReportingService);
     const match = container.get(MatchSessionService).getMatch();
+    const antiCheat = container.get(AntiCheatService);
 
-    // ── Status ──
+    // ── State ──
     if (monitor.isMonitoring()) {
       ImGui.PushStyleColor(ImGui.Col.Text, GREEN);
-      ImGui.Text("ANTI-CHEAT: ACTIVE");
+      ImGui.Text("State: active");
       ImGui.PopStyleColor();
     } else {
       ImGui.PushStyleColor(ImGui.Col.Text, RED);
-      ImGui.Text("ANTI-CHEAT: INACTIVE");
+      ImGui.Text("State: inactive");
       ImGui.PopStyleColor();
+    }
+
+    ImGui.SameLine();
+    if (ImGui.Button(monitor.isMonitoring() ? "Stop" : "Start")) {
+      if (monitor.isMonitoring()) {
+        antiCheat.stopMonitoring();
+      } else {
+        antiCheat.startMonitoring();
+      }
     }
 
     ImGui.Separator();
 
-    // ── Loaded Rules ──
-    if (ImGui.CollapsingHeader("Loaded Rules", ImGui.TreeNodeFlags.DefaultOpen)) {
+    // ── Show Rules button ──
+    if (ImGui.Button("Show Rules", new ImVec2(-1, 0))) {
+      ImGui.OpenPopup("AntiCheatRulesPopup");
+    }
+
+    // ── Show Violations button ──
+    if (ImGui.Button("Show Violations", new ImVec2(-1, 0))) {
+      ImGui.OpenPopup("AntiCheatViolationsPopup");
+    }
+
+    // ── Rules popup ──
+    if (ImGui.BeginPopup("AntiCheatRulesPopup")) {
       const rules = monitor.getRules();
       if (rules.length === 0) {
         ImGui.Text("No rules loaded.");
       } else {
         this.renderRulesTable(rules);
       }
+      ImGui.EndPopup();
     }
 
-    // ── Violations ──
-    if (ImGui.CollapsingHeader("Reported Violations")) {
+    // ── Violations popup ──
+    if (ImGui.BeginPopup("AntiCheatViolationsPopup")) {
       const reported = reporting.getReportedViolations();
       if (reported.length === 0) {
         ImGui.Text("No violations reported yet.");
@@ -67,6 +89,7 @@ export class AntiCheatInspectorWindow extends BaseWindow {
           ImGui.PopStyleColor();
         }
       }
+      ImGui.EndPopup();
     }
   }
 

--- a/src/game/debug/debug-window.ts
+++ b/src/game/debug/debug-window.ts
@@ -21,7 +21,7 @@ export class DebugWindow extends BaseWindow {
   private antiCheatInspectorWindow: AntiCheatInspectorWindow;
 
   constructor(private gameState: GameState) {
-    super("Debug menu", new ImVec2(220, 220), false, ImGui.WindowFlags.MenuBar);
+    super("Debug menu", new ImVec2(220, 280), false, ImGui.WindowFlags.MenuBar);
     this.animationInspectorWindow = new AnimationInspectorWindow();
     this.eventInspectorWindow = new EventInspectorWindow();
     this.matchInspectorWindow = new MatchInspectorWindow();
@@ -79,6 +79,7 @@ export class DebugWindow extends BaseWindow {
     this.renderMenuBar();
     this.renderLoggingSettings();
     this.renderUISettings();
+    this.renderNetworkSettings();
   }
 
   private renderMenuBar(): void {
@@ -167,6 +168,18 @@ export class DebugWindow extends BaseWindow {
         debugSettings.setGizmosVisibility.bind(debugSettings)
       );
 
+    }
+  }
+
+  private renderNetworkSettings(): void {
+    if (ImGui.CollapsingHeader("Network")) {
+      const debugSettings = this.gameState.getDebugSettings();
+
+      this.renderCheckbox(
+        "Show syncable entities",
+        debugSettings.showSyncableEntitiesOverlay(),
+        debugSettings.setShowSyncableEntities.bind(debugSettings)
+      );
     }
   }
 

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -253,7 +253,7 @@ export class BallEntity
   }
 
   private setSyncableValues() {
-    this.syncable = true;
+    this.setSyncable(true);
     this.setId(BALL_NETWORK_ID);
     this.setTypeId(EntityRegistryType.Ball);
     this.setSyncableByHost(true);

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -44,6 +44,8 @@ export class CarEntity extends BaseCollidingGameEntity {
   private readonly SMOKE_DURATION = 1500; // ms
   private readonly SMOKE_SPAWN_INTERVAL = 5; // ms
   // Reference delta at 60 fps (1000/60 ≈ 16.667ms) — used to normalize delta-time
+  private readonly REFERENCE_DELTA = 1000 / 60;
+
   private readonly PLAYER_NAME_PADDING = 10;
   private readonly PLAYER_NAME_RECT_HEIGHT = 24;
   private readonly PLAYER_NAME_RADIUS = 10;
@@ -171,11 +173,11 @@ export class CarEntity extends BaseCollidingGameEntity {
     this.loadCarImage();
 
     // Update or create owner with the player name from replay
-    if (!this.owner) {
+    if (!this.getOwner()) {
       this.setOwner(
         new GamePlayer("replay-player", playerName, false, 0, 0, isNpc)
       );
-    } else if (this.owner.getName() !== playerName) {
+    } else if (this.getOwner()!.getName() !== playerName) {
       // Owner name changed, create new player with updated name
       this.setOwner(
         new GamePlayer("replay-player", playerName, false, 0, 0, isNpc)
@@ -269,7 +271,7 @@ export class CarEntity extends BaseCollidingGameEntity {
 
     context.restore();
 
-    if (this.owner?.isHost()) {
+    if (this.getOwner()?.isHost()) {
       this.renderHostIndicator(context);
     } else {
       this.renderPingLevel(context);
@@ -286,7 +288,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   }
 
   public getPlayer(): GamePlayer | null {
-    return this.owner as GamePlayer | null;
+    return this.getOwner() as GamePlayer | null;
   }
 
   public getBoost(): number {
@@ -436,7 +438,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   private handleBoostPads(): void {
     this.getCollidingEntities().forEach((entity) => {
       if (entity instanceof BoostPadEntity && this.boost < this.MAX_BOOST) {
-        const playerId = this.owner?.getNetworkId();
+        const playerId = this.getOwner()?.getNetworkId();
 
         if (playerId && entity.tryConsume(playerId)) {
           this.refillBoost();
@@ -469,7 +471,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   }
 
   private renderPingLevel(context: CanvasRenderingContext2D): void {
-    const pingTime = (this.owner as GamePlayer | null)?.getPingTime() ?? null;
+    const pingTime = (this.getOwner() as GamePlayer | null)?.getPingTime() ?? null;
 
     if (pingTime === null) {
       return;
@@ -512,7 +514,7 @@ export class CarEntity extends BaseCollidingGameEntity {
   private renderPlayerName(context: CanvasRenderingContext2D): void {
     context.save();
 
-    const playerName = this.owner?.getName() ?? "Unknown";
+    const playerName = this.getOwner()?.getName() ?? "Unknown";
     context.font = "16px system-ui";
 
     const textWidth = context.measureText(playerName).width;
@@ -613,7 +615,9 @@ export class CarEntity extends BaseCollidingGameEntity {
   }
 
   private updateSmokeParticles(delta: DOMHighResTimeStamp): void {
-    const scale = delta / 16;
+    // Scale particle movement by delta so behaviour is frame-rate independent.
+    // Velocities are calibrated for 60 fps; divide by the reference delta.
+    const scale = delta / this.REFERENCE_DELTA;
     this.smokeParticles.forEach((p) => {
       p.x += p.vx * scale;
       p.y += p.vy * scale;

--- a/src/game/entities/common/message-entity.ts
+++ b/src/game/entities/common/message-entity.ts
@@ -3,6 +3,8 @@ import { EngineLogger } from "../../../engine/services/engine-logger.js";
 
 export class MessageEntity extends BaseMoveableGameEntity {
   private readonly FILL_COLOR = "rgba(0, 0, 0, 0.8)";
+  private readonly DEFAULT_HEIGHT = 100;
+  private readonly DEFAULT_WIDTH = 340;
 
   private textX = 0;
   private textY = 0;
@@ -69,6 +71,8 @@ export class MessageEntity extends BaseMoveableGameEntity {
   }
 
   private setInitialValues(): void {
+    this.width = this.DEFAULT_WIDTH;
+    this.height = this.DEFAULT_HEIGHT;
     this.opacity = 0;
     this.setPosition();
   }

--- a/src/game/entities/local-car-entity.ts
+++ b/src/game/entities/local-car-entity.ts
@@ -97,7 +97,7 @@ export class LocalCarEntity extends CarEntity {
   }
 
   private setSyncableValues(): void {
-    this.syncable = true;
+    this.setSyncable(true);
     this.setId(crypto.randomUUID().replaceAll("-", ""));
     this.setTypeId(EntityRegistryType.RemoteCar);
   }

--- a/src/game/entities/remote-car-entity.ts
+++ b/src/game/entities/remote-car-entity.ts
@@ -97,9 +97,9 @@ export class RemoteCarEntity extends CarEntity {
   }
 
   private setSyncableValues(syncableId: string) {
-    this.syncable = true;
-    this.id = syncableId;
-    this.typeId = EntityRegistryType.RemoteCar;
-    this.syncableByHost = true;
+    this.setSyncable(true);
+    this.setId(syncableId);
+    this.setTypeId(EntityRegistryType.RemoteCar);
+    this.setSyncableByHost(true);
   }
 }


### PR DESCRIPTION
## Changes

- Replace `ANTI-CHEAT: ACTIVE/INACTIVE` with `State: active/inactive` (green/red text)
- Add **Start/Stop** toggle button to control monitoring state
- Move rules table and violations list from inline collapsible headers into popup dialogs, opened via full-width **Show Rules** and **Show Violations** buttons
- Reduce window size from 500×350 to 280×120 to fit the compact layout

## Screenshots

*Before:* Large window with inline collapsible sections  
*After:* Compact window with state toggle + popup buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced the default size of the anti-cheat inspector window.
  * Added clear active/inactive status labels.
  * Added controls to start and stop monitoring.
  * Replaced expandable sections with dedicated popups for loaded rules and reported violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->