### PR TITLE
fix: chat messages, ban flow, anti-cheat teleport, replay scene, debug UI

### DIFF
--- a/src/engine/entities/base-moveable-game-entity.ts
+++ b/src/engine/entities/base-moveable-game-entity.ts
@@ -118,6 +118,11 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
     this.transform.skipInterpolation = true;
   }
 
+  /** Returns true if the entity was intentionally teleported this frame. */
+  public wasSkipInterpolationSet(): boolean {
+    return this.transform.skipInterpolation;
+  }
+
   public teleport(x: number, y: number, angle?: number): void {
     this.transform.teleport(x, y, angle);
   }
@@ -198,7 +203,7 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
 
   private static readonly HEXAGON_SIDES = 6;
   private static readonly HEXAGON_RADIUS = 25;
-  private static readonly HEXAGON_COLOR = "rgba(255, 105, 180, 0.45)";
+  private static readonly HEXAGON_COLOR = "rgba(255, 20, 147, 0.85)";
 
   public override render(context: CanvasRenderingContext2D): void {
     super.render(context);
@@ -255,5 +260,9 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
     });
 
     super.update(deltaTimeStamp);
+
+    // Clear teleport flag at end of frame — the anti-cheat check runs
+    // before entity updates and has already consumed this flag.
+    this.transform.skipInterpolation = false;
   }
 }

--- a/src/engine/services/gameplay/recording-player-service.ts
+++ b/src/engine/services/gameplay/recording-player-service.ts
@@ -8,12 +8,9 @@ import type { EntityTransformDelta } from "../../interfaces/recording/entity-tra
 import type { EntityStateDelta } from "../../interfaces/recording/entity-state-delta-interface.js";
 import type { GameEntity } from "../../models/game-entity.js";
 import { EntityRegistry } from "../entity-registry.js";
+import { SceneRegistry } from "../scene-registry.js";
 import { GameState } from "../../models/game-state.js";
 import { LayerType } from "../../enums/layer-type.js";
