### PR TITLE
fix: prevent spatial grid self-pairing causing constant collision and…

### DIFF
--- a/src/engine/scenes/base-colliding-game-scene.ts
+++ b/src/engine/scenes/base-colliding-game-scene.ts
@@ -75,6 +75,7 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
     // collision resolution per pair per frame.
     const visitedPairs = new Set<string>();
     this.spatialGrid.forEachPair((a, b) => {
+      if (a.entity.getId() === b.entity.getId()) return;
       const key =
         a.entity.getId() < b.entity.getId()
           ? `${a.entity.getId()}|${b.entity.getId()}`

--- a/src/engine/utils/spatial-grid.ts
+++ b/src/engine/utils/spatial-grid.ts
@@ -74,6 +74,7 @@ export class SpatialGrid<T> {
       // Within the same cell
       for (let i = 0; i < bucket.length; i++) {
         for (let j = i + 1; j < bucket.length; j++) {
+          if (bucket[i] === bucket[j]) continue;
           callback(bucket[i], bucket[j]);
         }
       }
@@ -99,6 +100,7 @@ export class SpatialGrid<T> {
 
         for (const a of bucket) {
           for (const b of neighborBucket) {
+            if (a === b) continue;
             callback(a, b);
           }
         }


### PR DESCRIPTION
… self-demolition

When an entity's hitbox bounding box spans multiple grid cells, SpatialGrid.forEachPair could pair the entity with itself via adjacent-cell checks. This caused:
- Cars adding themselves to their own collidingEntities
- isColliding() permanently returning true
- Self-demolition when boosting at max speed

Added identity guards in both SpatialGrid.forEachPair and BaseCollidingGameScene to skip self-pairs.