### PR TITLE
feat: report anti-cheat violations by rule id

### DIFF
--- a/src/game/constants/api-constants.ts
+++ b/src/game/constants/api-constants.ts
@@ -18,5 +18,8 @@ export const MATCHES_FIND_ENDPOINT = `${MATCHES_ENDPOINT}/find`;
 export const MATCHES_ADVERTISE_ENDPOINT = `${MATCHES_ENDPOINT}/advertise`;
 export const MATCHES_REMOVE_ENDPOINT = `${MATCHES_ENDPOINT}/owned`;
 export const USER_SCORES_PATH = "/user-scores";
-export const USER_MODERATION_REPORT_ENDPOINT = "/user-moderation/report";
+export const USER_MODERATION_MANUAL_REPORT_ENDPOINT =
+  "/user-moderation/manual-report";
+export const USER_MODERATION_AUTOMATIC_REPORT_ENDPOINT =
+  "/user-moderation/automatic-report";
 export const USER_MODERATION_BAN_ENDPOINT = "/user-moderation/ban";

--- a/src/game/interfaces/requests/automatic-report-request-interface.ts
+++ b/src/game/interfaces/requests/automatic-report-request-interface.ts
@@ -1,0 +1,4 @@
+export interface AutomaticReportRequest {
+  userId: string;
+  ruleId: number;
+}

--- a/src/game/interfaces/requests/report-user-request-interface.ts
+++ b/src/game/interfaces/requests/report-user-request-interface.ts
@@ -1,5 +1,4 @@
 export interface ReportUserRequest {
   userId: string;
   reason: string;
-  automatic: boolean;
 }

--- a/src/game/scripts/match-menu-script.ts
+++ b/src/game/scripts/match-menu-script.ts
@@ -241,7 +241,7 @@ export class MatchMenuScript {
   private handlePlayerReport(playerId: string, reason: string, playerName: string): void {
     this.pendingAction = () => {
       this.moderationService
-        .reportUser(playerId, reason, false)
+        .reportUser(playerId, reason)
         .then(() => { this.messageEntity.show("Report sent"); this.pendingClose = true; })
         .catch((error) => {
           EngineLogger.error("MatchMenuEntity", "Failed to report user:", error);

--- a/src/game/services/network/player-moderation-service.ts
+++ b/src/game/services/network/player-moderation-service.ts
@@ -1,10 +1,12 @@
 import { injectable, inject } from "@needle-di/core";
 import { APIService } from "./api-service.js";
 import {
-  USER_MODERATION_REPORT_ENDPOINT,
+  USER_MODERATION_MANUAL_REPORT_ENDPOINT,
+  USER_MODERATION_AUTOMATIC_REPORT_ENDPOINT,
   USER_MODERATION_BAN_ENDPOINT,
 } from "../../constants/api-constants.js";
 import type { ReportUserRequest } from "../../interfaces/requests/report-user-request-interface.js";
+import type { AutomaticReportRequest } from "../../interfaces/requests/automatic-report-request-interface.js";
 import type { BanUserRequest } from "../../interfaces/requests/ban-user-request-interface.js";
 import { APIUtils } from "../../utils/api-utils.js";
 import { UUIDUtils } from "../../utils/uuid-utils.js";
@@ -20,18 +22,43 @@ export class PlayerModerationService {
   public async reportUser(
     userId: string,
     reason: string,
-    automatic: boolean = false
   ): Promise<void> {
     // The moderation API expects a canonical UUID (36 chars with dashes).
     // Network IDs are stored without dashes, so normalize before sending.
     const reportRequest: ReportUserRequest = {
       userId: UUIDUtils.format(userId),
       reason,
-      automatic,
     };
 
     const response = await this.apiService.fetchWithAuthentication(
-      this.baseURL + USER_MODERATION_REPORT_ENDPOINT,
+      this.baseURL + USER_MODERATION_MANUAL_REPORT_ENDPOINT,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(reportRequest),
+      }
+    );
+
+    if (!response.ok) {
+      await APIUtils.throwAPIError(response);
+    }
+  }
+
+  public async reportAutomaticViolation(
+    userId: string,
+    ruleId: number,
+  ): Promise<void> {
+    // The moderation API expects a canonical UUID (36 chars with dashes).
+    // Network IDs are stored without dashes, so normalize before sending.
+    const reportRequest: AutomaticReportRequest = {
+      userId: UUIDUtils.format(userId),
+      ruleId,
+    };
+
+    const response = await this.apiService.fetchWithAuthentication(
+      this.baseURL + USER_MODERATION_AUTOMATIC_REPORT_ENDPOINT,
       {
         method: "POST",
         headers: {

--- a/src/game/services/security/anti-cheat-reporting-service.ts
+++ b/src/game/services/security/anti-cheat-reporting-service.ts
@@ -53,8 +53,7 @@ export class AntiCheatReportingService {
     };
     this.violations.push(violation);
 
-    const fullReason = `Rule #${ruleId}: ${reason}`;
-    this.send(userId, fullReason);
+    this.send(userId, ruleId);
 
     EngineLogger.warn(
       "AntiCheatReportingService",
@@ -62,9 +61,9 @@ export class AntiCheatReportingService {
     );
   }
 
-  private send(userId: string, reason: string): void {
+  private send(userId: string, ruleId: number): void {
     this.playerModerationService
-      .reportUser(userId, `[AntiCheat] ${reason}`, true)
+      .reportAutomaticViolation(userId, ruleId)
       .catch((error: unknown) => {
         EngineLogger.error(
           "AntiCheatReportingService",


### PR DESCRIPTION
## Summary

Splits player moderation reports into two flows to match the new gameserver endpoints:

- **Manual reports** — `PlayerModerationService.reportUser(userId, reason)` drops the `automatic` flag and posts to `/user-moderation/manual-report` with `{ userId, reason }`.
- **Automatic anti-cheat reports** — new `reportAutomaticViolation(userId, ruleId)` posts to `/user-moderation/automatic-report` with `{ userId, ruleId }`. `AntiCheatReportingService` now sends the broken rule's ID instead of embedding it in a `[AntiCheat] Rule #N: …` reason string.

## Changes

- `api-constants.ts`: replace `USER_MODERATION_REPORT_ENDPOINT` with `USER_MODERATION_MANUAL_REPORT_ENDPOINT` + `USER_MODERATION_AUTOMATIC_REPORT_ENDPOINT`.
- New `AutomaticReportRequest` interface; `ReportUserRequest` drops `automatic`.
- `player-moderation-service.ts`: `reportUser` (manual) + `reportAutomaticViolation`.
- `anti-cheat-reporting-service.ts`: send `ruleId` instead of a reason string.
- `match-menu-script.ts`: update the manual `reportUser` call.

Depends on the gameserver `manual-report` / `automatic-report` endpoints (already deployed).