### PR TITLE
fix: restore solo match menu, NPC border collision, message dismiss, and OOB detection

### DIFF
--- a/src/engine/constants/canvas-constants.ts
+++ b/src/engine/constants/canvas-constants.ts
@@ -1,4 +1,9 @@
 export const CANVAS_WIDTH = 440;
 export const CANVAS_HEIGHT = 760;
-export const CANVAS_MARGIN = 5;
+/**
+ * Inset of the football field border from the canvas edge. The field is
+ * drawn 25px smaller than the canvas (see WorldBackgroundEntity), so the
+ * border line sits 12.5px inside each edge.
+ */
+export const FIELD_BORDER_MARGIN = 12.5;
 export const CANVAS_EXTRA_MARGIN = 50;

--- a/src/engine/scenes/base-colliding-game-scene.ts
+++ b/src/engine/scenes/base-colliding-game-scene.ts
@@ -11,7 +11,7 @@ import { CANVAS_WIDTH, CANVAS_HEIGHT } from "../constants/canvas-constants.js";
 
 const GRID_CELL_SIZE = 100;
 
-interface GridEntry { getX(): number; getY(): number; entity: BaseGameEntity }
+interface GridEntry { entity: BaseGameEntity }
 
 export class BaseCollidingGameScene extends BaseMultiplayerScene {
   protected isReplayMode = false;
@@ -63,10 +63,24 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
     this.spatialGrid.clear();
     for (const e of entities) {
       const t = e.getComponent(TransformComponent)!;
-      this.spatialGrid.insert({ getX: () => t.x, getY: () => t.y, entity: e });
+      const c = e.getComponent(CollisionComponent)!;
+      this.spatialGrid.insertWithBounds(
+        { entity: e },
+        ...this.getCollisionBounds(t, c),
+      );
     }
 
+    // An entity inserted into several cells can be paired with the same
+    // neighbor more than once; track visited pairs to keep exactly one
+    // collision resolution per pair per frame.
+    const visitedPairs = new Set<string>();
     this.spatialGrid.forEachPair((a, b) => {
+      const key =
+        a.entity.getId() < b.entity.getId()
+          ? `${a.entity.getId()}|${b.entity.getId()}`
+          : `${b.entity.getId()}|${a.entity.getId()}`;
+      if (visitedPairs.has(key)) return;
+      visitedPairs.add(key);
       this.detectCollisionsBetween(a.entity, b.entity);
     });
 
@@ -76,6 +90,33 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
         c.avoidingCollision = false;
       }
     }
