### PR TITLE
fix: ball resets to quarter-canvas position (double halving)

### DIFF
--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -67,7 +67,10 @@ export class BallEntity
   }
 
   public override reset(): void {
-    this.ballScript.reset(this.canvas.width / 2, this.canvas.height / 2);
+    // Pass the FULL canvas dimensions: BallScript.reset() halves them to
+    // compute the center. Passing width/2 here would double-halve and leave
+    // the ball at (width/4, height/4) instead of center.
+    this.ballScript.reset(this.canvas.width, this.canvas.height);
     // Force an immediate reliable broadcast of the reset position so all
     // peers snap to center instead of holding a stale position during the
     // countdown (mustSync() is false once velocity is zeroed, so the


### PR DESCRIPTION
## Summary\n\nFixes the ball being off-center after countdown/reset in solo (and multiplayer) matches — the exact root cause the user suspected: **the reset path halves the canvas size twice**.\n\n### Root cause\nThe pre-ECS code called `this.teleport(canvas.width / 2, canvas.height / 2)` directly — a single halving to center. The ECS migration (`#718`) split the logic: `BallEntity.reset()` passes `canvas.width / 2, canvas.height / 2` into `BallScript.reset(canvasWidth, canvasHeight)`, which then halves **again** internally (`teleport(canvasWidth / 2, canvasHeight / 2)`).\n\nResult: the ball reset to `(width/4, height/4)` instead of center — confirmed via debug overlay: initial `X(220) Y(380)` → after NPC appears `X(110) Y(190)` on a 440x760 canvas.\n\n### Fix\n`BallEntity.reset()` now passes the **full** canvas dimensions, so the single halving inside `BallScript.reset()` lands on the exact center — identical to the initial `setCenterPosition(canvas.width, canvas.height)` path and to the pre-migration behavior.\n\n- `src/game/entities/ball-entity.ts`: `ballScript.reset(this.canvas.width, this.canvas.height)`\n\nValidated with `tsc --noEmit` (clean) and code review.\n\nCloses the ball-centering regression when an NPC/player joins.