### PR TITLE
fix: restore interactivity and visibility after #724 / #725 refactors

### DIFF
--- a/src/engine/components/input-component.ts
+++ b/src/engine/components/input-component.ts
@@ -30,6 +30,11 @@ export class InputComponent implements Component {
     const entity = this.entity;
     if (!entity) return;
 
+    // Reset per-frame state before processing new events. This used to
+    // happen in update() but was moved here so scripts can consume the
+    // previous frame's pressed/hovering state during their own update().
+    this.resetFrame();
+
     const transform = entity.getComponent(
       TransformComponent as unknown as new (...args: never[]) => TransformComponent,
     );
@@ -58,13 +63,10 @@ export class InputComponent implements Component {
   }
 
   /**
-   * Reset per-frame input state. Called automatically by BaseGameEntity each
-   * frame (after scripts have consumed the previous frame's events), matching
-   * the pre-migration BaseTappableGameEntity.update() behaviour.
+   * No longer resets per-frame state — that now happens at the start of
+   * {@link handlePointerEvent} so scripts can consume the previous frame's
+   * pressed/hovering state before it is cleared.
    */
-  public update(): void {
-    this.resetFrame();
-  }
 
   public resetFrame(): void {
     this.hovering = false;

--- a/src/engine/entities/base-game-entity.ts
+++ b/src/engine/entities/base-game-entity.ts
@@ -99,6 +99,7 @@ export class BaseGameEntity implements GameEntity {
   }
 
   public render(context: CanvasRenderingContext2D): void {
+    this.applyOpacity(context);
     this.components.forEach((component) => component.render?.(context));
   }
 }

--- a/src/game/entities/chat-button-entity.ts
+++ b/src/game/entities/chat-button-entity.ts
@@ -38,4 +38,10 @@ export class ChatButtonEntity extends BaseGameEntity {
   }
 
   public isInputVisible(): boolean { return this.script.inputVisible; }
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
+  public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
+  public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
+  public handlePointerEvent(gp: import("../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract): void {
+    this.getComponent(InputComponent)!.handlePointerEvent(gp);
+  }
 }

--- a/src/game/entities/close-button-entity.ts
+++ b/src/game/entities/close-button-entity.ts
@@ -25,6 +25,7 @@ export class CloseButtonEntity extends BaseGameEntity {
     transform.y = y;
   }
 
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
   public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
   public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
   public handlePointerEvent(

--- a/src/game/entities/common/button-entity.ts
+++ b/src/game/entities/common/button-entity.ts
@@ -26,6 +26,7 @@ export class ButtonEntity extends BaseGameEntity {
   public getY(): number { return this.getComponent(TransformComponent)!.y; }
   public getWidth(): number { return this.getComponent(TransformComponent)!.width; }
   public getHeight(): number { return this.getComponent(TransformComponent)!.height; }
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
   public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
   public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
   public handlePointerEvent(gp: import("../../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract): void {

--- a/src/game/entities/common/small-button-entity.ts
+++ b/src/game/entities/common/small-button-entity.ts
@@ -26,6 +26,7 @@ export class SmallButtonEntity extends BaseGameEntity {
   public setPosition(x: number, y: number): void { const t = this.getComponent(TransformComponent)!; t.x = x; t.y = y; }
   public setDisabled(d: boolean): void { this.script.disabled = d; if (d) { const i = this.getComponent(InputComponent)!; i.hovering = false; i.pressed = false; } }
   public isDisabled(): boolean { return this.script.disabled; }
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
   public isButtonPressed(): boolean { return this.script.isButtonPressed(); }
   public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
   public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }

--- a/src/game/entities/match-menu-button-entity.ts
+++ b/src/game/entities/match-menu-button-entity.ts
@@ -30,4 +30,10 @@ export class MatchMenuButtonEntity extends BaseGameEntity {
   public setOnToggleMenu(cb: () => void): void { this.script.setOnToggleMenu(cb); }
   public setMenuVisible(v: boolean): void { this.script.menuVisible = v; }
   public setActive(v: boolean): void { this.getComponent(InputComponent)!.active = v; }
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
+  public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
+  public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
+  public handlePointerEvent(gp: import("../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract): void {
+    this.getComponent(InputComponent)!.handlePointerEvent(gp);
+  }
 }

--- a/src/game/entities/match-menu-entity.ts
+++ b/src/game/entities/match-menu-entity.ts
@@ -51,6 +51,10 @@ export class MatchMenuEntity extends BaseGameEntity {
     this.script.setPlayers(players, localPlayerId);
   }
 
+  public isActive(): boolean { return this.opacity > 0; }
+  public isHovering(): boolean { return this.script.isHovering; }
+  public isPressed(): boolean { return this.script.isPressed; }
+
   public handlePointerEvent(gamePointer: GamePointerContract): void {
     if (!this.getComponent(InputComponent)!.active || this.opacity === 0) return;
     this.script.handlePointerEvent(gamePointer, this.opacity);

--- a/src/game/scripts/match-menu-script.ts
+++ b/src/game/scripts/match-menu-script.ts
@@ -44,6 +44,10 @@ export class MatchMenuScript {
   private pendingAction: (() => void) | null = null;
   pendingClose = false;
 
+  /** Exposed for the entity to report to the scene's tappable loop. */
+  isHovering = false;
+  isPressed = false;
+
   // ── Misc ──────────────────────────────────────────────────────
   private onClose: () => void;
   private onLeaveMatch: () => void;
@@ -175,18 +179,25 @@ export class MatchMenuScript {
   handlePointerEvent(gamePointer: GamePointerContract, entityOpacity: number): void {
     if (entityOpacity === 0) return;
 
+    // Reset per-frame state (called before child entities are updated)
+    this.isHovering = false;
+    this.isPressed = false;
+
     if (this.pendingClose && this.messageEntity.isActive()) {
       this.messageEntity.handlePointerEvent(gamePointer);
+      this.isHovering = true;
       return;
     }
 
     if (this.confirmationEntity.isOpen()) {
       this.confirmationEntity.handlePointerEvent(gamePointer);
+      this.isHovering = true;
       return;
     }
 
     if (this.playersListEntity.isActionMenuOpen()) {
       this.playersListEntity.handlePointerEvent(gamePointer);
+      this.isHovering = true;
       return;
     }
 
@@ -200,6 +211,8 @@ export class MatchMenuScript {
       this.leaveMatchButton.isHovering() ||
       this.leaveMatchButton.isPressed()
     ) {
+      this.isHovering = this.closeButtonEntity.isHovering() || this.leaveMatchButton.isHovering();
+      this.isPressed = this.closeButtonEntity.isPressed() || this.leaveMatchButton.isPressed();
       return;
     }
   }


### PR DESCRIPTION
Two regressions from the recent entity-to-script extraction:

1. Tapping broken (#724): InputComponent.resetFrame() ran during entity.update() before scripts could consume pressed state. Moved reset to start of handlePointerEvent() so scripts see the previous frame's state. Also added missing isActive() / isHovering() / isPressed() / handlePointerEvent() methods to ButtonEntity, SmallButtonEntity, CloseButtonEntity, ChatButtonEntity, MatchMenuButtonEntity, and MatchMenuEntity so they pass the scene's isTappableEntity duck-type check.

2. Objects always visible (#725): Extracted scripts no longer checked entity opacity before rendering. Added applyOpacity() call to BaseGameEntity.render() so entity opacity gates all component rendering globally.