### PR TITLE
fix: entity animation conflicts and stale hide timers

### DIFF
--- a/src/engine/components/animation-component.ts
+++ b/src/engine/components/animation-component.ts
@@ -10,6 +10,11 @@ import { TransformComponent } from "./transform-component.js";
  *
  * When attached to an entity, call animate*() methods to queue animations
  * that will be processed each frame during update().
+ *
+ * Semantics: **last animation wins.** Starting a new animation cancels any
+ * pending task that drives the same property (opacity for fades, scale, angle,
+ * x, y) and resets that property to its canonical starting value so the new
+ * animation always begins from a fresh state instead of fighting a stale one.
  */
 export class AnimationComponent implements Component {
   static readonly componentType = "AnimationComponent";
@@ -23,6 +28,8 @@ export class AnimationComponent implements Component {
   public fadeIn(seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.FadeIn, AnimationType.FadeOut);
+    entity.setOpacity(0);
     this.animationTasks.push(
       new EntityAnimationService(entity, AnimationType.FadeIn, 0, 1, seconds),
     );
@@ -31,6 +38,8 @@ export class AnimationComponent implements Component {
   public fadeOut(seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.FadeIn, AnimationType.FadeOut);
+    entity.setOpacity(1);
     this.animationTasks.push(
       new EntityAnimationService(entity, AnimationType.FadeOut, 1, 0, seconds),
     );
@@ -39,6 +48,7 @@ export class AnimationComponent implements Component {
   public moveToX(newX: number, seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.MoveX);
     const transform = entity.getComponent(
       TransformComponent as unknown as new (...args: never[]) => TransformComponent,
     );
@@ -51,6 +61,7 @@ export class AnimationComponent implements Component {
   public moveToY(newY: number, seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.MoveY);
     const transform = entity.getComponent(
       TransformComponent as unknown as new (...args: never[]) => TransformComponent,
     );
@@ -63,6 +74,7 @@ export class AnimationComponent implements Component {
   public rotateTo(newAngle: number, seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.Rotate);
     const transform = entity.getComponent(
       TransformComponent as unknown as new (...args: never[]) => TransformComponent,
     );
@@ -81,6 +93,7 @@ export class AnimationComponent implements Component {
   public scaleTo(newScale: number, seconds: number): void {
     const entity = this.entity;
     if (!entity) return;
+    this.removeTasksOfType(AnimationType.Scale);
     const transform = entity.getComponent(
       TransformComponent as unknown as new (...args: never[]) => TransformComponent,
     );
@@ -98,6 +111,18 @@ export class AnimationComponent implements Component {
 
   public clearAnimations(): void {
     this.animationTasks.length = 0;
+  }
+
+  /** True while at least one animation task is still running. */
+  public hasActiveAnimations(): boolean {
+    return this.animationTasks.length > 0;
+  }
+
+  /** Cancel any pending tasks that drive the same property as the new animation. */
+  private removeTasksOfType(...types: AnimationType[]): void {
+    this.animationTasks = this.animationTasks.filter(
+      (task) => !types.includes(task.getAnimationType()),
+    );
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {

--- a/src/engine/entities/notification-entity.ts
+++ b/src/engine/entities/notification-entity.ts
@@ -26,7 +26,7 @@ export class NotificationEntity extends BaseGameEntity {
     const _s = this;
     this.addComponent(new ScriptComponent({
       update: () => {
-        if (!_s._nactive || _s.animationTasks.length > 0) return;
+        if (!_s._nactive || anim.hasActiveAnimations()) return;
         _s.textX -= _s.TEXT_SPEED;
         const tw = _s.context.measureText(_s.text).width;
         if (_s.textX < -tw) {

--- a/src/engine/services/gameplay/entity-animation-service.ts
+++ b/src/engine/services/gameplay/entity-animation-service.ts
@@ -83,6 +83,10 @@ export class EntityAnimationService {
     return Math.min(this.elapsedMilliseconds / this.durationMilliseconds, 1);
   }
 
+  public getAnimationType(): AnimationType {
+    return this.animationType;
+  }
+
   public isCompleted(): boolean {
     return this.completed;
   }

--- a/src/game/entities/alert-entity.ts
+++ b/src/game/entities/alert-entity.ts
@@ -66,10 +66,17 @@ export class AlertEntity
 
     if (duration > 0) {
       this.timer = this.getTimerService(duration);
+    } else {
+      // Cancel a stale hide timer so a re-shown no-duration alert isn't
+      // hidden by a previous show's timer.
+      this.timer?.stop(false);
+      this.timer = null;
     }
   }
 
   public hide(): void {
+    // Skip when already hidden so fadeOut's reset-to-1 doesn't flash the alert.
+    if (this.opacity === 0) return;
     this.getComponent(AnimationComponent)!.fadeOut(0.3);
     this.getComponent(AnimationComponent)!.scaleTo(0, 0.3);
   }

--- a/src/game/entities/common/toast-entity.ts
+++ b/src/game/entities/common/toast-entity.ts
@@ -32,14 +32,23 @@ export class ToastEntity extends BaseGameEntity {
     this.getComponent(AnimationComponent)!.scaleTo(1, 0.2);
     this.getComponent(AnimationComponent)!.rotateTo(-2, 0.2);
 
+    // Cancel any pending hide from a previous show so a re-shown toast
+    // (e.g. a no-duration "Waiting for players...") isn't hidden by a stale timer.
+    this.timer?.stop(false);
+    this.timer = null;
+
     if (duration > 0) {
       this.timer = new TimerService(duration, this.hide.bind(this));
     }
   }
 
   public hide(): void {
+    // Skip when already hidden so fadeOut's reset-to-1 doesn't flash the toast.
+    if (this.opacity === 0) return;
     this.getComponent(AnimationComponent)!.fadeOut(0.2);
     this.getComponent(AnimationComponent)!.scaleTo(0, 0.2);
+    this.timer?.stop(false);
+    this.timer = null;
   }
 
   public override reset(): void {

--- a/src/game/entities/help-entity.ts
+++ b/src/game/entities/help-entity.ts
@@ -30,14 +30,23 @@ export class HelpEntity extends BaseGameEntity {
     this.reset();
     this.getComponent(AnimationComponent)!.fadeIn(0.2);
     this.getComponent(AnimationComponent)!.scaleTo(1, 0.2);
+
+    // Cancel any pending hide from a previous show.
+    this.timer?.stop(false);
+    this.timer = null;
+
     if (duration > 0) {
       this.timer = new TimerService(duration, this.hide.bind(this));
     }
   }
 
   public hide(): void {
+    // Skip when already hidden so fadeOut's reset-to-1 doesn't flash the help box.
+    if (this.opacity === 0) return;
     this.getComponent(AnimationComponent)!.fadeOut(0.2);
     this.getComponent(AnimationComponent)!.scaleTo(0, 0.2);
+    this.timer?.stop(false);
+    this.timer = null;
   }
 
   public override reset(): void {


### PR DESCRIPTION
## Summary

Fixes two animation regressions reported after the ECS migration (and last PRs): concurrent animations on the same entity fighting over the same property, and stale hide timers hiding re-shown toasts.

## Changes

**1. AnimationComponent: last animation wins**
Starting a new animation now cancels any pending task driving the same property and resets that property to its canonical starting value so the animation begins fresh:
- fadeIn / fadeOut remove pending FadeIn/FadeOut tasks and reset opacity to 0 / 1
- scaleTo / rotateTo / moveToX / moveToY replace same-type tasks, starting from the current transform value

This fixes the toast/alert conflict where hide()'s FadeOut + Scale(0) kept running alongside a new show()'s FadeIn + Scale(1), causing the animation to mix, flicker, or never appear.

**2. Stale hide timers cancelled on re-show**
ToastEntity / AlertEntity / HelpEntity now stop and clear any pending hide timer when show() is called again, so a short toast like "X left" (2s) no longer hides the subsequent no-duration "Waiting for players..." toast two seconds later. hide() also stops the timer and guards against hiding an already-hidden entity (avoids a flash from fadeOut's reset-to-1).

**3. NotificationEntity guard revived**
The scroll guard checked the legacy animationTasks array (never populated post-migration), so it silently did nothing. It now uses AnimationComponent.hasActiveAnimations().

## Testing

- npm run typecheck ✅
- npm run build ✅
