### PR TITLE
fix: pass rpId to sign-in passkey request

### DIFF
--- a/src/game/services/security/credential-service.ts
+++ b/src/game/services/security/credential-service.ts
@@ -44,6 +44,9 @@ export class CredentialService {
       challenge: WebAuthnUtils.challengeToArrayBuffer(
         authenticationOptions.challenge
       ),
+      rpId: authenticationOptions.rpId,
+      userVerification: authenticationOptions.userVerification,
+      timeout: authenticationOptions.timeout,
     };
 
     const credential = await navigator.credentials.get({


### PR DESCRIPTION
When signing in, the client dropped the WebAuthn options returned by the server and only forwarded the challenge. The browser then defaulted the RP ID to the calling origin (e.g. hoodball.vercel.app), so no passkeys created under the server's RP ID were shown in the sign-in picker.

Forward rpId, userVerification and timeout from the authentication options response into navigator.credentials.get().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication credential requests by applying the relying-party ID, user-verification policy, and timeout provided by the authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->