### PR TITLE
fix: soften wall bounce and prevent premature OOB teleports

### DIFF
--- a/src/engine/scenes/base-colliding-game-scene.ts
+++ b/src/engine/scenes/base-colliding-game-scene.ts
@@ -231,10 +231,15 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
     }
 
     const rest = phys.bounciness;
+    // Reflect velocity with restitution, but don't artificially amplify
+    // slow approaches — a gentle impact should produce a gentle bounce.
+    // Only clamp velocities that would be essentially zero to prevent
+    // the ball from getting stuck against walls.
+    const MIN_BOUNCE = 0.1;
     let vx = -phys.vx * rest;
     let vy = -phys.vy * rest;
-    if (vx > -1 && vx < 1) vx = vx < 0 ? -1 : 1;
-    if (vy > -1 && vy < 1) vy = vy < 0 ? -1 : 1;
+    if (Math.abs(vx) < MIN_BOUNCE) vx = vx < 0 ? -MIN_BOUNCE : MIN_BOUNCE;
+    if (Math.abs(vy) < MIN_BOUNCE) vy = vy < 0 ? -MIN_BOUNCE : MIN_BOUNCE;
 
     entity.getComponent(CollisionComponent)!.avoidingCollision = true;
     phys.vx = vx;

--- a/src/engine/utils/entity-utils.ts
+++ b/src/engine/utils/entity-utils.ts
@@ -1,8 +1,5 @@
 import type { WebRTCPeer } from "../interfaces/network/webrtc-peer-interface.js";
-import {
-  CANVAS_EXTRA_MARGIN,
-  FIELD_BORDER_MARGIN,
-} from "../constants/canvas-constants.js";
+import { CANVAS_EXTRA_MARGIN } from "../constants/canvas-constants.js";
 import type { GameEntity } from "../models/game-entity.js";
 
 /**
@@ -50,22 +47,22 @@ export class EntityUtils {
     const canvasWidth = canvas.width;
     const canvasHeight = canvas.height;
 
-    // Only correct when the entity has crossed the visible field border
-    // (which is inset FIELD_BORDER_MARGIN from the canvas edge), instead of
-    // firing while the entity is still inside the playable field.
-    if (entityLeft < FIELD_BORDER_MARGIN) {
+    // Only teleport when the entity has truly escaped past the field walls
+    // (which sit at the canvas edge). The wall hitboxes handle normal bounces;
+    // this is a last-resort safety net for tunneling or physics glitches.
+    if (entityLeft < 0) {
       moveableEntity.setX(entityX + CANVAS_EXTRA_MARGIN); // Prevent going out of the left boundary
       hasChanged = true;
-    } else if (entityRight > canvasWidth - FIELD_BORDER_MARGIN) {
+    } else if (entityRight > canvasWidth) {
       moveableEntity.setX(entityX - CANVAS_EXTRA_MARGIN); // Prevent going out of the right boundary
       hasChanged = true;
     }
 
     // Adjust Y position if out of bounds
-    if (entityTop < FIELD_BORDER_MARGIN) {
+    if (entityTop < 0) {
       moveableEntity.setY(entityY + CANVAS_EXTRA_MARGIN); // Prevent going out of the top boundary
       hasChanged = true;
-    } else if (entityBottom > canvasHeight - FIELD_BORDER_MARGIN) {
+    } else if (entityBottom > canvasHeight) {
       moveableEntity.setY(entityY - CANVAS_EXTRA_MARGIN); // Prevent going out of the bottom boundary
       hasChanged = true;
     }


### PR DESCRIPTION
## Summary

Fixes two gameplay feel issues with ball-wall interaction:

### Soften wall bounces
Reduces the minimum bounce velocity clamp from **±1 → ±0.1** so gentle wall collisions produce gentle bounces instead of being amplified. A ball drifting slowly into a wall no longer rockets away.

### Fix premature OOB teleports
Changes the out-of-bounds detection threshold from `FIELD_BORDER_MARGIN` (12.5px from canvas edge) to the **actual canvas edge** (0). The wall hitboxes at 12.5px handle normal bounces through collision detection. The OOB teleport now only fires as a last-resort safety net when the ball truly escapes past everything.

## Changes

- `src/engine/scenes/base-colliding-game-scene.ts`: Bounce velocity clamp ±1 → ±0.1
- `src/engine/utils/entity-utils.ts`: OOB threshold from `FIELD_BORDER_MARGIN` → canvas edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision behavior so objects retain gentle bounce velocities instead of becoming stuck.
  * Corrected boundary handling to reposition objects only after they cross the canvas edge, preventing premature adjustments near the field border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->