### PR TITLE
fix: restore field border bounces after spatial grid refactor

### DIFF
--- a/src/engine/scenes/base-colliding-game-scene.ts
+++ b/src/engine/scenes/base-colliding-game-scene.ts
@@ -146,6 +146,15 @@ export class BaseCollidingGameScene extends BaseMultiplayerScene {
     } else if (pa.isDynamic && !pb.isDynamic) {
       if (ca.avoidingCollision) return;
       this.simulateCollisionBetweenDynamicAndStaticEntities(a, pa);
+    } else if (!pa.isDynamic && pb.isDynamic) {
+      // The spatial grid pairs each entity exactly once per frame, but does
+      // not guarantee the dynamic entity is the first argument. Static
+      // colliders (e.g. the field border) are inserted before dynamic ones,
+      // so this branch resolves the pair when the static entity came first.
+      // Without it the wall bounce never fires and entities pass through the
+      // border, relying on the OOB safety net to teleport them back.
+      if (cb.avoidingCollision) return;
+      this.simulateCollisionBetweenDynamicAndStaticEntities(b, pb);
     }
   }
 


### PR DESCRIPTION
## Summary

Cars and the ball stopped bouncing off the field border after the ECS/spatial-grid refactors — instead they slid through the 1px walls and were teleported back inward by the out-of-bounds safety net.

## Root cause

`BaseCollidingGameScene.detectCollisionsBetween` only resolved a dynamic-vs-static collision when the *dynamic* entity was the first argument:

```ts
} else if (pa.isDynamic && !pb.isDynamic) { ... }
```

The spatial grid pairs each entity pair once per frame and does **not** guarantee argument order. The field border (`WorldBackgroundEntity`) is static and inserted first, so it is always `a` in the `(border, ball/car)` pair — meaning that branch never fired and the wall bounce never ran.

## Fix

Handle the mirrored ordering so dynamic/static pairs resolve regardless of which argument is the dynamic entity:

```ts
} else if (!pa.isDynamic && pb.isDynamic) {
  if (cb.avoidingCollision) return;
  this.simulateCollisionBetweenDynamicAndStaticEntities(b, pb);
}
```

This restores the pre-refactor behavior: entities bounce off the border walls (restitution 0.5 car / 0.8 ball) and the OOB teleport only acts as a genuine last resort.

## Verification

- `npm run typecheck` passes.

🤖 Generated with Codebuff