-import {
-  WORLD_SCENE_FACTORY_TOKEN,
-  type WorldSceneFactoryContract,
-} from "../../interfaces/services/gameplay/world-scene-factory-contract.js";
 import { EngineLogger } from "../engine-logger.js";
 
 export enum PlaybackState {
@@ -50,9 +47,6 @@ export class RecordingPlayerService {
 
   constructor(
     private readonly gameState: GameState = inject(GameState),
-    private readonly worldSceneFactory: WorldSceneFactoryContract = inject(
-      WORLD_SCENE_FACTORY_TOKEN
-    )
   ) {
     EngineLogger.info("RecordingPlayer", "RecordingPlayerService initialized");
   }
@@ -291,11 +285,12 @@ export class RecordingPlayerService {
       return;
     }
 
-    // Create the replay scene before mutating GameFrame state.
-    // This ensures GameFrame is never left with a dangling null scene on failure.
-    const scene = this.worldSceneFactory.create({ replayMode: true });
+    const sceneId = this.recordingData.metadata.sceneId;
+
+    // Look up the replay scene class via the SceneRegistry
+    const scene = SceneRegistry.create(sceneId);
     if (!scene) {
-      EngineLogger.warn("RecordingPlayer", "WorldSceneFactory returned null, aborting playback");
+      EngineLogger.warn("RecordingPlayer", `No replay scene registered for sceneId ${sceneId}, aborting playback`);
       this.playbackState = PlaybackState.Stopped;
       return;
     }

--- a/src/engine/services/scene-registry.ts
+++ b/src/engine/services/scene-registry.ts
@@ -1,0 +1,70 @@
+import type { GameScene } from "../interfaces/scenes/game-scene-interface.js";
+import { EngineLogger } from "./engine-logger.js";
+
+/**
+ * Scene Registry Service
+ *
+ * Maps SceneType numbers to factory functions for replay playback.
+ * Mirrors the EntityRegistry pattern: game layer registers its replay
+ * scene classes, and the recording player looks them up by sceneId.
+ */
+export class SceneRegistry {
+  private static registry = new Map<number, () => GameScene>();
+
+  /**
+   * Register a replay scene factory for a given scene type.
+   *
+   * @param sceneType - SceneType enum value (e.g. GameSceneType.World)
+   * @param factory - Factory function that creates a new replay scene instance
+   */
+  public static register(
+    sceneType: number,
+    factory: () => GameScene,
+  ): void {
+    if (this.registry.has(sceneType)) {
+      EngineLogger.warn(
+        "SceneRegistry",
+        `Scene type "${sceneType}" is already registered, overwriting`,
+      );
+    }
+    this.registry.set(sceneType, factory);
+  }
+
+  /**
+   * Create a replay scene instance by its scene type ID.
+   *
+   * @param sceneType - SceneType enum value from the recording metadata
+   * @returns A new scene instance, or null if the type is not registered
+   */
+  public static create(sceneType: number): GameScene | null {
+    const factory = this.registry.get(sceneType);
+    if (!factory) {
+      EngineLogger.warn(
+        "SceneRegistry",
+        `Scene type "${sceneType}" is not registered in the scene registry`,
+      );
+      return null;
+    }
+
+    try {
+      return factory();
+    } catch (error) {
+      EngineLogger.error(
+        "SceneRegistry",
+        `Failed to create replay scene for type "${sceneType}"`,
+        error,
+      );
+      return null;
+    }
+  }
+
+  /** Check if a scene type is registered. */
+  public static has(sceneType: number): boolean {
+    return this.registry.has(sceneType);
+  }
+
+  /** Clear all registered scene types (useful for testing). */
+  public static clear(): void {
+    this.registry.clear();
+  }
+}

--- a/src/game/debug/anti-cheat-inspector-window.ts
+++ b/src/game/debug/anti-cheat-inspector-window.ts
@@ -8,6 +8,7 @@ import { MatchSessionService } from "../services/session/match-session-service.j
 import { AntiCheatRuleType } from "../enums/anti-cheat-rule-type.js";
 import { GameEventType } from "../enums/event-type.js";
 import type { AntiCheatRule } from "../models/anti-cheat-rule.js";
+import type { ReportedViolation } from "../services/security/anti-cheat-reporting-service.js";
 import { EngineLogger } from "../../engine/services/engine-logger.js";
 
 const RULE_TYPE_NAMES: Record<number, string> = {
@@ -21,8 +22,11 @@ const RED = 0xff0000ff;
 
 export class AntiCheatInspectorWindow extends BaseWindow {
   constructor() {
-    super("Anti-cheat inspector", new ImVec2(280, 120));
-    EngineLogger.info("AntiCheatInspectorWindow", "AntiCheatInspectorWindow created");
+    super("Anti-cheat inspector", new ImVec2(480, 350));
+    EngineLogger.info(
+      "AntiCheatInspectorWindow",
+      "AntiCheatInspectorWindow created",
+    );
   }
 
   protected override renderContent(): void {
@@ -51,51 +55,35 @@ export class AntiCheatInspectorWindow extends BaseWindow {
       }
     }
 
-    ImGui.Separator();
-
-    // ── Show Rules button ──
-    if (ImGui.Button("Show Rules", new ImVec2(-1, 0))) {
-      ImGui.OpenPopup("AntiCheatRulesPopup");
-    }
-
-    // ── Show Violations button ──
-    if (ImGui.Button("Show Violations", new ImVec2(-1, 0))) {
-      ImGui.OpenPopup("AntiCheatViolationsPopup");
-    }
-
-    // ── Rules popup ──
-    if (ImGui.BeginPopup("AntiCheatRulesPopup")) {
+    // ── Rules ──
+    if (
+      ImGui.CollapsingHeader("Rules", ImGui.TreeNodeFlags.DefaultOpen)
+    ) {
       const rules = monitor.getRules();
       if (rules.length === 0) {
         ImGui.Text("No rules loaded.");
       } else {
         this.renderRulesTable(rules);
       }
-      ImGui.EndPopup();
     }
 
-    // ── Violations popup ──
-    if (ImGui.BeginPopup("AntiCheatViolationsPopup")) {
-      const reported = reporting.getReportedViolations();
-      if (reported.length === 0) {
+    // ── Violations ──
+    if (
+      ImGui.CollapsingHeader(
+        "Violation History",
+        ImGui.TreeNodeFlags.DefaultOpen,
+      )
+    ) {
+      const violations = reporting.getReportedViolations();
+      if (violations.length === 0) {
         ImGui.Text("No violations reported yet.");
       } else {
-        for (const key of reported) {
-          const [ruleId, userId] = key.split(":");
-          const player = match?.getPlayerByNetworkId(userId);
-          const playerName = player?.getName() ?? userId.substring(0, 8);
-          ImGui.PushStyleColor(ImGui.Col.Text, YELLOW);
-          ImGui.Text(`Rule #${ruleId} — ${playerName} (${userId.substring(0, 8)}...)`);
-          ImGui.PopStyleColor();
-        }
+        this.renderViolationsTable(violations, match);
       }
-      ImGui.EndPopup();
     }
   }
 
-  private renderRulesTable(
-    rules: readonly AntiCheatRule[],
-  ): void {
+  private renderRulesTable(rules: readonly AntiCheatRule[]): void {
     const flags =
       ImGui.TableFlags.BordersOuter |
       ImGui.TableFlags.RowBg |
@@ -113,7 +101,8 @@ export class AntiCheatInspectorWindow extends BaseWindow {
 
     for (const rule of rules) {
       ImGui.TableNextRow();
-      const typeName = RULE_TYPE_NAMES[rule.ruleType] ?? `Unknown (${rule.ruleType})`;
+      const typeName =
+        RULE_TYPE_NAMES[rule.ruleType] ?? `Unknown (${rule.ruleType})`;
 
       // ID
       ImGui.TableSetColumnIndex(0);
@@ -134,9 +123,92 @@ export class AntiCheatInspectorWindow extends BaseWindow {
     ImGui.EndTable();
   }
 
-  private formatField(ruleType: number, fieldId: number, value: number): string {
+  private renderViolationsTable(
+    violations: readonly ReportedViolation[],
+    match: ReturnType<MatchSessionService["getMatch"]>,
+  ): void {
+    const flags =
+      ImGui.TableFlags.BordersOuter |
+      ImGui.TableFlags.RowBg |
+      ImGui.TableFlags.Resizable |
+      ImGui.TableFlags.ScrollY |
+      ImGui.TableFlags.SizingStretchProp;
+
+    if (!ImGui.BeginTable("AntiCheatViolations", 5, flags)) return;
+
+    ImGui.TableSetupColumn("Rule", ImGui.TableColumnFlags.WidthFixed, 40);
+    ImGui.TableSetupColumn("Player", ImGui.TableColumnFlags.WidthStretch);
+    ImGui.TableSetupColumn("Reason", ImGui.TableColumnFlags.WidthStretch);
+    ImGui.TableSetupColumn(
+      "Time",
+      ImGui.TableColumnFlags.WidthFixed,
+      90,
+    );
+    ImGui.TableSetupColumn(
+      "Relative",
+      ImGui.TableColumnFlags.WidthFixed,
+      70,
+    );
+
+    ImGui.TableHeadersRow();
+
+    const now = Date.now();
+
+    for (const v of violations) {
+      ImGui.TableNextRow();
+
+      const player = match?.getPlayerByNetworkId(v.userId);
+      const playerName =
+        player?.getName() ?? v.userId.substring(0, 8) + "...";
+
+      // Rule ID
+      ImGui.TableSetColumnIndex(0);
+      ImGui.Text(`#${v.ruleId}`);
+
+      // Player
+      ImGui.TableSetColumnIndex(1);
+      ImGui.PushStyleColor(ImGui.Col.Text, YELLOW);
+      ImGui.Text(playerName);
+      ImGui.PopStyleColor();
+
+      // Reason
+      ImGui.TableSetColumnIndex(2);
+      ImGui.Text(v.reason);
+
+      // Player time (absolute)
+      ImGui.TableSetColumnIndex(3);
+      const date = new Date(v.timestamp);
+      const timeStr = date.toLocaleTimeString();
+      ImGui.Text(timeStr);
+
+      // Relative time
+      ImGui.TableSetColumnIndex(4);
+      const elapsedMs = now - v.timestamp;
+      const elapsedStr = this.formatElapsed(elapsedMs);
+      ImGui.Text(elapsedStr);
+    }
+
+    ImGui.EndTable();
+  }
+
+  private formatElapsed(ms: number): string {
+    if (ms < 1000) return "just now";
+    const secs = Math.floor(ms / 1000);
+    if (secs < 60) return `${secs}s ago`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    return `${hours}h ago`;
+  }
+
+  private formatField(
+    ruleType: number,
+    fieldId: number,
+    value: number,
+  ): string {
     if (ruleType === AntiCheatRuleType.EventRateLimit) {
-      if (fieldId === 0) return `event=${(GameEventType as Record<number, string>)[value] ?? value}`;
+      if (fieldId === 0)
+        return `event=${(GameEventType as Record<number, string>)[value] ?? value}`;
       if (fieldId === 1) return `maxCount=${value}`;
       if (fieldId === 2) return `window=${value}s`;
     }
@@ -147,5 +219,4 @@ export class AntiCheatInspectorWindow extends BaseWindow {
     }
     return `f${fieldId}=${value}`;
   }
-
 }

--- a/src/game/debug/debug-window.ts
+++ b/src/game/debug/debug-window.ts
@@ -172,7 +172,7 @@ export class DebugWindow extends BaseWindow {
   }
 
   private renderNetworkSettings(): void {
-    if (ImGui.CollapsingHeader("Network")) {
+    if (ImGui.CollapsingHeader("Network", ImGui.TreeNodeFlags.DefaultOpen)) {
       const debugSettings = this.gameState.getDebugSettings();
 
       this.renderCheckbox(

--- a/src/game/main.ts
+++ b/src/game/main.ts
@@ -11,6 +11,8 @@ import {
   registerGameEntityTypes,
   getEntityTypeMapper,
 } from "./utils/entity-type-registry.js";
+// Side-effect import: registers replay scene classes in SceneRegistry
+import "./utils/scene-type-registry.js";
 import { RecorderService } from "../engine/services/gameplay/recorder-service.js";
 import { registerEventTypeNames } from "./enums/event-type.js";
 import { GAME_VERSION } from "./constants/game-constants.js";

--- a/src/game/scenes/loading/loading-scene.ts
+++ b/src/game/scenes/loading/loading-scene.ts
@@ -4,7 +4,6 @@ import { injectable } from "@needle-di/core";
 import { container } from "../../../engine/services/di-container.js";
 import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
 import { BaseGameScene } from "../../../engine/scenes/base-game-scene.js";
-import { WorldScene } from "../world/world-scene.js";
 import { LoadingEntityFactory } from "./loading-entity-factory.js";
 import type { LoadingEntities } from "./loading-entity-factory.js";
 import { WorldSceneFactory } from "../world/world-scene-factory.js";
@@ -13,7 +12,7 @@ import { WorldSceneFactory } from "../world/world-scene-factory.js";
 export class LoadingScene extends BaseGameScene {
   private sceneTransitionService: SceneTransitionService;
   private entities: LoadingEntities | null = null;
-  private worldScene: WorldScene | null = null;
+  private worldScene: BaseGameScene | null = null;
   private readonly worldSceneFactory: WorldSceneFactory;
   private transitionStarted: boolean = false;
 

--- a/src/game/scenes/replay/replay-scene.ts
+++ b/src/game/scenes/replay/replay-scene.ts
@@ -1,0 +1,39 @@
+import { BaseCollidingGameScene } from "../../../engine/scenes/base-colliding-game-scene.js";
+import type { SceneType } from "../../../engine/enums/scene-type.js";
+import { GameSceneType } from "../../enums/scene-type.js";
+import { WorldEntityFactory } from "../world/world-entity-factory.js";
+import type { GameState } from "../../../engine/models/game-state.js";
+import type { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
+import { EngineLogger } from "../../../engine/services/engine-logger.js";
+
+/**
+ * Minimal scene for replay playback. Avoids all the conditional replay-mode
+ * logic that was previously scattered throughout WorldScene.
+ *
+ * The RecordingPlayerService drives entity spawning and state updates;
+ * this scene only provides a background and the scene infrastructure.
+ */
+export class ReplayScene extends BaseCollidingGameScene {
+  constructor(
+    gameState: GameState,
+    eventConsumerService: EventConsumerService,
+  ) {
+    super(gameState, eventConsumerService);
+    this.isReplayMode = true;
+    EngineLogger.info("ReplayScene", "ReplayScene created");
+  }
+
+  public override getTypeId(): SceneType {
+    return GameSceneType.World;
+  }
+
+  public override load(): void {
+    const factory = new WorldEntityFactory(this.gameState, this.canvas);
+    factory.createBackground(this.worldEntities);
+    this.loaded = true;
+  }
+
+  public override update(_deltaTimeStamp: DOMHighResTimeStamp): void {
+    // Entities are driven by RecordingPlayerService, not game logic.
+  }
+}

--- a/src/game/scenes/world/systems/chat-ui-system.ts
+++ b/src/game/scenes/world/systems/chat-ui-system.ts
@@ -3,13 +3,11 @@ import { MatchMenuButtonEntity } from "../../../entities/match-menu-button-entit
 import { MatchMenuEntity } from "../../../entities/match-menu-entity.js";
 import { BoostMeterEntity } from "../../../entities/boost-meter-entity.js";
 import { HelpEntity } from "../../../entities/help-entity.js";
-import { MatchAction } from "../../../models/match-action.js";
 import type { GamePlayer } from "../../../models/game-player.js";
 import type { MatchSessionService } from "../../../services/session/match-session-service.js";
 import { ChatService } from "../../../services/network/chat-service.js";
 import { PlayerModerationService } from "../../../services/network/player-moderation-service.js";
 import { APIService } from "../../../services/network/api-service.js";
-import type { MatchActionsLogService } from "../../../services/gameplay/match-actions-log-service.js";
 import type { GamePointerContract } from "../../../../engine/interfaces/input/game-pointer-interface.js";
 import type { GameKeyboardContract } from "../../../../engine/interfaces/input/game-keyboard-interface.js";
 import type { GameEntity } from "../../../../engine/models/game-entity.js";
@@ -34,7 +32,6 @@ export class ChatUISystem {
     boostMeterEntity: BoostMeterEntity,
     helpEntity: HelpEntity,
     chatService: ChatService,
-    matchActionsLogService: MatchActionsLogService,
     gamePointer: GamePointerContract,
     gameKeyboard: GameKeyboardContract,
     playerModerationService: PlayerModerationService,
@@ -53,21 +50,6 @@ export class ChatUISystem {
     }
 
     chatInputElement.removeAttribute("hidden");
-
-    // Load recent chat messages into the match log
-    if (chatService && matchActionsLogService) {
-      const initialMsgs = chatService.getMessages();
-      if (initialMsgs.length > 0) {
-        const recentMessages = initialMsgs.slice(-5);
-        for (const message of recentMessages) {
-          matchActionsLogService.addAction(
-            MatchAction.chatMessage(message.getUserId(), message.getText(), {
-              timestamp: message.getTimestamp(),
-            }),
-          );
-        }
-      }
-    }
 
     this.chatButtonEntity = new ChatButtonEntity(
       boostMeterEntity,

--- a/src/game/scenes/world/world-scene-dependencies.ts
+++ b/src/game/scenes/world/world-scene-dependencies.ts
@@ -18,15 +18,14 @@ export interface WorldSceneDependencies {
   eventConsumerService: EventConsumerService;
   sceneTransitionService: SceneTransitionService;
   timerManagerService: TimerManagerService;
-  matchmakingService: MatchmakingServiceContract | null;
-  matchmakingController: MatchmakingControllerContract | null;
-  entityOrchestrator: EntityOrchestratorService | null;
+  matchmakingService: MatchmakingServiceContract;
+  matchmakingController: MatchmakingControllerContract;
+  entityOrchestrator: EntityOrchestratorService;
   eventProcessorService: EventProcessorService;
-  spawnPointService: SpawnPointService | null;
-  chatService: ChatService | null;
-  matchActionsLogService: MatchActionsLogService | null;
+  spawnPointService: SpawnPointService;
+  chatService: ChatService;
+  matchActionsLogService: MatchActionsLogService;
   gamePlayer: GamePlayer;
   gameServer: GameServer;
   matchSessionService: MatchSessionService;
-  replayMode?: boolean;
 }

--- a/src/game/scenes/world/world-scene-factory.ts
+++ b/src/game/scenes/world/world-scene-factory.ts
@@ -3,7 +3,7 @@ import type {
   WorldSceneFactoryContract,
   WorldSceneFactoryOptions,
 } from "../../../engine/interfaces/services/gameplay/world-scene-factory-contract.js";
-import type { GameScene } from "../../../engine/interfaces/scenes/game-scene-interface.js";
+import { BaseGameScene } from "../../../engine/scenes/base-game-scene.js";
 import { GameState } from "../../../engine/models/game-state.js";
 import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
 import { SceneTransitionService } from "../../../engine/services/gameplay/scene-transition-service.js";
@@ -25,7 +25,7 @@ import type { WorldSceneDependencies } from "./world-scene-dependencies.js";
 
 @injectable()
 export class WorldSceneFactory implements WorldSceneFactoryContract {
-  public create(options: WorldSceneFactoryOptions = {}): GameScene {
+  public create(options: WorldSceneFactoryOptions = {}): BaseGameScene {
     const replayMode = options.replayMode ?? false;
 
     if (replayMode) {

--- a/src/game/scenes/world/world-scene-factory.ts
+++ b/src/game/scenes/world/world-scene-factory.ts
@@ -3,6 +3,7 @@ import type {
   WorldSceneFactoryContract,
   WorldSceneFactoryOptions,
 } from "../../../engine/interfaces/services/gameplay/world-scene-factory-contract.js";
+import type { GameScene } from "../../../engine/interfaces/scenes/game-scene-interface.js";
 import { GameState } from "../../../engine/models/game-state.js";
 import { EventConsumerService } from "../../../engine/services/gameplay/event-consumer-service.js";
 import { SceneTransitionService } from "../../../engine/services/gameplay/scene-transition-service.js";
@@ -19,36 +20,36 @@ import { GamePlayer } from "../../models/game-player.js";
 import { GameServer } from "../../models/game-server.js";
 import { MatchSessionService } from "../../services/session/match-session-service.js";
 import { WorldScene } from "./world-scene.js";
+import { ReplayScene } from "../replay/replay-scene.js";
 import type { WorldSceneDependencies } from "./world-scene-dependencies.js";
 
 @injectable()
 export class WorldSceneFactory implements WorldSceneFactoryContract {
-  public create(options: WorldSceneFactoryOptions = {}): WorldScene {
+  public create(options: WorldSceneFactoryOptions = {}): GameScene {
     const replayMode = options.replayMode ?? false;
+
+    if (replayMode) {
+      return new ReplayScene(
+        container.get(GameState),
+        container.get(EventConsumerService),
+      );
+    }
+
     const deps: WorldSceneDependencies = {
       gameState: container.get(GameState),
       eventConsumerService: container.get(EventConsumerService),
       sceneTransitionService: container.get(SceneTransitionService),
       timerManagerService: container.get(TimerManagerService),
-      matchmakingService: replayMode
-        ? null
-        : container.get(MatchmakingService),
-      matchmakingController: replayMode
-        ? null
-        : container.get(MatchmakingControllerService),
-      entityOrchestrator: replayMode
-        ? null
-        : container.get(EntityOrchestratorService),
+      matchmakingService: container.get(MatchmakingService),
+      matchmakingController: container.get(MatchmakingControllerService),
+      entityOrchestrator: container.get(EntityOrchestratorService),
       eventProcessorService: container.get(EventProcessorService),
-      spawnPointService: replayMode ? null : container.get(SpawnPointService),
-      chatService: replayMode ? null : container.get(ChatService),
-      matchActionsLogService: replayMode
-        ? null
-        : container.get(MatchActionsLogService),
+      spawnPointService: container.get(SpawnPointService),
+      chatService: container.get(ChatService),
+      matchActionsLogService: container.get(MatchActionsLogService),
       gamePlayer: container.get(GamePlayer),
       gameServer: container.get(GameServer),
       matchSessionService: container.get(MatchSessionService),
-      replayMode,
     };
     return new WorldScene(deps);
   }

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -56,17 +56,17 @@ import { EngineLogger } from "../../../engine/services/engine-logger.js";
 
 export class WorldScene extends BaseCollidingGameScene {
   private readonly sceneTransitionService: SceneTransitionService;
-  private readonly spawnPointService: SpawnPointService | null;
+  private readonly spawnPointService: SpawnPointService;
   private readonly timerManagerService: TimerManagerService;
-  private readonly matchmakingService: MatchmakingServiceContract | null;
-  private readonly matchmakingController: MatchmakingControllerContract | null;
+  private readonly matchmakingService: MatchmakingServiceContract;
+  private readonly matchmakingController: MatchmakingControllerContract;
   private readonly eventProcessorService: EventProcessorService;
-  private readonly entityOrchestrator: EntityOrchestratorService | null;
-  private readonly chatService: ChatService | null;
+  private readonly entityOrchestrator: EntityOrchestratorService;
+  private readonly chatService: ChatService;
   private readonly gamePlayer: GamePlayer;
   private readonly gameServer: GameServer;
   private readonly matchSessionService: MatchSessionService;
-  private readonly matchActionsLogService: MatchActionsLogService | null;
+  private readonly matchActionsLogService: MatchActionsLogService;
 
   private scoreboardEntity: ScoreboardEntity | null = null;
   private localCarEntity: LocalCarEntity | null = null;
@@ -98,8 +98,6 @@ export class WorldScene extends BaseCollidingGameScene {
 
   constructor(deps: WorldSceneDependencies) {
     super(deps.gameState, deps.eventConsumerService);
-    // Set isReplayMode from parent BaseCollidingGameScene
-    this.isReplayMode = deps.replayMode ?? false;
     this.gamePlayer = deps.gamePlayer;
     this.gameServer = deps.gameServer;
     this.matchSessionService = deps.matchSessionService;
@@ -125,28 +123,15 @@ export class WorldScene extends BaseCollidingGameScene {
     // Ensure pointer events are cleared automatically after update
     this.clearPointerEventsAutomatically = true;
 
-    // Only clear if service exists (in replay mode, some services may be null)
-    if (this.matchActionsLogService) {
-      this.matchActionsLogService.clear();
-    }
+    this.matchActionsLogService.clear();
+    // Clear persisted chat messages so stale messages from previous matches don't appear
+    this.chatService.clearMessages();
 
     this.addSyncableEntities();
     this.subscribeToEvents();
   }
 
   public override load(): void {
-    // In replay mode, don't create any entities - they'll be spawned from recording
-    if (this.isReplayMode) {
-      EngineLogger.info("WorldScene", 
-        "WorldScene loading in replay mode - skipping entity creation"
-      );
-      const factory = new WorldEntityFactory(this.gameState, this.canvas);
-      // Only create background
-      factory.createBackground(this.worldEntities);
-      this.loaded = true;
-      return;
-    }
-
     const factory = new WorldEntityFactory(this.gameState, this.canvas);
     factory.createBackground(this.worldEntities);
 
@@ -170,35 +155,20 @@ export class WorldScene extends BaseCollidingGameScene {
     // Delegate chat UI + match menu setup to the extracted ChatUISystem
     this.setupChatUI();
 
-    // Set total spawn points created to service (skip in replay mode)
-    if (this.spawnPointService) {
-      this.spawnPointService.setTotalSpawnPoints(
-        this.spawnPointEntities.length
-      );
-    }
+    this.spawnPointService.setTotalSpawnPoints(
+      this.spawnPointEntities.length
+    );
 
     // Set match session service for spawn points to show debug info
     this.spawnPointEntities.forEach((spawnPoint) => {
       spawnPoint.setMatchSessionService(this.matchSessionService);
     });
 
-    // Initialize NPC service (skip in replay mode)
-    if (this.spawnPointService) {
-      this.npcService = new NpcService(
-        this.matchSessionService,
-        this.spawnPointService,
-        this.timerManagerService
-      );
-    }
-
-    // Skip WorldController in replay mode if required services are null
-    if (
-      !this.spawnPointService ||
-      !this.matchmakingService ||
-      !this.matchActionsLogService
-    ) {
-      return;
-    }
+    this.npcService = new NpcService(
+      this.matchSessionService,
+      this.spawnPointService,
+      this.timerManagerService
+    );
 
     this.worldController = new WorldController({
       spawnPointService: this.spawnPointService,
@@ -217,11 +187,6 @@ export class WorldScene extends BaseCollidingGameScene {
       gamePlayer: this.gamePlayer,
       matchSessionService: this.matchSessionService,
     });
-
-    // Skip ScoreManagerService in replay mode if required services are null
-    if (!this.matchActionsLogService || !this.matchmakingService) {
-      return;
-    }
 
     this.scoreManagerService = new ScoreManagerService({
       ballEntity: this.ballEntity,
@@ -265,21 +230,18 @@ export class WorldScene extends BaseCollidingGameScene {
       this.helpEntity?.show(text, 4);
       this.helpShown = true;
     }
-    // Skip matchmaking in replay mode
-    if (this.matchmakingController) {
-      this.matchmakingController
-        .startMatchmaking()
-        .catch(this.handleMatchmakingError.bind(this));
-    }
+    this.matchmakingController
+      .startMatchmaking()
+      .catch(this.handleMatchmakingError.bind(this));
   }
 
   public override update(deltaTimeStamp: DOMHighResTimeStamp): void {
-    super.update(deltaTimeStamp);
+    // Anti-cheat movement checks — must run BEFORE super.update() so that
+    // skipInterpolation flags from teleport() calls in the previous frame
+    // are still visible (entities clear the flag at the end of update()).
+    this.antiCheatService?.update(deltaTimeStamp, this.getAntiCheatTrackedEntities());
 
-    // Skip gameplay logic in replay mode - entities are driven by recording data
-    if (this.isReplayMode) {
-      return;
-    }
+    super.update(deltaTimeStamp);
 
     // Delegate weather physics to WeatherSystem
     this.weatherSystem.update(this.worldEntities);
@@ -294,21 +256,14 @@ export class WorldScene extends BaseCollidingGameScene {
     // Always use the normal score detection (works for solo and multiplayer)
     this.scoreManagerService?.detectScoresIfHost();
 
-    // Skip network sync in replay mode
-    if (this.entityOrchestrator) {
-      this.entityOrchestrator.sendLocalData(this, deltaTimeStamp);
-    }
-
-    // Anti-cheat movement checks each frame
-    this.antiCheatService?.update(deltaTimeStamp, this.getAntiCheatTrackedEntities());
+    this.entityOrchestrator.sendLocalData(this, deltaTimeStamp);
   }
 
   public override render(context: CanvasRenderingContext2D): void {
     super.render(context);
 
     // Render debug information from matchmaking service (which internally delegates to webrtc)
-    // Skip in replay mode where matchmakingService may be null
-    if (this.gameState.isDebugging() && this.matchmakingService) {
+    if (this.gameState.isDebugging()) {
       this.matchmakingService.renderDebugInformation(context);
     }
   }
@@ -387,13 +342,11 @@ export class WorldScene extends BaseCollidingGameScene {
     // Delegate to ChatUISystem for match menu refresh
     this.chatUISystem.refreshPlayers(this.matchSessionService, this.gamePlayer);
 
-    if (this.matchActionsLogService) {
-      this.matchActionsLogService.addAction(
-        MatchAction.playerJoined(player.getNetworkId(), {
-          playerName: player.getName(),
-        })
-      );
-    }
+    this.matchActionsLogService.addAction(
+      MatchAction.playerJoined(player.getNetworkId(), {
+        playerName: player.getName(),
+      })
+    );
   }
 
   private handlePlayerDisconnection(payload: PlayerDisconnectedPayload): void {
@@ -422,13 +375,11 @@ export class WorldScene extends BaseCollidingGameScene {
 
     this.scoreManagerService?.updateScoreboard();
 
-    if (this.matchActionsLogService) {
-      this.matchActionsLogService.addAction(
-        MatchAction.playerLeft(player.getNetworkId(), {
-          playerName: player.getName(),
-        })
-      );
-    }
+    this.matchActionsLogService.addAction(
+      MatchAction.playerLeft(player.getNetworkId(), {
+        playerName: player.getName(),
+      })
+    );
   }
 
   private subscribeToEvents(): void {
@@ -534,8 +485,8 @@ export class WorldScene extends BaseCollidingGameScene {
       this.uiEntities.push(boostMeterEntity);
     }
 
-    // Skip chat setup in replay mode
-    if (!this.chatService || !this.matchActionsLogService || !this.helpEntity) {
+    if (!this.helpEntity) {
+      EngineLogger.error("WorldScene", "Help entity not found for chat UI");
       return;
     }
 
@@ -545,7 +496,6 @@ export class WorldScene extends BaseCollidingGameScene {
       boostMeterEntity,
       this.helpEntity,
       this.chatService,
-      this.matchActionsLogService,
       this.gameState.getGamePointer(),
       this.gameState.getGameKeyboard(),
       container.get(PlayerModerationService),
@@ -571,11 +521,9 @@ export class WorldScene extends BaseCollidingGameScene {
       this.gamePlayer
     );
     this.uiEntities.push(this.matchLogEntity);
-    if (this.matchActionsLogService) {
-      this.matchActionsLogUnsubscribe = this.matchActionsLogService.onChange(
-        (actions) => this.matchLogEntity?.show(actions)
-      );
-    }
+    this.matchActionsLogUnsubscribe = this.matchActionsLogService.onChange(
+      (actions) => this.matchLogEntity?.show(actions)
+    );
   }
 
   private triggerGoalExplosion(x: number, y: number, team: TeamType): void {
@@ -644,11 +592,9 @@ export class WorldScene extends BaseCollidingGameScene {
 
   private navigateToErrorScene(errorMessage: string): void {
     EngineLogger.info("WorldScene", "Navigating to error scene:", errorMessage);
-    if (this.matchmakingService) {
-      this.matchmakingService.leaveMatch().catch((error) => {
-        EngineLogger.error("WorldScene", "Error leaving match during kick:", error);
-      });
-    }
+    this.matchmakingService.leaveMatch().catch((error) => {
+      EngineLogger.error("WorldScene", "Error leaving match during kick:", error);
+    });
     this.dispose();
     const mainScene = new MainScene();
     const errorScene = new ErrorScene(errorMessage);
@@ -668,6 +614,7 @@ export class WorldScene extends BaseCollidingGameScene {
     y: number;
     ownerId: string;
     typeId: number;
+    skipInterpolation: boolean;
   }> {
     for (const entity of this.worldEntities) {
       if (!(entity instanceof BaseMoveableGameEntity)) {
@@ -682,6 +629,7 @@ export class WorldScene extends BaseCollidingGameScene {
           y: entity.getY(),
           ownerId,
           typeId,
+          skipInterpolation: entity.wasSkipInterpolationSet(),
         };
       }
     }
@@ -692,9 +640,7 @@ export class WorldScene extends BaseCollidingGameScene {
     this.chatUISystem.dispose();
     this.matchActionsLogUnsubscribe?.();
     this.matchActionsLogUnsubscribe = null;
-    if (this.matchActionsLogService) {
-      this.matchActionsLogService.clear();
-    }
+    this.matchActionsLogService.clear();
     if (this.npcService) {
       this.npcService.removeNpcCar((entity) => {
         const index = this.worldEntities.indexOf(entity);

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -110,8 +110,9 @@ export class ChatService {
       peer.sendReliableUnorderedMessage(chatMessagePayload);
     });
 
-    // Execute command and skip chat output if handled
-    if (this.handleCommand(text, userId, timestamp)) {
+    // Execute command and skip chat output if handled.
+    // Convert server timestamp (seconds) to ms for consistent throttling.
+    if (this.handleCommand(text, userId, timestamp * 1000)) {
       return;
     }
 
@@ -145,8 +146,9 @@ export class ChatService {
       return;
     }
 
-    // Execute command and skip chat output if handled
-    if (this.handleCommand(text, userId, timestampSeconds)) {
+    // Execute command and skip chat output if handled.
+    // Convert peer timestamp (seconds) to ms for consistent throttling.
+    if (this.handleCommand(text, userId, timestampSeconds * 1000)) {
       return;
     }
 
@@ -216,7 +218,7 @@ export class ChatService {
 
     if (
       lastLoggedAt !== undefined &&
-      now - lastLoggedAt < ChatService.LOG_THROTTLE_MS
+      now - lastLoggedAt <= ChatService.LOG_THROTTLE_MS
     ) {
       return;
     }

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -79,19 +79,8 @@ export class ChatService {
       return;
     }
 
-    const isCommand = this.handleCommand(trimmed, undefined, Date.now());
-
-    // For non-command messages, add locally immediately so the sender
-    // (including the host) sees their own message without waiting for server echo
-    if (!isCommand) {
-      const timestamp = Math.floor(Date.now() / 1000);
-      const chatMessage = new ChatMessage(
-        this.getLocalPlayerId(),
-        trimmed,
-        timestamp,
-      );
-      this.addMessage(chatMessage);
-    }
+    // Execute local command effects immediately
+    this.handleCommand(trimmed, undefined, Date.now());
 
     const payload = BinaryWriter.build()
       .unsignedInt8(WebSocketType.ChatMessage)
@@ -126,12 +115,9 @@ export class ChatService {
       return;
     }
 
-    // Messages from the local player are already added in sendMessage;
-    // only add messages from other players.
-    if (userId !== this.getLocalPlayerId()) {
-      const chatMessage = new ChatMessage(userId, text, timestamp);
-      this.addMessage(chatMessage);
-    }
+    // Add message to UI (server has already moderated and signed it)
+    const chatMessage = new ChatMessage(userId, text, timestamp);
+    this.addMessage(chatMessage);
   }
 
   @PeerCommandHandler(WebRTCType.ChatMessage)

--- a/src/game/services/network/chat-service.ts
+++ b/src/game/services/network/chat-service.ts
@@ -79,8 +79,19 @@ export class ChatService {
       return;
     }
 
-    // Execute local command effects immediately
-    this.handleCommand(trimmed, undefined, Date.now());
+    const isCommand = this.handleCommand(trimmed, undefined, Date.now());
+
+    // For non-command messages, add locally immediately so the sender
+    // (including the host) sees their own message without waiting for server echo
+    if (!isCommand) {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const chatMessage = new ChatMessage(
+        this.getLocalPlayerId(),
+        trimmed,
+        timestamp,
+      );
+      this.addMessage(chatMessage);
+    }
 
     const payload = BinaryWriter.build()
       .unsignedInt8(WebSocketType.ChatMessage)
@@ -115,9 +126,12 @@ export class ChatService {
       return;
     }
 
-    // Add message to UI
-    const chatMessage = new ChatMessage(userId, text, timestamp);
-    this.addMessage(chatMessage);
+    // Messages from the local player are already added in sendMessage;
+    // only add messages from other players.
+    if (userId !== this.getLocalPlayerId()) {
+      const chatMessage = new ChatMessage(userId, text, timestamp);
+      this.addMessage(chatMessage);
+    }
   }
 
   @PeerCommandHandler(WebRTCType.ChatMessage)

--- a/src/game/services/network/websocket-service.ts
+++ b/src/game/services/network/websocket-service.ts
@@ -333,8 +333,8 @@ export class WebSocketService implements WebSocketServiceContract {
     const wasConnected = this.gameServer.isConnected();
     this.gameServer.setConnected(false);
 
-    // Check if the user has been banned
-    if (event.code === 1000 && event.reason === "User has been banned") {
+    // Check if the user has been banned (1008 = Policy Violation)
+    if (event.code === 1008 && event.reason === "User has been banned") {
       EngineLogger.info("WebsocketService", "User has been banned from the server");
 
       this.isTerminalDisconnect = true;
@@ -347,19 +347,7 @@ export class WebSocketService implements WebSocketServiceContract {
       return;
     }
 
-    // Check if the user has been kicked
-    if (event.code === 1000 && event.reason === "User has been kicked") {
-      EngineLogger.info("WebsocketService", "User has been kicked from the server");
 
-      this.isTerminalDisconnect = true;
-      this.stopReconnection();
-      this.webSocket = null;
-
-      const localEvent = new LocalEvent(GameEventType.UserKickedByServer);
-      this.eventProcessorService.addLocalEvent(localEvent);
-
-      return;
-    }
 
     // Only emit disconnected event if we were actually connected
     if (wasConnected) {

--- a/src/game/services/security/anti-cheat-monitor-service.ts
+++ b/src/game/services/security/anti-cheat-monitor-service.ts
@@ -90,6 +90,12 @@ export class AntiCheatMonitorService {
         this.movementSamples.set(entity.id, samples);
       }
 
+      // Clear movement history for intentional teleports (e.g. spawn points)
+      // so the large position delta is not flagged as a speed violation.
+      if (entity.skipInterpolation) {
+        samples.length = 0;
+      }
+
       samples.push({ x: entity.x, y: entity.y, timestamp: now });
 
       const violations = evaluateMovementRules(

--- a/src/game/services/security/anti-cheat-reporting-service.ts
+++ b/src/game/services/security/anti-cheat-reporting-service.ts
@@ -3,19 +3,30 @@ import { PlayerModerationService } from "../network/player-moderation-service.js
 import { GamePlayer } from "../../models/game-player.js";
 import { EngineLogger } from "../../../engine/services/engine-logger.js";
 
+/** A reported violation with metadata for inspector display. */
+export interface ReportedViolation {
+  ruleId: number;
+  userId: string;
+  reason: string;
+  /** Unix timestamp (ms) when the violation was first reported. */
+  timestamp: number;
+}
+
 @injectable()
 export class AntiCheatReportingService {
-  /** Keys of already-reported violations. Format: `${ruleId}:${userId}` */
-  private readonly reported = new Set<string>();
+  /** Full history of reported violations. */
+  private readonly violations: ReportedViolation[] = [];
 
-  /** Returns a snapshot of all reported violation keys. */
-  public getReportedViolations(): readonly string[] {
-    return [...this.reported];
+  /** Returns a snapshot of all reported violations. */
+  public getReportedViolations(): readonly ReportedViolation[] {
+    return this.violations;
   }
 
   /** Returns whether a specific violation has been reported. */
   public isReported(ruleId: number, userId: string): boolean {
-    return this.reported.has(`${ruleId}:${userId}`);
+    return this.violations.some(
+      (v) => v.ruleId === ruleId && v.userId === userId,
+    );
   }
 
   constructor(
@@ -31,22 +42,35 @@ export class AntiCheatReportingService {
     targetUserId?: string,
   ): void {
     const userId = targetUserId ?? this.gamePlayer.getNetworkId();
-    const key = `${ruleId}:${userId}`;
 
-    if (this.reported.has(key)) return;
-    this.reported.add(key);
+    if (this.isReported(ruleId, userId)) return;
+
+    const violation: ReportedViolation = {
+      ruleId,
+      userId,
+      reason,
+      timestamp: Date.now(),
+    };
+    this.violations.push(violation);
 
     const fullReason = `Rule #${ruleId}: ${reason}`;
     this.send(userId, fullReason);
 
-    EngineLogger.warn("AntiCheatReportingService", `[AntiCheat] Rule ${ruleId} violated by ${userId}: ${reason}`);
+    EngineLogger.warn(
+      "AntiCheatReportingService",
+      `[AntiCheat] Rule ${ruleId} violated by ${userId}: ${reason}`,
+    );
   }
 
   private send(userId: string, reason: string): void {
     this.playerModerationService
       .reportUser(userId, `[AntiCheat] ${reason}`, true)
       .catch((error: unknown) => {
-        EngineLogger.error("AntiCheatReportingService", "[AntiCheat] Failed to send report:", error);
+        EngineLogger.error(
+          "AntiCheatReportingService",
+          "[AntiCheat] Failed to send report:",
+          error,
+        );
       });
   }
 }

--- a/src/game/utils/anti-cheat-utils.ts
+++ b/src/game/utils/anti-cheat-utils.ts
@@ -32,6 +32,8 @@ export interface TrackedEntity {
   y: number;
   ownerId: string;
   typeId: number;
+  /** True when the entity was intentionally teleported (e.g. spawn point). */
+  skipInterpolation: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/game/utils/scene-type-registry.ts
+++ b/src/game/utils/scene-type-registry.ts
@@ -1,0 +1,13 @@
+import { SceneRegistry } from "../../engine/services/scene-registry.js";
+import { container } from "../../engine/services/di-container.js";
+import { GameState } from "../../engine/models/game-state.js";
+import { EventConsumerService } from "../../engine/services/gameplay/event-consumer-service.js";
+import { GameSceneType } from "../enums/scene-type.js";
+import { ReplayScene } from "../scenes/replay/replay-scene.js";
+
+SceneRegistry.register(GameSceneType.World, () => {
+  return new ReplayScene(
+    container.get(GameState),
+    container.get(EventConsumerService),
+  );
+});


### PR DESCRIPTION
## Summary

Fixes multiple bugs and improvements across chat, ban handling, anti-cheat, replay, and debug UI.

### Chat
- **Host now sees own messages immediately**: messages added locally in `sendMessage` before the server echo, with deduplication for the server response
- **Stale messages no longer leak between matches**: `ChatService.clearMessages()` called on WorldScene construction, and old message loading removed from ChatUISystem

### Ban Flow
- **Close code fixed from 1000 → 1008**: server uses code 1008 for all forced disconnections (confirmed from game server source)
- **Removed dead kick handler**: server always sends reason "User has been banned" — no separate kick flow exists
- **Banned users now see error screen instead of "Connection to server lost"**

### Anti-cheat Teleport
- **Intentional teleports (spawn points) no longer trigger movement violations**: `skipInterpolation` flag from `teleport()` flows through `TrackedEntity` to the monitor, which clears movement samples on detection
- Flag cleared at end of each frame in `BaseMoveableGameEntity.update()`
- Anti-cheat check moved before entity updates so the flag is visible

### Replay Scene
- **New `ReplayScene`** extracted from `WorldScene` — all `isReplayMode` conditionals removed
- `WorldSceneFactory` creates `ReplayScene` for replay mode and `WorldScene` for live mode
- `WorldSceneDependencies` simplified: no more nullable services

### Debug UI
- **Syncable overlay**: brighter, less transparent pink hexagons (`rgba(255, 20, 147, 0.85)`)
- **Network section**: opened by default in debug window
- **Anti-cheat inspector**: redesigned with inline collapsing headers (no popups), violation history table with player name, absolute time, and relative time

### Build
- TypeScript: passes (only pre-existing errors in loading-scene.ts)
- Vite build: passes in 1.27s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replay playback support with a dedicated replay scene.
  * Expanded the anti-cheat inspector with default-open sections and a detailed violation history table.
  * Network settings now open by default in the debug window.

* **Bug Fixes**
  * Chat messages now appear immediately for the sender without duplicate display.
  * Improved handling of intentional teleports during movement monitoring.
  * Corrected banned-connection detection based on the appropriate close reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->