### PR TITLE
fix: restore settings toggle tap input after ECS refactor

### DIFF
--- a/src/game/entities/setting-entity.ts
+++ b/src/game/entities/setting-entity.ts
@@ -38,4 +38,13 @@ export class SettingEntity extends BaseGameEntity {
   public setUpdated(updated: boolean): void { this.script.updated = updated; }
   public setX(x: number): void { this.getComponent(TransformComponent)!.x = x; }
   public setY(y: number): void { this.getComponent(TransformComponent)!.y = y; }
+
+  public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
+  public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
+  public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
+  public handlePointerEvent(
+    gp: import("../../engine/interfaces/input/game-pointer-interface.js").GamePointerContract,
+  ): void {
+    this.getComponent(InputComponent)!.handlePointerEvent(gp);
+  }
 }


### PR DESCRIPTION
## Summary

Tapping the **Debug mode** (and **Show menu**) toggles in Settings did nothing.

## Root cause

The ECS refactor in #724/#725 removed `BaseTappableGameEntity`, flattening `SettingEntity` onto `BaseGameEntity`. In the process, `SettingEntity` lost the four tappable methods (`handlePointerEvent`, `isActive`, `isHovering`, `isPressed`) that `BaseGameScene.handlePointerEvent()` uses to identify tappable entities via duck-typing. As a result the entity was silently filtered out, its `InputComponent.handlePointerEvent()` was never called, and `input.pressed` never became true.

Every other input-driven entity (`ButtonEntity`, `MenuOptionEntity`, `CloseButtonEntity`, etc.) kept these delegates; `SettingEntity` was the only one missing them.

## Fix

Re-add the four delegate methods, backed by the existing `InputComponent`:

```ts
public isActive(): boolean { return this.getComponent(InputComponent)!.active; }
public isHovering(): boolean { return this.getComponent(InputComponent)!.hovering; }
public isPressed(): boolean { return this.getComponent(InputComponent)!.pressed; }
public handlePointerEvent(gp: GamePointerContract): void {
  this.getComponent(InputComponent)!.handlePointerEvent(gp);
}
```

## Verification

- `npx tsc --noEmit` passes.

🤖 Generated with Codebuff