### PR TITLE
fix: cache syncable entities list and trim anti-cheat violations table

### DIFF
--- a/src/engine/scenes/base-multiplayer-scene.ts
+++ b/src/engine/scenes/base-multiplayer-scene.ts
@@ -16,6 +16,13 @@ export class BaseMultiplayerScene
   protected syncableEntityTypes: Map<EntityType, StaticMultiplayerGameEntity> =
     new Map();
 
+  /**
+   * Cached result of {@link getSyncableEntities}, rebuilt only when the
+   * scene's entity lists change. Avoids allocating a new array every frame
+   * in the entity orchestrator's per-frame send loop.
+   */
+  private syncableEntitiesCache: MultiplayerGameEntity[] | null = null;
+
   public addSyncableEntity(entityClass: StaticMultiplayerGameEntity): void {
     const typeId = entityClass.getTypeId();
     this.syncableEntityTypes.set(typeId, entityClass);
@@ -28,6 +35,29 @@ export class BaseMultiplayerScene
   }
 
   public getSyncableEntities(): MultiplayerGameEntity[] {
+    if (this.syncableEntitiesCache === null) {
+      this.syncableEntitiesCache = this.buildSyncableEntities();
+    }
+
+    return this.syncableEntitiesCache;
+  }
+
+  public override addEntityToSceneLayer(entity: GameEntity): void {
+    super.addEntityToSceneLayer(entity);
+    this.syncableEntitiesCache = null;
+  }
+
+  protected override deleteEntityIfRemoved(
+    layer: GameEntity[],
+    entity: GameEntity
+  ): void {
+    if (entity.isRemoved()) {
+      super.deleteEntityIfRemoved(layer, entity);
+      this.syncableEntitiesCache = null;
+    }
+  }
+
+  private buildSyncableEntities(): MultiplayerGameEntity[] {
     const result: MultiplayerGameEntity[] = [];
 
     for (const entity of this.uiEntities) {

--- a/src/game/debug/anti-cheat-inspector-window.ts
+++ b/src/game/debug/anti-cheat-inspector-window.ts
@@ -133,16 +133,11 @@ export class AntiCheatInspectorWindow extends BaseWindow {
       ImGui.TableFlags.SizingStretchProp;
 
     const outerSize = new ImVec2(0, VIOLATIONS_TABLE_ROWS * 20 + ImGui.GetTextLineHeightWithSpacing());
-    if (!ImGui.BeginTable("AntiCheatViolations", 5, flags, outerSize)) return;
+    if (!ImGui.BeginTable("AntiCheatViolations", 4, flags, outerSize)) return;
 
     ImGui.TableSetupColumn("Rule", ImGui.TableColumnFlags.WidthFixed, 40);
     ImGui.TableSetupColumn("Player", ImGui.TableColumnFlags.WidthStretch);
     ImGui.TableSetupColumn("Reason", ImGui.TableColumnFlags.WidthStretch);
-    ImGui.TableSetupColumn(
-      "Time",
-      ImGui.TableColumnFlags.WidthFixed,
-      90,
-    );
     ImGui.TableSetupColumn(
       "Relative",
       ImGui.TableColumnFlags.WidthFixed,
@@ -174,14 +169,8 @@ export class AntiCheatInspectorWindow extends BaseWindow {
       ImGui.TableSetColumnIndex(2);
       ImGui.Text(v.reason);
 
-      // Player time (absolute)
-      ImGui.TableSetColumnIndex(3);
-      const date = new Date(v.timestamp);
-      const timeStr = date.toLocaleTimeString();
-      ImGui.Text(timeStr);
-
       // Relative time
-      ImGui.TableSetColumnIndex(4);
+      ImGui.TableSetColumnIndex(3);
       const elapsedMs = now - v.timestamp;
       const elapsedStr = this.formatElapsed(elapsedMs);
       ImGui.Text(elapsedStr);


### PR DESCRIPTION
## What

Two small fixes:

1. **`getSyncableEntities()` allocation per frame** — the entity orchestrator calls `scene.getSyncableEntities()` in its per-frame send loop, and each call allocated and filtered a brand-new array. The result is now cached on the scene and only rebuilt when entities are added to or removed from the scene (via `addEntityToSceneLayer` / `deleteEntityIfRemoved`). The syncable flag on `NetworkComponent` is set once at entity construction and never toggles, so the cached set stays correct.

2. **Anti-cheat debug window** — the Violation History table showed both an absolute timestamp and a relative elapsed time per row. Removed the redundant absolute "Time" column, keeping the relative one (`just now`, `12s ago`, …).

## Verification

- `npm run typecheck` passes.