### PR TITLE
refactor: move debug overlays (hitboxes, gizmos, sync-hexagon) into components

### DIFF
--- a/src/engine/components/collision-component.ts
+++ b/src/engine/components/collision-component.ts
@@ -1,5 +1,6 @@
 import type { Component } from "./component.js";
 import type { HitboxEntity } from "../entities/hitbox-entity.js";
+import type { DebugSettings } from "../models/debug-settings.js";
 
 type CollidingEntity = {
   hasRigidBody(): boolean;
@@ -13,6 +14,9 @@ type CollisionExclusionCtor = new (...args: never[]) => CollidingEntity;
  * Manages collision state: hitbox references, colliding-entity tracking,
  * and class-based collision exclusions. Previously part of
  * BaseStaticCollidingGameEntity.
+ *
+ * Also renders hitbox debug overlays (purple rectangles) when debug
+ * mode is enabled and hitbox visibility is on.
  */
 export class CollisionComponent implements Component {
   public readonly componentType = "CollisionComponent";
@@ -20,7 +24,15 @@ export class CollisionComponent implements Component {
   public collidingEntities: CollidingEntity[] = [];
   public avoidingCollision = false;
 
+  /** Populated by BaseGameEntity.setDebugSettings() when debug toggles change. */
+  public debugSettings: DebugSettings | null = null;
+
   private excludedCollisionClasses: CollisionExclusionCtor[] = [];
+
+  // ── Hitbox debug rendering constants ───────────────────────────
+
+  private static readonly HITBOX_STROKE_STYLE = "rgba(148, 0, 211, 0.2)";
+  private static readonly HITBOX_COLLIDING_FILL_STYLE = "rgba(148, 0, 211, 0.5)";
 
   public isColliding(): boolean {
     return this.collidingEntities.some(
@@ -49,6 +61,37 @@ export class CollisionComponent implements Component {
     this.excludedCollisionClasses = this.excludedCollisionClasses.filter(
       (type) => type !== classType,
     );
+  }
+
+  public render(context: CanvasRenderingContext2D): void {
+    if (
+      !this.debugSettings?.isDebugging() ||
+      !this.debugSettings?.areHitboxesVisible()
+    ) return;
+
+    for (const hitbox of this.hitboxEntities) {
+      context.save();
+
+      context.strokeStyle = CollisionComponent.HITBOX_STROKE_STYLE;
+      context.strokeRect(
+        hitbox.getX(),
+        hitbox.getY(),
+        hitbox.getWidth(),
+        hitbox.getHeight(),
+      );
+
+      if (hitbox.isColliding()) {
+        context.fillStyle = CollisionComponent.HITBOX_COLLIDING_FILL_STYLE;
+        context.fillRect(
+          hitbox.getX(),
+          hitbox.getY(),
+          hitbox.getWidth(),
+          hitbox.getHeight(),
+        );
+      }
+
+      context.restore();
+    }
   }
 
   private isCollisionClassIncluded(classType: CollisionExclusionCtor): boolean {

--- a/src/engine/components/component.ts
+++ b/src/engine/components/component.ts
@@ -1,3 +1,5 @@
+import type { BaseGameEntity } from "../entities/base-game-entity.js";
+
 /**
  * Base interface for all entity components.
  *
@@ -12,12 +14,15 @@ export interface Component {
   /** Unique type identifier for the component (set to constructor name by convention). */
   readonly componentType: string;
 
+  /** Reference to the owning entity. Set automatically by addComponent(). */
+  entity?: BaseGameEntity;
+
   /** Called once when the component is attached to an entity. */
   init?(): void;
 
   /** Called each frame. Receives the delta time in milliseconds. */
   update?(deltaTimeStamp: DOMHighResTimeStamp): void;
 
-  /** Called each frame for rendering. */
+  /** Called each frame for rendering debug overlays, gizmos, and visualizations. */
   render?(context: CanvasRenderingContext2D): void;
 }

--- a/src/engine/components/network-component.ts
+++ b/src/engine/components/network-component.ts
@@ -1,10 +1,16 @@
 import type { Component } from "./component.js";
+import type { BaseGameEntity } from "../entities/base-game-entity.js";
 import type { EntityType } from "../enums/entity-type.js";
 import type { Player } from "../interfaces/models/player-interface.js";
+import type { DebugSettings } from "../models/debug-settings.js";
+import { TransformComponent } from "./transform-component.js";
 
 /**
  * Holds multiplayer networking state for an entity: owner, type registry ID,
  * and sync flags. Previously part of BaseMultiplayerGameEntity.
+ *
+ * Also renders a debug hexagon overlay on syncable entities when
+ * the "show syncable entities" debug toggle is on.
  */
 export class NetworkComponent implements Component {
   public readonly componentType = "NetworkComponent";
@@ -20,7 +26,52 @@ export class NetworkComponent implements Component {
   /** Flag: request reliable-ordered sync next frame. */
   public mustSyncReliablyFlag = false;
 
+  /** Reference to the owning entity. Set automatically by addComponent(). */
+  public entity?: BaseGameEntity;
+
+  /** Populated by BaseGameEntity.setDebugSettings() when debug toggles change. */
+  public debugSettings: DebugSettings | null = null;
+
+  // ── Hexagon rendering constants ────────────────────────────────
+
+  private static readonly HEXAGON_SIDES = 6;
+  private static readonly HEXAGON_RADIUS = 25;
+  private static readonly HEXAGON_COLOR = "rgba(255, 20, 147, 0.85)";
+
   public getId(): string {
     return this.networkId ?? "";
+  }
+
+  public render(context: CanvasRenderingContext2D): void {
+    if (
+      !this.debugSettings?.showSyncableEntitiesOverlay() ||
+      !this.syncable
+    ) return;
+
+    const transform = this.entity?.getComponent(TransformComponent);
+    if (!transform) return;
+
+    const cx = transform.x;
+    const cy = transform.y;
+
+    context.save();
+    context.strokeStyle = NetworkComponent.HEXAGON_COLOR;
+    context.lineWidth = 1.5;
+    context.beginPath();
+
+    const r = NetworkComponent.HEXAGON_RADIUS;
+    for (let i = 0; i < NetworkComponent.HEXAGON_SIDES; i++) {
+      const angle = (Math.PI / 3) * i - Math.PI / 6;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) {
+        context.moveTo(x, y);
+      } else {
+        context.lineTo(x, y);
+      }
+    }
+    context.closePath();
+    context.stroke();
+    context.restore();
   }
 }

--- a/src/engine/components/physics-component.ts
+++ b/src/engine/components/physics-component.ts
@@ -1,8 +1,14 @@
 import type { Component } from "./component.js";
+import type { BaseGameEntity } from "../entities/base-game-entity.js";
+import type { DebugSettings } from "../models/debug-settings.js";
+import { TransformComponent } from "./transform-component.js";
 
 /**
  * Holds physics state for dynamic entities: velocity, mass, and collision
  * response properties. Previously part of BaseDynamicCollidingGameEntity.
+ *
+ * Also renders debug gizmos (center circle + direction arrow) when
+ * debug mode is enabled and gizmos are visible.
  */
 export class PhysicsComponent implements Component {
   public readonly componentType = "PhysicsComponent";
@@ -13,8 +19,79 @@ export class PhysicsComponent implements Component {
   public rigidBody = true;
   public isDynamic = false;
 
+  /** Reference to the owning entity. Set automatically by addComponent(). */
+  public entity?: BaseGameEntity;
+
+  /** Populated by BaseGameEntity.setDebugSettings() when debug toggles change. */
+  public debugSettings: DebugSettings | null = null;
+
+  // ── Gizmo rendering constants ──────────────────────────────────
+
+  private static readonly LINE_LENGTH = 50;
+  private static readonly ARROW_SIZE = 15;
+  private static readonly CENTER_CIRCLE_RADIUS = 7;
+  private static readonly CENTER_FILL_STYLE = "rgba(255, 255, 0, 0.6)";
+  private static readonly CENTER_STROKE_STYLE = "yellow";
+  private static readonly DIRECTION_STROKE_STYLE = "orange";
+  private static readonly ARROW_ANGLE_OFFSET = Math.PI / 7;
+  private static readonly LINE_WIDTH = 3;
+  private static readonly CENTER_LINE_WIDTH = 2;
+
   public resetVelocity(): void {
     this.vx = 0;
     this.vy = 0;
+  }
+
+  public render(context: CanvasRenderingContext2D): void {
+    if (
+      !this.debugSettings?.isDebugging() ||
+      !this.debugSettings?.areGizmosVisible()
+    ) return;
+
+    const transform = this.entity?.getComponent(TransformComponent);
+    if (!transform) return;
+
+    const { x, y, angle } = transform;
+
+    context.save();
+
+    // Center circle
+    context.fillStyle = PhysicsComponent.CENTER_FILL_STYLE;
+    context.strokeStyle = PhysicsComponent.CENTER_STROKE_STYLE;
+    context.lineWidth = PhysicsComponent.CENTER_LINE_WIDTH;
+    context.beginPath();
+    context.arc(
+      x, y,
+      PhysicsComponent.CENTER_CIRCLE_RADIUS,
+      0, 2 * Math.PI,
+    );
+    context.fill();
+    context.stroke();
+
+    // Direction arrow
+    const lineLength = PhysicsComponent.LINE_LENGTH;
+    const endX = x + Math.cos(angle) * lineLength;
+    const endY = y + Math.sin(angle) * lineLength;
+
+    context.strokeStyle = PhysicsComponent.DIRECTION_STROKE_STYLE;
+    context.lineWidth = PhysicsComponent.LINE_WIDTH;
+    context.beginPath();
+    context.moveTo(x, y);
+    context.lineTo(endX, endY);
+    context.stroke();
+
+    // Arrowhead
+    const arrowSize = PhysicsComponent.ARROW_SIZE;
+    context.fillStyle = PhysicsComponent.DIRECTION_STROKE_STYLE;
+    context.beginPath();
+    const a1 = angle + PhysicsComponent.ARROW_ANGLE_OFFSET;
+    const a2 = angle - PhysicsComponent.ARROW_ANGLE_OFFSET;
+    context.moveTo(endX, endY);
+    context.lineTo(endX - arrowSize * Math.cos(a1), endY - arrowSize * Math.sin(a1));
+    context.lineTo(endX - arrowSize * Math.cos(a2), endY - arrowSize * Math.sin(a2));
+    context.closePath();
+    context.fill();
+
+    context.restore();
   }
 }

--- a/src/engine/entities/base-colliding-game-entity.ts
+++ b/src/engine/entities/base-colliding-game-entity.ts
@@ -11,9 +11,12 @@ type CollidingGameEntityConstructor = new (
  * Unified colliding entity — replaces both BaseStaticCollidingGameEntity and
  * BaseDynamicCollidingGameEntity. A "static" collider is simply one with
  * {@link PhysicsComponent.isDynamic} = false and zero velocity.
+ *
+ * Debug overlays (gizmos, hitboxes) are rendered by the PhysicsComponent and
+ * CollisionComponent respectively — no rendering code lives here.
  */
 export class BaseCollidingGameEntity extends BaseMoveableGameEntity {
-  /** Physics state — prefer accessing via this getComponent(PhysicsComponent) for new code. */
+  /** Physics state — prefer accessing via {@code getComponent(PhysicsComponent)} for new code. */
   protected readonly physics: PhysicsComponent;
 
   // ── Collision (from old BaseStaticCollidingGameEntity) ─────────
@@ -24,20 +27,8 @@ export class BaseCollidingGameEntity extends BaseMoveableGameEntity {
   private avoidingCollision = false;
   private excludedCollisionClasses: CollidingGameEntityConstructor[] = [];
 
-  /** Backing CollisionComponent – use getComponent(CollisionComponent) for new code. */
+  /** Backing CollisionComponent — use {@code getComponent(CollisionComponent)} for new code. */
   protected readonly collision: CollisionComponent;
-
-  // ── Debug gizmos ───────────────────────────────────────────────
-
-  private static readonly LINE_LENGTH = 50;
-  private static readonly ARROW_SIZE = 15;
-  private static readonly CENTER_CIRCLE_RADIUS = 7;
-  private static readonly CENTER_FILL_STYLE = "rgba(255, 255, 0, 0.6)";
-  private static readonly CENTER_STROKE_STYLE = "yellow";
-  private static readonly DIRECTION_STROKE_STYLE = "orange";
-  private static readonly ARROW_ANGLE_OFFSET = Math.PI / 7;
-  private static readonly LINE_WIDTH = 3;
-  private static readonly CENTER_LINE_WIDTH = 2;
 
   constructor() {
     super();
@@ -87,13 +78,6 @@ export class BaseCollidingGameEntity extends BaseMoveableGameEntity {
   }
 
   // ── Collision accessors ────────────────────────────────────────
-
-  public override load(): void {
-    this.hitboxEntities.forEach((entity) =>
-      entity.setDebugSettings(this.debugSettings)
-    );
-    super.load();
-  }
 
   public isColliding(): boolean {
     this.syncCollisionState();
@@ -170,59 +154,16 @@ export class BaseCollidingGameEntity extends BaseMoveableGameEntity {
     // Default implementation — subclasses override
   }
 
-  // ── Render (debug gizmos + hitboxes) ───────────────────────────
+  // ── Render ─────────────────────────────────────────────────────
 
+  /**
+   * Debug overlays (gizmos, hitbox rectangles) are now rendered by
+   * {@link PhysicsComponent.render} and {@link CollisionComponent.render}
+   * respectively, invoked via the component lifecycle in
+   * {@link BaseGameEntity.render}. This method only chains to the parent.
+   */
   public override render(context: CanvasRenderingContext2D): void {
-    if (this.debugSettings?.isDebugging()) {
-      this.renderDebugGizmos(context);
-    }
-    this.hitboxEntities.forEach((entity) => entity.render(context));
     super.render(context);
-  }
-
-  private renderDebugGizmos(context: CanvasRenderingContext2D): void {
-    if (this.debugSettings?.areGizmosVisible() === false) return;
-
-    context.save();
-
-    // Center circle
-    context.fillStyle = BaseCollidingGameEntity.CENTER_FILL_STYLE;
-    context.strokeStyle = BaseCollidingGameEntity.CENTER_STROKE_STYLE;
-    context.lineWidth = BaseCollidingGameEntity.CENTER_LINE_WIDTH;
-    context.beginPath();
-    context.arc(
-      this.x, this.y,
-      BaseCollidingGameEntity.CENTER_CIRCLE_RADIUS,
-      0, 2 * Math.PI,
-    );
-    context.fill();
-    context.stroke();
-
-    // Direction arrow
-    const lineLength = BaseCollidingGameEntity.LINE_LENGTH;
-    const endX = this.x + Math.cos(this.angle) * lineLength;
-    const endY = this.y + Math.sin(this.angle) * lineLength;
-
-    context.strokeStyle = BaseCollidingGameEntity.DIRECTION_STROKE_STYLE;
-    context.lineWidth = BaseCollidingGameEntity.LINE_WIDTH;
-    context.beginPath();
-    context.moveTo(this.x, this.y);
-    context.lineTo(endX, endY);
-    context.stroke();
-
-    // Arrowhead
-    const arrowSize = BaseCollidingGameEntity.ARROW_SIZE;
-    context.fillStyle = BaseCollidingGameEntity.DIRECTION_STROKE_STYLE;
-    context.beginPath();
-    const a1 = this.angle + BaseCollidingGameEntity.ARROW_ANGLE_OFFSET;
-    const a2 = this.angle - BaseCollidingGameEntity.ARROW_ANGLE_OFFSET;
-    context.moveTo(endX, endY);
-    context.lineTo(endX - arrowSize * Math.cos(a1), endY - arrowSize * Math.sin(a1));
-    context.lineTo(endX - arrowSize * Math.cos(a2), endY - arrowSize * Math.sin(a2));
-    context.closePath();
-    context.fill();
-
-    context.restore();
   }
 
   // ── Internal sync ──────────────────────────────────────────────

--- a/src/engine/entities/base-game-entity.ts
+++ b/src/engine/entities/base-game-entity.ts
@@ -29,11 +29,13 @@ export class BaseGameEntity implements GameEntity {
 
   /**
    * Attach a component to this entity. If a component of the same type
-   * already exists, it is replaced.
+   * already exists, it is replaced. The component's {@code entity} reference
+   * is set to this entity.
    */
   public addComponent<T extends Component>(component: T): T {
     const key = component.constructor.name;
     this.components.set(key, component);
+    component.entity = this;
     component.init?.();
     return component;
   }
@@ -131,6 +133,15 @@ export class BaseGameEntity implements GameEntity {
 
   public setDebugSettings(debugSettings: DebugSettings | null): void {
     this.debugSettings = debugSettings;
+
+    // Propagate debug settings to components that carry their own
+    // debug-rendering logic (PhysicsComponent, CollisionComponent,
+    // NetworkComponent, etc.).
+    this.components.forEach((comp) => {
+      if ("debugSettings" in comp) {
+        (comp as Record<string, unknown>).debugSettings = debugSettings;
+      }
+    });
   }
 
   public getReplayState(): ArrayBuffer | null {
@@ -142,7 +153,15 @@ export class BaseGameEntity implements GameEntity {
     // Base implementation does nothing - override in subclasses that need it
   }
 
-  public update(_deltaTimeStamp: DOMHighResTimeStamp): void {}
+  public update(deltaTimeStamp: DOMHighResTimeStamp): void {
+    this.components.forEach((component) =>
+      component.update?.(deltaTimeStamp),
+    );
+  }
 
-  public render(_context: CanvasRenderingContext2D): void {}
+  public render(context: CanvasRenderingContext2D): void {
+    this.components.forEach((component) =>
+      component.render?.(context),
+    );
+  }
 }

--- a/src/engine/entities/base-moveable-game-entity.ts
+++ b/src/engine/entities/base-moveable-game-entity.ts
@@ -199,48 +199,6 @@ export class BaseMoveableGameEntity extends BaseMultiplayerGameEntity {
     );
   }
 
-  // ── Debug overlay ──────────────────────────────────────────────
-
-  private static readonly HEXAGON_SIDES = 6;
-  private static readonly HEXAGON_RADIUS = 25;
-  private static readonly HEXAGON_COLOR = "rgba(255, 20, 147, 0.85)";
-
-  public override render(context: CanvasRenderingContext2D): void {
-    super.render(context);
-
-    if (
-      !this.debugSettings?.showSyncableEntitiesOverlay() ||
-      !this.isSyncable()
-    ) return;
-
-    this.drawHexagon(context);
-  }
-
-  private drawHexagon(context: CanvasRenderingContext2D): void {
-    const cx = this.getX();
-    const cy = this.getY();
-
-    context.save();
-    context.strokeStyle = BaseMoveableGameEntity.HEXAGON_COLOR;
-    context.lineWidth = 1.5;
-    context.beginPath();
-
-    const r = BaseMoveableGameEntity.HEXAGON_RADIUS;
-    for (let i = 0; i < BaseMoveableGameEntity.HEXAGON_SIDES; i++) {
-      const angle = (Math.PI / 3) * i - Math.PI / 6;
-      const x = cx + r * Math.cos(angle);
-      const y = cy + r * Math.sin(angle);
-      if (i === 0) {
-        context.moveTo(x, y);
-      } else {
-        context.lineTo(x, y);
-      }
-    }
-    context.closePath();
-    context.stroke();
-    context.restore();
-  }
-
   // ── Lifecycle ──────────────────────────────────────────────────
 
   public reset(): void {

--- a/src/engine/entities/hitbox-entity.ts
+++ b/src/engine/entities/hitbox-entity.ts
@@ -46,24 +46,12 @@ export class HitboxEntity extends BaseGameEntity {
     this.colliding = colliding;
   }
 
-  public render(context: CanvasRenderingContext2D): void {
-    if (
-      this.debugSettings?.isDebugging() &&
-      this.debugSettings?.areHitboxesVisible()
-    ) {
-      context.save();
-
-      context.strokeStyle = "rgba(148, 0, 211, 0.2)";
-      context.strokeRect(this.x, this.y, this.width, this.height);
-
-      if (this.colliding) {
-        // Fill with transparent purple
-        context.fillStyle = "rgba(148, 0, 211, 0.5)"; // Adjust alpha value for transparency
-        context.fillRect(this.x, this.y, this.width, this.height);
-      }
-
-      context.restore();
-    }
+  /**
+   * Hitbox rendering is now handled by {@link CollisionComponent.render}.
+   * This method is a no-op — kept to satisfy the GameEntity interface.
+   */
+  public render(_context: CanvasRenderingContext2D): void {
+    // Hitbox debug overlay rendering moved to CollisionComponent.render()
   }
 
   private setPosition(x: number, y: number): void {


### PR DESCRIPTION
Moves hitbox debug rendering from `BaseCollidingGameEntity`/`HitboxEntity` into `CollisionComponent`, debug gizmos (center circle + direction arrow) into `PhysicsComponent`, and the syncable entity hexagon overlay into `NetworkComponent`.

This aligns with how game engines like Unity handle debug visualization — collider gizmos and network overlays are separate from the component data logic, and the Component interface already had `render()` and `update()` hooks designed for this purpose.

## Changes

- **`Component` interface** — Added `entity?` reference, set automatically by `addComponent()`
- **`BaseGameEntity`** — Wires component lifecycle: iterates components in `render()` and `update()`, propagates `debugSettings` to components
- **`PhysicsComponent`** — Added gizmo rendering (yellow center circle + orange direction arrow)
- **`CollisionComponent`** — Added hitbox rendering (purple rectangles, filled when colliding)
- **`NetworkComponent`** — Added hexagon overlay on syncable entities
- **`BaseCollidingGameEntity`** — Stripped of all debug rendering (~100 lines removed)
- **`BaseMoveableGameEntity`** — Stripped of hexagon rendering (~25 lines removed)
- **`HitboxEntity.render()`** — Now a no-op (rendering moved to `CollisionComponent`)

## Stats
```
8 files changed, 217 insertions(+), 135 deletions(-)
```