### PR TITLE
fix: isolate entity opacity to prevent globalAlpha leak (#726 regression)

### DIFF
--- a/src/engine/entities/base-game-entity.ts
+++ b/src/engine/entities/base-game-entity.ts
@@ -99,7 +99,11 @@ export class BaseGameEntity implements GameEntity {
   }
 
   public render(context: CanvasRenderingContext2D): void {
+    // Isolate this entity's opacity with save/restore so a hidden entity
+    // (opacity 0) cannot leak globalAlpha to entities rendered after it.
+    context.save();
     this.applyOpacity(context);
     this.components.forEach((component) => component.render?.(context));
+    context.restore();
   }
 }


### PR DESCRIPTION
## Problem

PR #726 added `this.applyOpacity(context)` to `BaseGameEntity.render()` but without isolating it. `applyOpacity` clamps `context.globalAlpha` to the entity's opacity, and when a **hidden entity** (opacity `0`) renders, it leaves `globalAlpha = 0` for **every entity rendered after it** in the same pass. This one leak regressed four things:

| Symptom | Mechanism |
| --- | --- |
| After joining a match, the other player's car fades out during countdown and becomes invisible | `worldEntities` order puts the **toast before remote cars**. When a player joins, `toastEntity.hide()` fades 1 → 0 right before the countdown, so remote cars are drawn at the toast's fading alpha, then at 0. The local car and ball (rendered before the toast) stay visible. |
| Match log renders differently; emojis disappear | The match log is drawn right after the help box, which auto-hides 4s after match start → the log gets clamped to alpha 0 / partial alpha, making it dim or invisible. Its text/emoji strings are byte-identical to the pre-#725 version. |
| Match menu button and chat button never appear | Both buttons render after the match log (opacity `0` until actions) and menu in `uiEntities`, so they are drawn at leaked alpha 0. |
| Loading spinner does not appear during API requests | `GameLoopService.render()` draws the **notification entity** (opacity `0` when idle) immediately before the **loading indicator** → spinner drawn at alpha 0. |

## Fix

One change in `src/engine/entities/base-game-entity.ts` — isolate each entity's opacity with `save()` / `restore()`:

```ts
public render(context: CanvasRenderingContext2D): void {
  // Isolate this entity's opacity with save/restore so a hidden entity
  // (opacity 0) cannot leak globalAlpha to entities rendered after it.
  context.save();
  this.applyOpacity(context);
  this.components.forEach((component) => component.render?.(context));
  context.restore();
}
```

Each entity's opacity now only affects itself. Scripts that already use their own `save()` / `restore()` nest safely, and `MatchMenuEntity` (which renders its script directly) is unaffected.

## Validation

- `npm run typecheck` passes
- `npm run build` passes (only pre-existing chunk-size warning)
