### PR TITLE
fix: countdown ball centering, duplicate waiting toast, debug logging

### DIFF
--- a/src/engine/models/debug-settings.ts
+++ b/src/engine/models/debug-settings.ts
@@ -25,6 +25,9 @@ export class DebugSettings {
     this.debugging = value;
 
     if (this.debugging) {
+      // Enable logging first so the "Debug mode on" banner is captured,
+      // mirroring the ?debug URL query parameter behavior.
+      EngineLogger.setEnabled(true);
       EngineLogger.info(
         "DebugSettings",
         "%cDebug mode on",
@@ -36,6 +39,7 @@ export class DebugSettings {
         "%cDebug mode off",
         "color: #ff5733; font-size: 20px; font-weight: bold"
       );
+      EngineLogger.setEnabled(false);
     }
   }
 

--- a/src/engine/services/gameplay/game-loop-service.ts
+++ b/src/engine/services/gameplay/game-loop-service.ts
@@ -96,6 +96,7 @@ export class GameLoopService {
     if (this.debug === false) return;
 
     EngineLogger.info(
+      "GameLoopService",
       "%cDebug mode on",
       "color: #b6ff35; font-size: 20px; font-weight: bold"
     );

--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -68,6 +68,15 @@ export class BallEntity
 
   public override reset(): void {
     this.ballScript.reset(this.canvas.width / 2, this.canvas.height / 2);
+    // Force an immediate reliable broadcast of the reset position so all
+    // peers snap to center instead of holding a stale position during the
+    // countdown (mustSync() is false once velocity is zeroed, so the
+    // periodic 500ms sync alone would leave remote balls off-center).
+    // Only the host broadcasts the ball — on non-hosts the flag would stick
+    // because the orchestrator skips host-owned entities without clearing it.
+    if (this.getOwner() === container.get(GamePlayer)) {
+      this.setSyncReliably(true);
+    }
     super.reset();
   }
 

--- a/src/game/entities/common/toast-entity.ts
+++ b/src/game/entities/common/toast-entity.ts
@@ -25,6 +25,13 @@ export class ToastEntity extends BaseGameEntity {
   }
 
   public show(text: string, duration = 0): void {
+    // A persistent toast (duration 0) already showing the same message
+    // doesn't need to be re-shown. Both the player-disconnect and
+    // match-advertised handlers can show "Waiting for players..."
+    // back-to-back; re-showing just makes it flash.
+    if (duration === 0 && this.text === text && this.opacity > 0) {
+      return;
+    }
     this.text = text;
     this.parseTextSegments();
     this.reset();

--- a/src/game/scripts/ball-script.ts
+++ b/src/game/scripts/ball-script.ts
@@ -148,6 +148,13 @@ export class BallScript implements ScriptLifecycle {
   // ── ScriptLifecycle ───────────────────────────────────────────
 
   update(_delta: DOMHighResTimeStamp): void {
+    // Close the teleport skip window after a fixed number of frames even if
+    // no network packet arrives. Otherwise a stale EntityData could snap the
+    // ball away from its reset position (e.g. center during countdown) while
+    // the window stays open waiting for the next periodic sync.
+    if (this.teleportFrameCount > 0) {
+      this.teleportFrameCount--;
+    }
     this.applyFriction();
     this.calculateMovement();
     this.updateHitbox();


### PR DESCRIPTION
## Summary\n\nFixes three regressions from today's ECS migration commits plus the debug-mode banner styling.\n\n### 1. Ball not centered during countdown when a player/NPC appears\nThe reset logic was correct, but the centered position was never broadcast promptly: after `ballEntity.reset()` the velocity is zero, so `mustSync()` returns false and the ball was only re-sent on the 500ms periodic tick. Remote clients held a stale ball position (or got snapped back to it by late-arriving packets) during the countdown.\n\n- `src/game/entities/ball-entity.ts`: `reset()` now sets `setSyncReliably(true)\' on the host so the reset (center) position is broadcast reliably and immediately.\n- `src/game/scripts/ball-script.ts`: `update()` now decrements `teleportFrameCount` each frame, closing the interpolation-skip window deterministically so stale EntityData can't yank the ball off-center.\n\n### 2. "Waiting for players..." toast shown twice\nBoth `handlePlayerDisconnection` (down to 1 real player) and `handleMatchAdvertised` (solo NPC start) show the same persistent toast back-to-back.\n\n- `src/game/entities/common/toast-entity.ts`: `show()` skips re-showing an identical persistent (duration 0) message while it is already visible.\n\n### 3. Debug mode should enable logging (like `?debug`)\n\n- `src/engine/models/debug-settings.ts`: `setDebugging()` now calls `EngineLogger.setEnabled()`, mirroring the `?debug` URL query parameter.\n\n### 4. "[Debug mode on]" banner showed an unstyled `[`\n`GameLoopService.logDebugInfo()` passed the styled message as the category argument, producing `console.info("[%cDebug mode on]", style)` where the leading `[` falls before the `%c` and stays unstyled.\n\n- `src/engine/services/gameplay/game-loop-service.ts`: corrected argument order (category, message, style).\n\n## Validation\n\n- `npx tsc --noEmit` passes.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiplayer synchronization when the ball is reset.
  * Fixed teleport recovery so movement resumes reliably without requiring new network updates.
  * Prevented duplicate persistent notifications from flashing or reappearing unnecessarily.
  * Improved debug logging visibility when debug mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->