### PR TITLE
fix: canonical UUID for moderation endpoints and anti-cheat inspector fixes

### DIFF
--- a/src/game/debug/anti-cheat-inspector-window.ts
+++ b/src/game/debug/anti-cheat-inspector-window.ts
@@ -15,8 +15,9 @@ const RULE_TYPE_NAMES: Record<number, string> = {
   [AntiCheatRuleType.MovementSpeedLimit]: "Movement Speed Limit",
 };
 
-const GREEN = 0x00ff00ff;
-const YELLOW = 0xffff00ff;
+// Packed as IM_COL32(R, G, B, A): (A << 24) | (B << 16) | (G << 8) | R
+const GREEN = 0xff00ff00;
+const YELLOW = 0xff00ffff;
 const RED = 0xff0000ff;
 
 const RULES_TABLE_ROWS = 6;
@@ -49,13 +50,7 @@ export class AntiCheatInspectorWindow extends BaseWindow {
     ImGui.Text(monitoring ? "active" : "inactive");
     ImGui.PopStyleColor();
 
-    if (ImGui.Button(monitoring ? "Stop" : "Start")) {
-      if (monitoring) {
-        this.antiCheat.stopMonitoring();
-      } else {
-        this.antiCheat.startMonitoring();
-      }
-    }
+    // Monitoring is started/stopped automatically with the world scene.
 
     // ── Rules ──
     if (

--- a/src/game/services/network/player-moderation-service.ts
+++ b/src/game/services/network/player-moderation-service.ts
@@ -7,6 +7,7 @@ import {
 import type { ReportUserRequest } from "../../interfaces/requests/report-user-request-interface.js";
 import type { BanUserRequest } from "../../interfaces/requests/ban-user-request-interface.js";
 import { APIUtils } from "../../utils/api-utils.js";
+import { UUIDUtils } from "../../utils/uuid-utils.js";
 
 @injectable()
 export class PlayerModerationService {
@@ -21,8 +22,10 @@ export class PlayerModerationService {
     reason: string,
     automatic: boolean = false
   ): Promise<void> {
+    // The moderation API expects a canonical UUID (36 chars with dashes).
+    // Network IDs are stored without dashes, so normalize before sending.
     const reportRequest: ReportUserRequest = {
-      userId,
+      userId: UUIDUtils.format(userId),
       reason,
       automatic,
     };
@@ -48,8 +51,10 @@ export class PlayerModerationService {
     reason: string,
     duration?: { value: number; unit: string }
   ): Promise<void> {
+    // The moderation API expects a canonical UUID (36 chars with dashes).
+    // Network IDs are stored without dashes, so normalize before sending.
     const banRequest: BanUserRequest = {
-      userId,
+      userId: UUIDUtils.format(userId),
       reason,
       duration,
     };


### PR DESCRIPTION
## Summary\n\nTwo fixes:\n\n### 1. Moderation endpoints require a canonical UUID\nThe `/api/v1/user-moderation/report` and `/api/v1/user-moderation/ban` endpoints require a valid 36-char UUID with dashes, but the game was sending dashless 32-char network IDs (e.g. from `GamePlayer.getNetworkId()` via the anti-cheat auto-report path), causing:\n\n```\n{"origin":"string","code":"too_small","minimum":36,"inclusive":true,"exact":true,"path":["userId"],"message":"Too small: expected string to have >=36 characters"}\n```\n\n`PlayerModerationService.reportUser()` / `banUser()` now normalize the `userId` with `UUIDUtils.format()` before sending - converting 32-char hex network IDs back to canonical UUIDs (already-dashed UUIDs pass through unchanged).\n\n### 2. Anti-cheat inspector fixes\n- **"State: active" text was invisible**: the `GREEN` constant `0x00ff00ff` has alpha = 0 under Dear ImGui's `IM_COL32(R,G,B,A)` packing (`(A<<24)|(B<<16)|(G<<8)|R`), so the text disappeared exactly when monitoring turned on (world scene). Fixed to `0xff00ff00` (also corrected `YELLOW` from `0xffff00ff` = magenta to `0xff00ffff`).\n- **Removed the Start/Stop button**: monitoring is started/stopped automatically by the world scene, so the manual toggle was redundant.\n\n## Validation\n- `npx tsc --noEmit` passes.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Monitoring in the anti-cheat inspector is now managed automatically by the game world, removing the manual Start/Stop control.
  - Updated inspector colors improve consistency and readability.
  - User reports and bans now use standardized identifiers, improving moderation request reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->