+  }
+
+  /**
+   * Compute the union bounding box of an entity's hitboxes, falling back
+   * to the transform position when it has no hitboxes yet.
+   */
+  private getCollisionBounds(
+    t: TransformComponent,
+    c: CollisionComponent,
+  ): [number, number, number, number] {
+    if (c.hitboxEntities.length === 0) {
+      return [t.x, t.y, t.x, t.y];
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+
+    for (const h of c.hitboxEntities) {
+      minX = Math.min(minX, h.getX());
+      minY = Math.min(minY, h.getY());
+      maxX = Math.max(maxX, h.getX() + h.getWidth());
+      maxY = Math.max(maxY, h.getY() + h.getHeight());
+    }
+
+    return [minX, minY, maxX, maxY];
   }
 
   private detectCollisionsBetween(

--- a/src/engine/utils/entity-utils.ts
+++ b/src/engine/utils/entity-utils.ts
@@ -1,7 +1,7 @@
 import type { WebRTCPeer } from "../interfaces/network/webrtc-peer-interface.js";
 import {
   CANVAS_EXTRA_MARGIN,
-  CANVAS_MARGIN,
+  FIELD_BORDER_MARGIN,
 } from "../constants/canvas-constants.js";
 import type { GameEntity } from "../models/game-entity.js";
 
@@ -50,19 +50,22 @@ export class EntityUtils {
     const canvasWidth = canvas.width;
     const canvasHeight = canvas.height;
 
-    if (entityLeft < CANVAS_MARGIN) {
+    // Only correct when the entity has crossed the visible field border
+    // (which is inset FIELD_BORDER_MARGIN from the canvas edge), instead of
+    // firing while the entity is still inside the playable field.
+    if (entityLeft < FIELD_BORDER_MARGIN) {
       moveableEntity.setX(entityX + CANVAS_EXTRA_MARGIN); // Prevent going out of the left boundary
       hasChanged = true;
-    } else if (entityRight > canvasWidth - CANVAS_MARGIN) {
+    } else if (entityRight > canvasWidth - FIELD_BORDER_MARGIN) {
       moveableEntity.setX(entityX - CANVAS_EXTRA_MARGIN); // Prevent going out of the right boundary
       hasChanged = true;
     }
 
     // Adjust Y position if out of bounds
-    if (entityTop < CANVAS_MARGIN) {
+    if (entityTop < FIELD_BORDER_MARGIN) {
       moveableEntity.setY(entityY + CANVAS_EXTRA_MARGIN); // Prevent going out of the top boundary
       hasChanged = true;
-    } else if (entityBottom > canvasHeight - CANVAS_MARGIN) {
+    } else if (entityBottom > canvasHeight - FIELD_BORDER_MARGIN) {
       moveableEntity.setY(entityY - CANVAS_EXTRA_MARGIN); // Prevent going out of the bottom boundary
       hasChanged = true;
     }

--- a/src/engine/utils/spatial-grid.ts
+++ b/src/engine/utils/spatial-grid.ts
@@ -5,7 +5,7 @@
  * Reduces collision detection from O(n²) brute-force to O(n) in typical
  * cases by only checking entities in the same or adjacent cells.
  */
-export class SpatialGrid<T extends { getX: () => number; getY: () => number }> {
+export class SpatialGrid<T> {
   private readonly cells = new Map<number, T[]>();
 
   constructor(
@@ -32,16 +32,32 @@ export class SpatialGrid<T extends { getX: () => number; getY: () => number }> {
     this.cells.clear();
   }
 
-  /** Insert an entity into the appropriate cell. */
-  public insert(entity: T): void {
-    const { cx, cy } = this.cellCoords(entity.getX(), entity.getY());
-    const key = this.cellKey(cx, cy);
-    let bucket = this.cells.get(key);
-    if (!bucket) {
-      bucket = [];
-      this.cells.set(key, bucket);
+  /**
+   * Insert an entity into every cell its bounding box overlaps. Use for
+   * large static colliders (e.g. field border walls whose hitboxes span
+   * the whole arena) so they get paired with entities anywhere on the field.
+   */
+  public insertWithBounds(
+    entity: T,
+    minX: number,
+    minY: number,
+    maxX: number,
+    maxY: number,
+  ): void {
+    const minCell = this.cellCoords(minX, minY);
+    const maxCell = this.cellCoords(maxX, maxY);
+
+    for (let cy = minCell.cy; cy <= maxCell.cy; cy++) {
+      for (let cx = minCell.cx; cx <= maxCell.cx; cx++) {
+        const key = this.cellKey(cx, cy);
+        let bucket = this.cells.get(key);
+        if (!bucket) {
+          bucket = [];
+          this.cells.set(key, bucket);
+        }
+        bucket.push(entity);
+      }
     }
-    bucket.push(entity);
   }
 
   /**

--- a/src/game/entities/common/closeable-message-entity.ts
+++ b/src/game/entities/common/closeable-message-entity.ts
@@ -27,7 +27,8 @@ export class CloseableMessageEntity extends BaseGameEntity {
 
   public show(value: string): void { this.script.show(value); }
   public isActive(): boolean { return this.script.active; }
-  public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
+  public isHovering(): boolean { return this.getComponent(InputComponent)?.hovering ?? false; }
+  public isPressed(): boolean { return this.getComponent(InputComponent)?.pressed ?? false; }
 
   public handlePointerEvent(
     gp: import("../../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract,

--- a/src/game/entities/common/spawn-point-entity.ts
+++ b/src/game/entities/common/spawn-point-entity.ts
@@ -15,6 +15,7 @@ export class SpawnPointEntity extends BaseGameEntity {
     this.script = new SpawnPointScript(index);
     this.addComponent(new ScriptComponent(this.script));
     this.script.resolveTransform(transform);
+    this.script.resolveEntity(this);
   }
 
   public getIndex(): number { return this.script.getIndex(); }

--- a/src/game/entities/npc-car-entity.ts
+++ b/src/game/entities/npc-car-entity.ts
@@ -4,6 +4,7 @@ import { GamePlayer } from "../models/game-player.js";
 import { NetworkComponent } from "../../engine/components/network-component.js";
 import { ScriptComponent } from "../../engine/components/script-component.js";
 import { NpcScript } from "../scripts/npc-script.js";
+import { EntityUtils, type MoveableEntity } from "../../engine/utils/entity-utils.js";
 import { BinaryWriter } from "../../engine/utils/binary-writer-utils.js";
 import { BinaryReader } from "../../engine/utils/binary-reader-utils.js";
 
@@ -36,6 +37,28 @@ export class NpcCarEntity extends CarEntity {
     this.npcScript = new NpcScript(ballEntity);
     this.npcScript.resolveEntity(this);
     this.addComponent(new ScriptComponent(this.npcScript, -1));
+
+    // Bounds safety check, matching the pre-refactor NpcCarEntity.update()
+    // behavior (which only ran while the NPC was active). Runs after
+    // CarScript (priority 0) so it corrects the position produced by this
+    // frame's movement.
+    this.addComponent(
+      new ScriptComponent(
+        {
+          update: () => {
+            if (!this.npcScript.inputActive) return;
+            const canvas = this.getCanvas();
+            if (canvas) {
+              EntityUtils.fixEntityPositionIfOutOfBounds(
+                this as unknown as MoveableEntity,
+                canvas,
+              );
+            }
+          },
+        },
+        1,
+      ),
+    );
   }
 
   public setActive(active: boolean): void { this.npcScript.inputActive = active; }

--- a/src/game/scenes/world/systems/chat-ui-system.ts
+++ b/src/game/scenes/world/systems/chat-ui-system.ts
@@ -22,6 +22,8 @@ export class ChatUISystem {
   private chatButtonEntity: ChatButtonEntity | null = null;
   private matchMenuButtonEntity: MatchMenuButtonEntity | null = null;
   private matchMenuEntity: MatchMenuEntity | null = null;
+  private matchSessionService: MatchSessionService | null = null;
+  private gamePlayer: GamePlayer | null = null;
 
   /**
    * Set up chat UI: makes chat input visible, creates chat button,
@@ -39,6 +41,8 @@ export class ChatUISystem {
     matchmakingService: MatchmakingServiceContract | null,
     uiEntities: GameEntity[],
     onReturnToMainMenu: () => Promise<void>,
+    matchSessionService: MatchSessionService,
+    gamePlayer: GamePlayer,
   ): ChatButtonEntity | null {
     const chatInputElement = document.querySelector(
       "#chat-input",
@@ -48,6 +52,9 @@ export class ChatUISystem {
       EngineLogger.error("ChatUiSystem", "Chat input element not found");
       return null;
     }
+
+    this.matchSessionService = matchSessionService;
+    this.gamePlayer = gamePlayer;
 
     chatInputElement.removeAttribute("hidden");
 
@@ -133,6 +140,14 @@ export class ChatUISystem {
 
   private showMatchMenu(): void {
     if (!this.matchMenuEntity || !this.matchMenuButtonEntity) return;
+
+    // Refresh the player list on every open so the menu always reflects
+    // the current match players (e.g. solo matches, where no
+    // PlayerConnected/PlayerDisconnected event fires to trigger a refresh).
+    if (this.matchSessionService && this.gamePlayer) {
+      this.refreshPlayers(this.matchSessionService, this.gamePlayer);
+    }
+
     this.matchMenuEntity.show();
     this.matchMenuButtonEntity.setMenuVisible(true);
     this.matchMenuButtonEntity.setActive(false);

--- a/src/game/scenes/world/world-scene.ts
+++ b/src/game/scenes/world/world-scene.ts
@@ -503,6 +503,8 @@ export class WorldScene extends BaseCollidingGameScene {
       this.matchmakingService,
       this.uiEntities,
       () => this.returnToMainMenuScene(),
+      this.matchSessionService,
+      this.gamePlayer,
     );
 
     // Connect chat button to local car to disable controls during chat

--- a/src/game/scripts/spawn-point-script.ts
+++ b/src/game/scripts/spawn-point-script.ts
@@ -1,21 +1,28 @@
 import type { ScriptLifecycle } from "../../engine/components/script-component.js";
 import type { TransformComponent } from "../../engine/components/transform-component.js";
+import type { BaseGameEntity } from "../../engine/entities/base-game-entity.js";
 import type { MatchSessionService } from "../services/session/match-session-service.js";
 import { DebugUtils } from "../../engine/utils/debug-utils.js";
 
 export class SpawnPointScript implements ScriptLifecycle {
   private matchSessionService: MatchSessionService | null = null;
+  private entity: BaseGameEntity | null = null;
   private index: number;
   private transform!: TransformComponent;
 
   constructor(index: number) { this.index = index; }
 
   resolveTransform(transform: TransformComponent): void { this.transform = transform; }
+  resolveEntity(entity: BaseGameEntity): void { this.entity = entity; }
 
   getIndex(): number { return this.index; }
   setMatchSessionService(s: MatchSessionService): void { this.matchSessionService = s; }
 
   render(context: CanvasRenderingContext2D): void {
+    // Spawn points are debug-only markers — only render in debug mode
+    // (matches the pre-refactor behavior).
+    if (!this.entity?.debugSettings?.isDebugging()) return;
+
     context.save();
     const radius = 12;
     const t = this.transform;


### PR DESCRIPTION
## Summary

Fixes regressions introduced by today's commits (the `#718` ECS migration and `#724`/`#725` refactors), restoring behavior from a week ago, plus an out-of-bounds improvement.

## Changes

### 1. Match menu empty when playing solo
- `ChatUISystem.showMatchMenu()` now calls `refreshPlayers()` on every open (the old code did `setPlayers()` here). Solo matches show the local player and NPC, with the report button disabled for your own player.
- Files: `chat-ui-system.ts`, `world-scene.ts`

### 2. NPC car not colliding with field borders
- `BaseCollidingGameScene` now inserts entities into the spatial grid by their **hitbox bounds** (`insertWithBounds`) instead of their transform center, so large static colliders (the field border walls) pair with entities anywhere on the field. A `visitedPairs` set prevents duplicate collision resolution.
- Restored the NPC's out-of-bounds safety check (priority-1 script running after `CarScript`, only while active), matching the pre-refactor `NpcCarEntity.update()`.
- Files: `spatial-grid.ts`, `base-colliding-game-scene.ts`, `npc-car-entity.ts`

### 3. "Host has disconnected" message not dismissible by tapping
- `CloseableMessageEntity` regains `isHovering()`, so `BaseGameScene.isTappableEntity()` no longer filters it out of pointer routing.
- File: `closeable-message-entity.ts`

### 4. Spawn points always rendering debug info
- `SpawnPointScript.render()` is gated behind `debugSettings.isDebugging()` again (markers only show in debug mode, as before the refactor).
- Files: `spawn-point-script.ts`, `spawn-point-entity.ts`

### 5. Out-of-bounds detection triggers too early
- `fixEntityPositionIfOutOfBounds` now uses `FIELD_BORDER_MARGIN` (12.5px inset — the visible field border) instead of `CANVAS_MARGIN` (5px), so it only corrects once an entity actually crosses the field border.
- Files: `canvas-constants.ts`, `entity-utils.ts`

## Validation
- `npx tsc --noEmit` passes
- `npx vite build` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collision detection for larger entities and entities spanning multiple areas.
  - Updated field boundary handling to keep entities within the visible play area.
  - NPC vehicles now remain within the field while moving.
  - Chat match menus now refresh the player list when opened.
  - Closeable messages behave safely when input controls are unavailable.

- **Improvements**
  - Spawn-point markers are now shown only when debug mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->