### PR TITLE
fix: restore multiplayer car sync and prevent help text animation glitch

### DIFF
--- a/src/game/entities/car-entity.ts
+++ b/src/game/entities/car-entity.ts
@@ -5,7 +5,9 @@ import { CollisionComponent } from "../../engine/components/collision-component.
 import { NetworkComponent } from "../../engine/components/network-component.js";
 import { ScriptComponent } from "../../engine/components/script-component.js";
 import { CarScript } from "../scripts/car-script.js";
+import type { MultiplayerGameEntity } from "../../engine/interfaces/entities/multiplayer-game-entity-interface.js";
 import type { Player } from "../../engine/interfaces/models/player-interface.js";
+import type { EntityType } from "../../engine/enums/entity-type.js";
 import { GamePlayer } from "../models/game-player.js";
 import { BinaryWriter } from "../../engine/utils/binary-writer-utils.js";
 import { BinaryReader } from "../../engine/utils/binary-reader-utils.js";
@@ -15,7 +17,7 @@ import { SCALE_FACTOR_FOR_ANGLES, SCALE_FACTOR_FOR_COORDINATES } from "../consta
  * Pure component container. All per-frame game logic, rendering, physics,
  * boost, smoke, and networking live in {@link CarScript}.
  */
-export class CarEntity extends BaseGameEntity {
+export class CarEntity extends BaseGameEntity implements MultiplayerGameEntity {
   protected readonly carScript: CarScript;
   protected remote: boolean;
 
@@ -49,6 +51,16 @@ export class CarEntity extends BaseGameEntity {
 
   public getOwner(): Player | null { return this.getComponent(NetworkComponent)?.owner ?? null; }
   public setOwner(p: Player | null): void { const n = this.getComponent(NetworkComponent); if (n) n.owner = p; }
+  public getTypeId(): EntityType | null { return this.getComponent(NetworkComponent)?.typeId ?? null; }
+  public setTypeId(id: EntityType): void { const n = this.getComponent(NetworkComponent); if (n) n.typeId = id; }
+  public isSyncable(): boolean { return this.getComponent(NetworkComponent)?.syncable ?? false; }
+  public setSyncable(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.syncable = v; }
+  public isSyncableByHost(): boolean { return this.getComponent(NetworkComponent)?.syncableByHost ?? false; }
+  public setSyncableByHost(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.syncableByHost = v; }
+  public mustSync(): boolean { return this.getComponent(NetworkComponent)?.mustSyncFlag ?? false; }
+  public setSync(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.mustSyncFlag = v; }
+  public mustSyncReliably(): boolean { return this.getComponent(NetworkComponent)?.mustSyncReliablyFlag ?? false; }
+  public setSyncReliably(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.mustSyncReliablyFlag = v; }
 
   // ── Transform / Collision queries (used by external callers) ──
 

--- a/src/game/entities/remote-car-entity.ts
+++ b/src/game/entities/remote-car-entity.ts
@@ -2,7 +2,6 @@ import { EntityRegistryType } from "../enums/entity-registry-type.js";
 import { CarEntity } from "./car-entity.js";
 import { NetworkComponent } from "../../engine/components/network-component.js";
 import type { MultiplayerGameEntity } from "../../engine/interfaces/entities/multiplayer-game-entity-interface.js";
-import type { EntityType } from "../../engine/enums/entity-type.js";
 import {
   SCALE_FACTOR_FOR_ANGLES, SCALE_FACTOR_FOR_SPEED, SCALE_FACTOR_FOR_COORDINATES,
 } from "../constants/webrtc-constants.js";
@@ -32,15 +31,11 @@ export class RemoteCarEntity extends CarEntity {
     return EntityRegistryType.RemoteCar;
   }
 
-  // ── MultiplayerGameEntity instance methods (thin wrappers) ────
+  // ── MultiplayerGameEntity instance methods (inherit from CarEntity) ────
 
-  public getTypeId(): EntityType | null { return this.getComponent(NetworkComponent)?.typeId ?? null; }
-  public isSyncable(): boolean { return this.getComponent(NetworkComponent)?.syncable ?? false; }
-  public isSyncableByHost(): boolean { return this.getComponent(NetworkComponent)?.syncableByHost ?? false; }
-  public mustSync(): boolean { return this.getComponent(NetworkComponent)?.mustSyncFlag ?? false; }
-  public setSync(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.mustSyncFlag = v; }
-  public mustSyncReliably(): boolean { return this.getComponent(NetworkComponent)?.mustSyncReliablyFlag ?? false; }
-  public setSyncReliably(v: boolean): void { const n = this.getComponent(NetworkComponent); if (n) n.mustSyncReliablyFlag = v; }
+  // All network wrapper methods (getTypeId, isSyncable, isSyncableByHost,
+  // mustSync, setSync, mustSyncReliably, setSyncReliably) are inherited
+  // from CarEntity, which delegates to NetworkComponent.
 
   public static deserialize(
     syncableId: string, arrayBuffer: ArrayBuffer,

--- a/src/game/scripts/help-script.ts
+++ b/src/game/scripts/help-script.ts
@@ -42,10 +42,16 @@ export class HelpScript implements ScriptLifecycle {
   show(text: string, duration = 0): void {
     this.lines = text.split("\n");
     this.measure();
-    this.transform.scale = 0;
     this.setPosition();
-    this.animation.fadeIn(0.2);
-    this.animation.scaleTo(1, 0.2);
+
+    // Only play the entrance animation if the help box is not already visible.
+    // Calling fadeIn while visible resets opacity to 0, causing a flash.
+    const isVisible = this.transform.scale > 0.5;
+    if (!isVisible) {
+      this.transform.scale = 0;
+      this.animation.fadeIn(0.2);
+      this.animation.scaleTo(1, 0.2);
+    }
 
     this.timer?.stop(false);
     this.timer = null;


### PR DESCRIPTION
## Summary

Fixes two regressions from the #724/#725 ECS refactoring:

### 1. Cars not visible in multiplayer (main fix)

**Root cause:** After #724 removed component delegates from `BaseGameEntity`, `RemoteCarEntity` got explicit `isSyncable()`, `getTypeId()`, `mustSyncReliably()`, etc., but `CarEntity` (parent of `LocalCarEntity`) did **not**. The `isMultiplayerEntity()` duck-type check in `BaseMultiplayerScene.getSyncableEntities()` looks for `isSyncable in entity` — since `LocalCarEntity` inherited zero of these methods, it was silently filtered out. The entity orchestrator never sent or received local car data.

**Fix:** Moved all `NetworkComponent` wrapper methods from `RemoteCarEntity` into `CarEntity`. Both `LocalCarEntity` and `RemoteCarEntity` now inherit them. Added `implements MultiplayerGameEntity` to `CarEntity` for compile-time safety.

### 2. Help text animation flash

**Root cause:** `HelpScript.show()` unconditionally called `animation.fadeIn()` which sets opacity to 0 before starting the fade. If called while already visible, it caused a flash.

**Fix:** Added visibility check — entrance animation only plays if the help box isn't already visible.

## Changed files

| File | Change |
|------|--------|
| `src/game/entities/car-entity.ts` | +14 lines: Added 10 NetworkComponent wrapper methods + `implements MultiplayerGameEntity` |
| `src/game/entities/remote-car-entity.ts` | -8/+6 lines: Removed duplicate methods now inherited from CarEntity |
| `src/game/scripts/help-script.ts` | +9 lines: Added visibility check before animation reset |