### PR TITLE
fix: restore server message tap-to-dismiss and fix getWidth crash (#727)

### DIFF
--- a/src/game/entities/ball-entity.ts
+++ b/src/game/entities/ball-entity.ts
@@ -112,7 +112,11 @@ export class BallEntity
   // ── Transform queries (used by external callers) ──────────────
 
   public getX(): number { return this.getComponent(TransformComponent)?.x ?? 0; }
+  public setX(x: number): void { const t = this.getComponent(TransformComponent); if (t) t.x = x; }
   public getY(): number { return this.getComponent(TransformComponent)?.y ?? 0; }
+  public setY(y: number): void { const t = this.getComponent(TransformComponent); if (t) t.y = y; }
+  public getWidth(): number { return this.getComponent(TransformComponent)?.width ?? 0; }
+  public getHeight(): number { return this.getComponent(TransformComponent)?.height ?? 0; }
   public setVX(vx: number): void { const p = this.getComponent(PhysicsComponent); if (p) p.vx = vx; }
   public setVY(vy: number): void { const p = this.getComponent(PhysicsComponent); if (p) p.vy = vy; }
 

--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -53,7 +53,9 @@ export class CarEntity extends BaseGameEntity {
   // ── Transform / Collision queries (used by external callers) ──
 
   public getX(): number { return this.carScript.transform.x; }
+  public setX(x: number): void { this.carScript.transform.x = x; }
   public getY(): number { return this.carScript.transform.y; }
+  public setY(y: number): void { this.carScript.transform.y = y; }
   public getWidth(): number { return this.carScript.transform.width; }
   public getHeight(): number { return this.carScript.transform.height; }
   public isColliding(): boolean { return this.carScript.collision.isColliding(); }

--- a/src/game/entities/common/closeable-window-entity.ts
+++ b/src/game/entities/common/closeable-window-entity.ts
@@ -17,6 +17,9 @@ export class CloseableWindowEntity extends BaseGameEntity {
     this.script = new CloseableWindowScript(canvas);
     this.addComponent(new ScriptComponent(this.script));
     this.script.resolveComponents(transform, anim, input);
+    // Route tap-to-close through the entity so subclasses (e.g.
+    // ServerMessageWindowEntity) can override close() behaviour.
+    this.script.closeCallback = () => this.close();
 
     this.opacity = 0;
     input.active = false;
@@ -31,4 +34,16 @@ export class CloseableWindowEntity extends BaseGameEntity {
   }
 
   public close(): void { this.script.close(); }
+
+  // ── TappableEntity contract ───────────────────────────────────
+
+  public handlePointerEvent(
+    gp: import("../../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract,
+  ): void {
+    this.getComponent(InputComponent)!.handlePointerEvent(gp);
+  }
+
+  public isActive(): boolean { return this.script.opened; }
+  public isHovering(): boolean { return this.getComponent(InputComponent)?.hovering ?? false; }
+  public isPressed(): boolean { return this.getComponent(InputComponent)?.pressed ?? false; }
 }

--- a/src/game/scripts/closeable-window-script.ts
+++ b/src/game/scripts/closeable-window-script.ts
@@ -19,6 +19,13 @@ export class CloseableWindowScript implements ScriptLifecycle {
   protected content = "Content goes here";
   protected timestamp: number | null = null;
 
+  /**
+   * Called when the input triggers a close. Set by the owning entity so
+   * that subclasses can override close behaviour (e.g. server messages
+   * set {@code next = true} instead of closing).
+   */
+  closeCallback?: () => void;
+
   private transform!: TransformComponent;
   private animation!: AnimationComponent;
   private input!: InputComponent;
@@ -62,7 +69,13 @@ export class CloseableWindowScript implements ScriptLifecycle {
   }
 
   update(delta: DOMHighResTimeStamp): void {
-    if (this.input.pressed) this.close();
+    if (this.input.pressed) {
+      if (this.closeCallback) {
+        this.closeCallback();
+      } else {
+        this.close();
+      }
+    }
     this.backdropEntity.update(delta);
   }
 


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by recent refactoring commits (#724, #725).

### 1. Server message tap-to-dismiss broken

- **Root cause:** `CloseableWindowEntity` was missing `handlePointerEvent`, `isActive`, `isHovering`, and `isPressed` methods, so it didn't pass the `TappableEntity` duck-type check in `BaseGameScene.handlePointerEvent()`. Pointer events were never routed to the window.
- **Secondary issue:** `CloseableWindowScript.update()` called its own `close()` method directly, bypassing `ServerMessageWindowEntity.close()` override which sets `next = true` to trigger message advancement.
- **Fix:** Added the four missing methods to `CloseableWindowEntity` and a `closeCallback` pattern to `CloseableWindowScript` so tap-to-close routes through the entity's `close()` method.

### 2. `getWidth is not a function` crash during scene loading

- **Root cause:** `BallEntity` was missing `getWidth()`, `getHeight()`, `setX()`, `setY()` — methods required by the `MoveableEntity` interface used in `fixEntityPositionIfOutOfBounds()`.
- **Fix:** Added the four missing methods to `BallEntity`, and also added missing `setX()`/`setY()` to `CarEntity` for the same interface.

## Changes

| File | Change |
|------|--------|
| `closeable-window-entity.ts` | Add `handlePointerEvent`, `isActive`, `isHovering`, `isPressed` + `closeCallback` wiring |
| `closeable-window-script.ts` | Add `closeCallback` field; call it instead of `this.close()` in `update()` |
| `ball-entity.ts` | Add `getWidth`, `getHeight`, `setX`, `setY` |
| `car-entity.ts` | Add `setX`, `setY` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved position and size controls for game objects.
  * Enhanced closeable windows with interactive pointer states, including active, hovering, and pressed status.
  * Added optional custom close behavior for windows while preserving the default close action.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->